### PR TITLE
Use the new ssl CRT that includes analyze.buffer.com

### DIFF
--- a/buffer-analyze/values.yaml
+++ b/buffer-analyze/values.yaml
@@ -14,7 +14,7 @@ service:
   internalPort: 80
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert:  arn:aws:acm:us-east-1:980620087509:certificate/6501b96a-0a79-4898-b0a5-ec2f30015de8
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:980620087509:certificate/6b704a93-67de-444c-89fc-9f659bf2dd42
 ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).


### PR DESCRIPTION
### Purpose
This PR should install the updated ssl crt that includes `analyze.buffer.com` to its production ELB

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
