### PR TITLE
Task/use the new ssl crt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 
 @Library('github.com/bufferapp/k8s-jenkins-pipeline@master')
-def pipeline = new com.buffer.Pipeline3()
+def pipeline = new com.buffer.Pipeline4()
 
 pipeline.start('Jenkinsfile.json')

--- a/buffer-analyze/templates/deployment.yaml
+++ b/buffer-analyze/templates/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     service: app
     track: stable
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-  namespace: buffer
 spec:
   minReadySeconds: 10
   replicas: {{ .Values.replicaCount }}

--- a/buffer-analyze/templates/ingress.yaml
+++ b/buffer-analyze/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: "{{ .Values.branchName }}.analyze.buffer.com"
+    - host: "{{ .Values.branchName }}analyze.dev.buffer.com"
       http:
         paths:
           - path: /

--- a/buffer-analyze/values.yaml
+++ b/buffer-analyze/values.yaml
@@ -21,7 +21,7 @@ ingress:
   hosts:
     - chart-example.local
   annotations:
-    # kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
     # Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Purpose
This PR should makes the staging deploys go to `dev` namespace with url `branch_name.analyze.dev.buffer.com`

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
