### PR TITLE
Faster project wide linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --hoist",
     "clean": "lerna clean",
-    "test": "if [ -n \"$CI\" ]; then yarn run init; fi && lerna run test",
+    "test": "if [ -n \"$CI\" ]; then yarn run init; fi && yarn run lint && lerna run test",
     "test-update": "lerna run test-update",
     "init": "yarn install && lerna bootstrap --loglevel verbose --hoist",
+    "lint-branch": "git diff --name-only master... |  grep .jsx*$ | xargs --no-run-if-empty eslint -c .eslintrc.json --stdin --quiet -f table",
+    "lint-head": "git diff --name-only |  grep .jsx*$ | xargs --no-run-if-empty eslint -c .eslintrc.json --stdin --quiet -f table",
+    "lint": "yarn run lint-branch && yarn run lint-head",
     "start": "cd ./packages/server/ && yarn start",
     "publish": "echo \"will eventually run: lerna publish\"",
     "build": "webpack  --config ./packages/server/webpack.config.js --output-path=`pwd`"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "start-storybook -p 9001",
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch",
     "test-update": "jest -u"
   },

--- a/packages/nav-sidebar/package.json
+++ b/packages/nav-sidebar/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "start-storybook -p 9001",
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch",
     "test-update": "jest -u"
   },

--- a/packages/performance-tracking/package.json
+++ b/packages/performance-tracking/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch"
   },
   "jest": {

--- a/packages/profile-selector/package.json
+++ b/packages/profile-selector/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "start-storybook -p 9003",
     "lint": "eslint . --ignore-pattern coverage .storybook node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch",
     "test-update": "jest -u"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "micro",
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch"
   },
   "jest": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch"
   },
   "jest": {

--- a/packages/summary-table/package.json
+++ b/packages/summary-table/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "start-storybook -p 9001",
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-update": "jest -u",
     "test-watch": "jest --watch"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "start-storybook -p 9003",
     "lint": "eslint . --ignore-pattern coverage .storybook node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-watch": "jest --watch",
     "test-update": "jest -u"
   },


### PR DESCRIPTION
### Purpose
To speed up project wide testing, this will lint `.js` and `.jsx` files
that have been edited in the current branch (both committed and not).

Doing some test this reduced the testing time from **28s** to **19s** _( time will vary based on the number of files to lint, but it should be faster than linting it all :smile: )_.

To fully lint individual package you should run `yarn run lint` from the package directory.

### Notes
As ESlint uses stdout, this won't run the tests if there is a linting error, if you just want to run the tests you can use `lerna run test`

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
