### PR TITLE
Automatic async data fetch performance tracking

### DIFF
--- a/packages/performance-tracking/index.js
+++ b/packages/performance-tracking/index.js
@@ -1,1 +1,2 @@
-export middleware, { actionTypes, actions } from './middleware';
+export middleware from './middleware';
+export reducer, { actionTypes, actions } from './reducer';

--- a/packages/performance-tracking/middleware.js
+++ b/packages/performance-tracking/middleware.js
@@ -1,6 +1,10 @@
 import { chronos } from '@bufferapp/chronos';
-import { actions as fetchActions } from '@bufferapp/async-data-fetch';
-import { actionTypes } from './reducer';
+import {
+  actions as fetchActions,
+  actionTypes as asyncActionTypes,
+} from '@bufferapp/async-data-fetch';
+
+import { actionTypes, actions } from './reducer';
 
 export const storeMeasure = dispatch => (data) => {
   dispatch(fetchActions.fetch({
@@ -9,23 +13,49 @@ export const storeMeasure = dispatch => (data) => {
   }));
 };
 
+function actionTypeRegExp(actionType) {
+  // ignoring performance events to avoid tracking those
+  return RegExp(`^(?!performance)\\w*_${actionType}$`);
+}
+
+function getNameFromActionType(actionType) {
+  const parsedAction = actionType.match(/^([a-z]*)_/i);
+  return parsedAction ? `${parsedAction[1]}Fetch` : null;
+}
+
 export default ({ dispatch }) => next => (action) => {
   const thisChronos = chronos({
     store: storeMeasure(dispatch),
   });
 
-  switch (action.type) {
-    case actionTypes.PERFORMANCE_START_MEASURE:
+  switch (true) {
+    case RegExp(actionTypes.PERFORMANCE_START_MEASURE).test(action.type):
       thisChronos.startMeasure(action.measureName, action.measureData);
       break;
-    case actionTypes.PERFORMANCE_STOP_MEASURE:
+    case RegExp(actionTypes.PERFORMANCE_STOP_MEASURE).test(action.type):
       thisChronos.stopMeasure(action.measureName);
       break;
-    case actionTypes.PERFORMANCE_MEASURE_FROM_EVENT:
+    case RegExp(actionTypes.PERFORMANCE_MEASURE_FROM_EVENT).test(action.type):
       thisChronos.measureFromSpecialEvent(action.measureName, action.measureData);
       break;
-    case actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START:
+    case RegExp(actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START).test(action.type):
       thisChronos.measureFromNavigationStart(action.measureName, action.measureData);
+      break;
+    // Automatic Async Data Fetch tracking
+    case actionTypeRegExp(asyncActionTypes.FETCH_START).test(action.type):
+      dispatch(actions.startMeasure({
+        name: getNameFromActionType(action.type),
+      }));
+      break;
+    case actionTypeRegExp(asyncActionTypes.FETCH_SUCCESS).test(action.type):
+      dispatch(actions.stopMeasure({
+        name: getNameFromActionType(action.type),
+      }));
+      break;
+    case actionTypeRegExp(asyncActionTypes.FETCH_FAIL).test(action.type):
+      dispatch(actions.stopMeasure({
+        name: getNameFromActionType(action.type),
+      }));
       break;
     default:
       break;

--- a/packages/performance-tracking/middleware.js
+++ b/packages/performance-tracking/middleware.js
@@ -1,34 +1,6 @@
 import { chronos } from '@bufferapp/chronos';
 import { actions as fetchActions } from '@bufferapp/async-data-fetch';
-
-export const actionTypes = {
-  PERFORMANCE_START_MEASURE: 'PERFORMANCE_START_MEASURE',
-  PERFORMANCE_STOP_MEASURE: 'PERFORMANCE_STOP_MEASURE',
-  PERFORMANCE_MEASURE_FROM_EVENT: 'MEASURE_FROM_EVENT',
-  PERFORMANCE_MEASURE_FROM_NAVIGATION_START: 'MEASURE_FROM_NAVIGATION_START',
-};
-
-export const actions = {
-  startMeasure: ({ name, data }) => ({
-    type: actionTypes.PERFORMANCE_START_MEASURE,
-    measureName: name,
-    measureData: data,
-  }),
-  measureFromSpecialEvent: ({ name, data }) => ({
-    type: actionTypes.PERFORMANCE_MEASURE_FROM_EVENT,
-    measureName: name,
-    measureData: data,
-  }),
-  measureFromNavigationStart: ({ name, data }) => ({
-    type: actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START,
-    measureName: name,
-    measureData: data,
-  }),
-  stopMeasure: ({ name }) => ({
-    type: actionTypes.PERFORMANCE_STOP_MEASURE,
-    measureName: name,
-  }),
-};
+import { actionTypes } from './reducer';
 
 export const storeMeasure = dispatch => (data) => {
   dispatch(fetchActions.fetch({

--- a/packages/performance-tracking/middleware.test.js
+++ b/packages/performance-tracking/middleware.test.js
@@ -1,5 +1,6 @@
 /* globals jest describe test beforeEach expect */
 import { actionTypes as asyncActionTypes } from '@bufferapp/async-data-fetch';
+import { actionTypes } from './reducer';
 import middleware, { storeMeasure } from './middleware';
 
 describe('middleware', () => {
@@ -22,5 +23,42 @@ describe('middleware', () => {
     expect(mockReduxStore.dispatch).toBeCalledWith({
       args: { data: {} }, name: 'performance', type: asyncActionTypes.FETCH,
     });
+  });
+
+  test('should start a measure on FETCH_START', () => {
+    middleware(mockReduxStore)(next)({
+      type: `test_${asyncActionTypes.FETCH_START}`,
+    });
+    expect(mockReduxStore.dispatch)
+      .toHaveBeenCalledTimes(1);
+    expect(mockReduxStore.dispatch)
+      .toHaveBeenCalledWith({
+        type: actionTypes.PERFORMANCE_START_MEASURE,
+        measureName: 'testFetch',
+      });
+  });
+  test('should stop a measure on FETCH_SUCCESS', () => {
+    middleware(mockReduxStore)(next)({
+      type: `test_${asyncActionTypes.FETCH_SUCCESS}`,
+    });
+    expect(mockReduxStore.dispatch)
+      .toHaveBeenCalledTimes(1);
+    expect(mockReduxStore.dispatch)
+      .toHaveBeenCalledWith({
+        type: actionTypes.PERFORMANCE_STOP_MEASURE,
+        measureName: 'testFetch',
+      });
+  });
+  test('should stop a measure on FETCH_FAIL', () => {
+    middleware(mockReduxStore)(next)({
+      type: `test_${asyncActionTypes.FETCH_FAIL}`,
+    });
+    expect(mockReduxStore.dispatch)
+      .toHaveBeenCalledTimes(1);
+    expect(mockReduxStore.dispatch)
+      .toHaveBeenCalledWith({
+        type: actionTypes.PERFORMANCE_STOP_MEASURE,
+        measureName: 'testFetch',
+      });
   });
 });

--- a/packages/performance-tracking/middleware.test.js
+++ b/packages/performance-tracking/middleware.test.js
@@ -3,6 +3,17 @@ import { actionTypes as asyncActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes } from './reducer';
 import middleware, { storeMeasure } from './middleware';
 
+const mockChronos = {
+  startMeasure: jest.fn(),
+  stopMeasure: jest.fn(),
+  measureFromSpecialEvent: jest.fn(),
+  measureFromNavigationStart: jest.fn(),
+};
+
+jest.mock('@bufferapp/chronos', () => (
+  { chronos: () => mockChronos }
+));
+
 describe('middleware', () => {
   const next = jest.fn();
   const mockReduxStore = {
@@ -25,6 +36,53 @@ describe('middleware', () => {
     });
   });
 
+  test('should start a measure', () => {
+    middleware(mockReduxStore)(next)({
+      type: actionTypes.PERFORMANCE_START_MEASURE,
+      measureName: 'test',
+      measureData: {},
+    });
+    expect(mockChronos.startMeasure)
+      .toHaveBeenCalledTimes(1);
+    expect(mockChronos.startMeasure)
+      .toBeCalledWith('test', {});
+  });
+
+  test('should measure from special event', () => {
+    middleware(mockReduxStore)(next)({
+      type: actionTypes.PERFORMANCE_MEASURE_FROM_EVENT,
+      measureName: 'test',
+      measureData: {},
+    });
+    expect(mockChronos.measureFromSpecialEvent)
+      .toHaveBeenCalledTimes(1);
+    expect(mockChronos.measureFromSpecialEvent)
+      .toBeCalledWith('test', {});
+  });
+
+  test('should measure from navigation start', () => {
+    middleware(mockReduxStore)(next)({
+      type: actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START,
+      measureName: 'test',
+      measureData: {},
+    });
+    expect(mockChronos.measureFromNavigationStart)
+      .toHaveBeenCalledTimes(1);
+    expect(mockChronos.measureFromNavigationStart)
+      .toBeCalledWith('test', {});
+  });
+
+  test('should stop a measure', () => {
+    middleware(mockReduxStore)(next)({
+      type: actionTypes.PERFORMANCE_STOP_MEASURE,
+      measureName: 'test',
+    });
+    expect(mockChronos.stopMeasure)
+      .toHaveBeenCalledTimes(1);
+    expect(mockChronos.stopMeasure)
+      .toBeCalledWith('test');
+  });
+
   test('should start a measure on FETCH_START', () => {
     middleware(mockReduxStore)(next)({
       type: `test_${asyncActionTypes.FETCH_START}`,
@@ -37,6 +95,7 @@ describe('middleware', () => {
         measureName: 'testFetch',
       });
   });
+
   test('should stop a measure on FETCH_SUCCESS', () => {
     middleware(mockReduxStore)(next)({
       type: `test_${asyncActionTypes.FETCH_SUCCESS}`,
@@ -49,6 +108,7 @@ describe('middleware', () => {
         measureName: 'testFetch',
       });
   });
+
   test('should stop a measure on FETCH_FAIL', () => {
     middleware(mockReduxStore)(next)({
       type: `test_${asyncActionTypes.FETCH_FAIL}`,

--- a/packages/performance-tracking/middleware.test.js
+++ b/packages/performance-tracking/middleware.test.js
@@ -1,7 +1,6 @@
 /* globals jest describe test beforeEach expect */
 import { actionTypes as asyncActionTypes } from '@bufferapp/async-data-fetch';
-import { middleware, actionTypes, actions } from './index';
-import { storeMeasure } from './middleware';
+import middleware, { storeMeasure } from './middleware';
 
 describe('middleware', () => {
   const next = jest.fn();
@@ -25,48 +24,3 @@ describe('middleware', () => {
     });
   });
 });
-
-describe('actions', () => {
-  test('should dispatch PERFORMANCE_START_MEASURE', () => {
-    expect(actions.startMeasure({
-      name: 'test',
-      data: {},
-    })).toMatchObject({
-      measureName: 'test',
-      measureData: {},
-      type: actionTypes.PERFORMANCE_START_MEASURE,
-    });
-  });
-
-  test('should dispatch PERFORMANCE_MEASURE_FROM_EVENT', () => {
-    expect(actions.measureFromSpecialEvent({
-      name: 'test',
-      data: {},
-    })).toMatchObject({
-      measureName: 'test',
-      measureData: {},
-      type: actionTypes.PERFORMANCE_MEASURE_FROM_EVENT,
-    });
-  });
-
-  test('should dispatch PERFORMANCE_MEASURE_FROM_NAVIGATION_START', () => {
-    expect(actions.measureFromNavigationStart({
-      name: 'test',
-      data: {},
-    })).toMatchObject({
-      measureName: 'test',
-      measureData: {},
-      type: actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START,
-    });
-  });
-
-  test('should dispatch PERFORMANCE_STOP_MEASURE', () => {
-    expect(actions.stopMeasure({
-      name: 'test',
-    })).toMatchObject({
-      measureName: 'test',
-      type: actionTypes.PERFORMANCE_STOP_MEASURE,
-    });
-  });
-});
-

--- a/packages/performance-tracking/reducer.js
+++ b/packages/performance-tracking/reducer.js
@@ -1,0 +1,38 @@
+export const actionTypes = {
+  PERFORMANCE_START_MEASURE: 'PERFORMANCE_START_MEASURE',
+  PERFORMANCE_STOP_MEASURE: 'PERFORMANCE_STOP_MEASURE',
+  PERFORMANCE_MEASURE_FROM_EVENT: 'MEASURE_FROM_EVENT',
+  PERFORMANCE_MEASURE_FROM_NAVIGATION_START: 'MEASURE_FROM_NAVIGATION_START',
+};
+
+const initialState = {};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    default:
+      return state;
+  }
+};
+
+export const actions = {
+  startMeasure: ({ name, data }) => ({
+    type: actionTypes.PERFORMANCE_START_MEASURE,
+    measureName: name,
+    measureData: data,
+  }),
+  measureFromSpecialEvent: ({ name, data }) => ({
+    type: actionTypes.PERFORMANCE_MEASURE_FROM_EVENT,
+    measureName: name,
+    measureData: data,
+  }),
+  measureFromNavigationStart: ({ name, data }) => ({
+    type: actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START,
+    measureName: name,
+    measureData: data,
+  }),
+  stopMeasure: ({ name }) => ({
+    type: actionTypes.PERFORMANCE_STOP_MEASURE,
+    measureName: name,
+  }),
+};
+

--- a/packages/performance-tracking/reducer.test.js
+++ b/packages/performance-tracking/reducer.test.js
@@ -1,0 +1,46 @@
+import { actions, actionTypes } from './reducer';
+
+describe('actions', () => {
+  test('should dispatch PERFORMANCE_START_MEASURE', () => {
+    expect(actions.startMeasure({
+      name: 'test',
+      data: {},
+    })).toMatchObject({
+      measureName: 'test',
+      measureData: {},
+      type: actionTypes.PERFORMANCE_START_MEASURE,
+    });
+  });
+
+  test('should dispatch PERFORMANCE_MEASURE_FROM_EVENT', () => {
+    expect(actions.measureFromSpecialEvent({
+      name: 'test',
+      data: {},
+    })).toMatchObject({
+      measureName: 'test',
+      measureData: {},
+      type: actionTypes.PERFORMANCE_MEASURE_FROM_EVENT,
+    });
+  });
+
+  test('should dispatch PERFORMANCE_MEASURE_FROM_NAVIGATION_START', () => {
+    expect(actions.measureFromNavigationStart({
+      name: 'test',
+      data: {},
+    })).toMatchObject({
+      measureName: 'test',
+      measureData: {},
+      type: actionTypes.PERFORMANCE_MEASURE_FROM_NAVIGATION_START,
+    });
+  });
+
+  test('should dispatch PERFORMANCE_STOP_MEASURE', () => {
+    expect(actions.stopMeasure({
+      name: 'test',
+    })).toMatchObject({
+      measureName: 'test',
+      type: actionTypes.PERFORMANCE_STOP_MEASURE,
+    });
+  });
+});
+


### PR DESCRIPTION
### Purpose
to ensure we are tracking performances for all RPC endpoints, we are now tracking all async data fetch request automatically.

### Notes
To keep the middleware cases declarations Redux friendly, this is using `RegExp.test` method instead of passing the type variable as a `switch` argument.

### Review


#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
