### PR TITLE
Handle profile fetching after login with profile-loader

### DIFF
--- a/packages/nav-sidebar/middleware.js
+++ b/packages/nav-sidebar/middleware.js
@@ -1,5 +1,5 @@
 import { push } from 'react-router-redux';
-import { actionTypes, actions as asyncDataFetchActions } from '@bufferapp/async-data-fetch';
+import { actionTypes } from '@bufferapp/async-data-fetch';
 import { actions as profilesActions, actionTypes as profileActionTypes } from '@bufferapp/analyze-profile-selector';
 
 const getProfileIdFromRoute = (state) => {
@@ -30,11 +30,6 @@ const getProfileRoute = (state, id) => {
 
 export default ({ dispatch, getState }) => next => (action) => {
   switch (action.type) {
-    case `login_${actionTypes.FETCH_SUCCESS}`:
-      dispatch(asyncDataFetchActions.fetch({
-        name: 'profiles',
-      }));
-      break;
     case `profiles_${actionTypes.FETCH_SUCCESS}`:
       if (getProfileIdFromRoute(getState())) {
         dispatch(profilesActions.selectProfile(getProfileIdFromRoute(getState())));

--- a/packages/nav-sidebar/middleware.test.js
+++ b/packages/nav-sidebar/middleware.test.js
@@ -1,4 +1,4 @@
-import { actionTypes, actions } from '@bufferapp/async-data-fetch';
+import { actionTypes } from '@bufferapp/async-data-fetch';
 import {
   actionTypes as profileActionTypes,
   actions as profileActions,
@@ -47,18 +47,6 @@ describe('middleware', () => {
       type: 'TEST',
     };
     invoke(action);
-    expect(next).toHaveBeenCalledWith(action);
-  });
-
-  it('should dispatch the data fetch action for fetching the profiles once login has been successful', () => {
-    const { store, next, invoke } = getMiddlewareElements();
-    const action = {
-      type: `login_${actionTypes.FETCH_SUCCESS}`,
-    };
-    invoke(action);
-    expect(store.dispatch).toHaveBeenCalledWith(actions.fetch({
-      name: 'profiles',
-    }));
     expect(next).toHaveBeenCalledWith(action);
   });
 

--- a/packages/profile-loader/index.js
+++ b/packages/profile-loader/index.js
@@ -10,3 +10,5 @@ export default connect(
 
 // export reducer, actions and action types
 export reducer, { actions, actionTypes } from './reducer';
+
+export middleware from './middleware';

--- a/packages/profile-loader/index.test.jsx
+++ b/packages/profile-loader/index.test.jsx
@@ -5,6 +5,7 @@ import ProfileLoaderContainer, {
   reducer,
   actions,
   actionTypes,
+  middleware,
 } from './index';
 import ProfileLoader from './components/ProfileLoader';
 
@@ -43,6 +44,11 @@ describe('ProfileLoaderContainer', () => {
 
   it('should export actionTypes', () => {
     expect(actionTypes)
+      .toBeDefined();
+  });
+
+  it('should export middleware', () => {
+    expect(middleware)
       .toBeDefined();
   });
 });

--- a/packages/profile-loader/middleware.js
+++ b/packages/profile-loader/middleware.js
@@ -1,0 +1,14 @@
+import { actionTypes, actions as asyncDataFetchActions } from '@bufferapp/async-data-fetch';
+
+export default ({ dispatch }) => next => (action) => {
+  switch (action.type) {
+    case `login_${actionTypes.FETCH_SUCCESS}`:
+      dispatch(asyncDataFetchActions.fetch({
+        name: 'profiles',
+      }));
+      break;
+    default:
+      break;
+  }
+  return next(action);
+};

--- a/packages/profile-loader/middleware.test.js
+++ b/packages/profile-loader/middleware.test.js
@@ -1,0 +1,31 @@
+import { actionTypes, actions } from '@bufferapp/async-data-fetch';
+import middleware from './middleware';
+
+describe('middleware', () => {
+  const next = jest.fn();
+  const store = {
+    dispatch: jest.fn(),
+  };
+  it('should exist', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('should keep propagating the action through the chain', () => {
+    const action = {
+      type: 'TEST',
+    };
+    middleware(store)(next)(action);
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('should dispatch the data fetch action for fetching the profiles once login has been successful', () => {
+    const action = {
+      type: `login_${actionTypes.FETCH_SUCCESS}`,
+    };
+    middleware(store)(next)(action);
+    expect(store.dispatch).toHaveBeenCalledWith(actions.fetch({
+      name: 'profiles',
+    }));
+    expect(next).toHaveBeenCalledWith(action);
+  });
+});

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -14,6 +14,7 @@ import { middleware as performanceMiddleware } from '@bufferapp/performance-trac
 import { middleware as summaryMiddleware } from '@bufferapp/summary-table';
 import { middleware as profileHeaderMiddleware } from '@bufferapp/profile-header';
 import { middleware as datePickerMiddleware } from '@bufferapp/analyze-date-picker';
+import { middleware as profileLoaderMiddleware } from '@bufferapp/profile-loader';
 import reducers from './reducers';
 
 export const history = createHistory();
@@ -39,6 +40,7 @@ const configureStore = (initialstate) => {
         summaryMiddleware,
         profileHeaderMiddleware,
         datePickerMiddleware,
+        profileLoaderMiddleware,
       ),
     ),
   );


### PR DESCRIPTION
### Purpose

@federicoweber made a really good point that the logic place for the profile fetching to be triggered would be the middleware for the profile-loader package, since that's also the package that prevents UI elements from being rendered until there are profiles available.

This PR takes care of that move 😄 