### PR TITLE
Move getTimezoneOffset to Highcharts.global

### DIFF
--- a/packages/hourly-chart/components/HourlyEngagementChart/index.jsx
+++ b/packages/hourly-chart/components/HourlyEngagementChart/index.jsx
@@ -15,6 +15,13 @@ import {
 
 const HourlyEngagementChart = ({ metric, secondaryMetric, posts, timezone, chartRef }) => {
   let hour = moment().startOf('day').subtract(1, 'hour');
+  ReactHighcharts.Highcharts.setOptions(
+    {
+      global: {
+        getTimezoneOffset: timestamp => -moment.tz(timestamp, timezone).utcOffset(),
+      },
+    },
+  );
   const metricByHour = metric.hourlyMetrics.map((hourlyMetric, index) => {
     hour.add(1, 'hour');
     return {
@@ -26,7 +33,6 @@ const HourlyEngagementChart = ({ metric, secondaryMetric, posts, timezone, chart
   });
   const config = {
     ...chartConfig,
-    getTimezoneOffset: timestamp => -moment.tz(timestamp, timezone).utcOffset(),
     series: [{
       ...primarySeriesConfig,
       color: color[metric.label],

--- a/packages/hourly-chart/components/PostCountByHour/index.jsx
+++ b/packages/hourly-chart/components/PostCountByHour/index.jsx
@@ -116,7 +116,6 @@ const PostCountByHour = ({ posts, timezone, hourlyChart }) => {
   });
   const config = {
     ...chartConfig,
-    getTimezoneOffset: timestamp => -moment.tz(timestamp, timezone).utcOffset(),
     series: [{
       ...seriesConfig,
       data: postsByHour,


### PR DESCRIPTION
### Purpose

To _really_ set the timezone offset for the HourlyEngagements chart 😄. Thanks @federicoweber for noticing that!