### PR TITLE
Add posts summary table to report detail

### DIFF
--- a/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
@@ -10,30 +10,37 @@ exports[`Snapshots PostsSummaryTable should render a "no data" state 1`] = `
     }
   >
     <div>
-      <h2
+      <header
         style={
           Object {
-            "margin": "2rem 0 1rem",
+            "alignItems": "baseline",
+            "display": "flex",
+            "justifyContent": "space-between",
           }
         }
       >
-        <span
+        <h2
           style={
             Object {
-              "color": "#59626a",
-              "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
+              "margin": "2rem 0 1rem",
             }
           }
         >
-          Tweet 
-          summary for 
-          <span>
-            yesterday
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Open Sans\\", sans-serif",
+                "fontSize": "2rem",
+                "fontWeight": 600,
+              }
+            }
+          >
+            Tweet 
+            summary
           </span>
-        </span>
-      </h2>
+        </h2>
+      </header>
       <div
         id="js-dom-to-png-posts-summary"
         style={
@@ -129,30 +136,37 @@ exports[`Snapshots PostsSummaryTable should render a loading state 1`] = `
     }
   >
     <div>
-      <h2
+      <header
         style={
           Object {
-            "margin": "2rem 0 1rem",
+            "alignItems": "baseline",
+            "display": "flex",
+            "justifyContent": "space-between",
           }
         }
       >
-        <span
+        <h2
           style={
             Object {
-              "color": "#59626a",
-              "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
+              "margin": "2rem 0 1rem",
             }
           }
         >
-          Post 
-          summary for 
-          <span>
-            yesterday
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Open Sans\\", sans-serif",
+                "fontSize": "2rem",
+                "fontWeight": 600,
+              }
+            }
+          >
+            Post 
+            summary
           </span>
-        </span>
-      </h2>
+        </h2>
+      </header>
       <div
         id="js-dom-to-png-posts-summary"
         style={
@@ -282,30 +296,37 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
     }
   >
     <div>
-      <h2
+      <header
         style={
           Object {
-            "margin": "2rem 0 1rem",
+            "alignItems": "baseline",
+            "display": "flex",
+            "justifyContent": "space-between",
           }
         }
       >
-        <span
+        <h2
           style={
             Object {
-              "color": "#59626a",
-              "fontFamily": "\\"Open Sans\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
+              "margin": "2rem 0 1rem",
             }
           }
         >
-          Post 
-          summary for 
-          <span>
-            yesterday
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Open Sans\\", sans-serif",
+                "fontSize": "2rem",
+                "fontWeight": 600,
+              }
+            }
+          >
+            Post 
+            summary
           </span>
-        </span>
-      </h2>
+        </h2>
+      </header>
       <div
         id="js-dom-to-png-posts-summary"
         style={

--- a/packages/posts-summary-table/components/PostsSummaryTable/index.jsx
+++ b/packages/posts-summary-table/components/PostsSummaryTable/index.jsx
@@ -7,8 +7,11 @@ import {
 import {
   ChartStateNoData as NoData,
   ChartStateLoading as Loading,
+  ChartHeader,
   GridItem,
 } from '@bufferapp/analyze-shared-components';
+
+import AddReport from '@bufferapp/add-report';
 
 import Title from '../Title';
 
@@ -28,6 +31,19 @@ const gridContainer = {
   margin: '1rem 0 1.5rem',
 };
 
+export const Table = ({ metrics }) =>
+  <ul style={gridStyle}>
+    {metrics.map(metric => <GridItem key={metric.label} metric={metric} gridWidth={'33.33%'} />)}
+  </ul>;
+
+Table.propTypes = {
+  metrics: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.number,
+    diff: PropTypes.number,
+  })).isRequired,
+};
+
 const PostsSummaryTable = ({ metrics, loading, profileService, startDate, endDate }) => {
   let content = null;
   if (loading) {
@@ -35,16 +51,15 @@ const PostsSummaryTable = ({ metrics, loading, profileService, startDate, endDat
   } else if (metrics.length === 0) {
     content = <NoData />;
   } else {
-    content = (
-      <ul style={gridStyle}>
-        {metrics.map(metric => <GridItem key={metric.label} metric={metric} gridWidth={'33.33%'} />)}
-      </ul>
-    );
+    content = <Table metrics={metrics} />;
   }
 
   return (
     <div>
-      <Title profileService={profileService} startDate={startDate} endDate={endDate} />
+      <ChartHeader>
+        <Title profileService={profileService} startDate={startDate} endDate={endDate} />
+        <AddReport chart="posts-summary" />
+      </ChartHeader>
       <div id="js-dom-to-png-posts-summary" style={gridContainer}>
         {content}
       </div>

--- a/packages/posts-summary-table/components/Title/index.jsx
+++ b/packages/posts-summary-table/components/Title/index.jsx
@@ -2,30 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Text from '@bufferapp/components/Text';
 
-import { PeriodPhrase } from '@bufferapp/analyze-shared-components';
-
 const title = {
   margin: '2rem 0 1rem',
 };
 
-const Title = ({ profileService, startDate, endDate }) =>
+const Title = ({ profileService }) =>
   <h2 style={title}>
-    <Text>
+    <Text weight="bold" size="extra-large">
       {profileService === 'twitter' ? 'Tweet ' : 'Post '}
-      summary for <PeriodPhrase startDate={startDate} endDate={endDate} />
+      summary
     </Text>
   </h2>
 ;
 
-Title.defaultProps = {
-  startDate: null,
-  endDate: null,
-};
-
 Title.propTypes = {
   profileService: PropTypes.string.isRequired,
-  startDate: PropTypes.number,
-  endDate: PropTypes.number,
 };
 
 export default Title;

--- a/packages/posts-summary-table/index.js
+++ b/packages/posts-summary-table/index.js
@@ -14,3 +14,5 @@ export default connect(
 // export reducer, actions and action types
 export reducer, { actions, actionTypes } from './reducer';
 export middleware from './middleware';
+export { Table } from './components/PostsSummaryTable';
+export Title from './components/Title';

--- a/packages/posts-summary-table/index.test.jsx
+++ b/packages/posts-summary-table/index.test.jsx
@@ -25,6 +25,9 @@ describe('PostsSummaryTable', () => {
         loading: false,
         metrics: [],
       },
+      i18n: {
+        translations: {},
+      },
       date: {},
     });
     const wrapper = mount(

--- a/packages/posts-summary-table/package.json
+++ b/packages/posts-summary-table/package.json
@@ -21,6 +21,7 @@
   },
   "author": "tik.hakobyan@gmail.com",
   "dependencies": {
+    "@bufferapp/add-report": "^0.3.0",
     "@bufferapp/analyze-csv-export": "^0.1.0",
     "@bufferapp/analyze-date-picker": "^0.3.0",
     "@bufferapp/analyze-png-export": "^0.1.0",

--- a/packages/posts-summary-table/snapshot.test.js
+++ b/packages/posts-summary-table/snapshot.test.js
@@ -1,6 +1,8 @@
 // use story.js files as snapshots
 import initStoryshots from '@storybook/addon-storyshots';
 
+jest.mock('@bufferapp/add-report');
+
 initStoryshots({
   suit: 'Snapshots',
 });

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -9,7 +9,7 @@ exports[`Snapshots Report renders a loading report 1`] = `
 exports[`Snapshots Report renders a report with summary table 1`] = `
 <span>
   <section
-    className="sc-fjdhpX bKPOyI"
+    className="sc-gZMcBi dfNeYM"
   >
     <span
       style={
@@ -22,7 +22,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       }
     >
       <h1
-        className="sc-jzJRlG dpxUef"
+        className="sc-gqjmRU iGtJFC"
       >
         Weekly Sync Report
       </h1>
@@ -37,13 +37,13 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-VigVT iRCHKt"
+          className="sc-dnqmqq cyBbIy"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-jTzLTM iLmgMI"
+          className="sc-iwsKbI ebSInR"
         >
           January 27, 49385
            to 
@@ -52,7 +52,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       </span>
     </span>
     <section
-      className="sc-iwsKbI qINPN"
+      className="sc-bZQynM dKDtFu"
     >
       <h2
         style={
@@ -65,9 +65,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "color": "#59626a",
-              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontFamily": "\\"Open Sans\\", sans-serif",
               "fontSize": "2rem",
-              "fontWeight": 700,
+              "fontWeight": 600,
             }
           }
         >
@@ -85,12 +85,12 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-gZMcBi dRvCux"
+          className="sc-gzVnrw eMydYi"
         >
           Showing for accounts
         </span>
         <span
-          className="sc-gqjmRU gVGNLb"
+          className="sc-htoDjs eCjlmS"
         >
            
         </span>
@@ -140,8 +140,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -181,9 +181,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -243,7 +243,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "shamrock",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -290,8 +290,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -331,9 +331,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -394,7 +394,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -441,8 +441,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -482,9 +482,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -545,7 +545,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -592,8 +592,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -633,9 +633,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -696,7 +696,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -743,8 +743,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -784,9 +784,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -839,7 +839,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "#8D969E",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -886,8 +886,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -927,9 +927,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -990,7 +990,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -1037,8 +1037,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -1078,9 +1078,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -1141,7 +1141,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -1188,8 +1188,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
+                    "fontFamily": "\\"Open Sans\\", sans-serif",
+                    "fontSize": "0.8rem",
                     "fontWeight": 400,
                   }
                 }
@@ -1229,9 +1229,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontFamily": "\\"Open Sans\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
@@ -1292,7 +1292,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontFamily": "\\"Open Sans\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -9,7 +9,7 @@ exports[`Snapshots Report renders a loading report 1`] = `
 exports[`Snapshots Report renders a report with summary table 1`] = `
 <span>
   <section
-    className="sc-gZMcBi dfNeYM"
+    className="sc-dxgOiQ ileNkq"
   >
     <span
       style={
@@ -22,7 +22,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       }
     >
       <h1
-        className="sc-gqjmRU iGtJFC"
+        className="sc-ckVGcZ ilPpEQ"
       >
         Weekly Sync Report
       </h1>
@@ -37,13 +37,13 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-dnqmqq cyBbIy"
+          className="sc-kGXeez gJeseo"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-iwsKbI ebSInR"
+          className="sc-kpOJdX gQvbAX"
         >
           January 27, 49385
            to 
@@ -52,7 +52,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       </span>
     </span>
     <section
-      className="sc-bZQynM dKDtFu"
+      className="sc-kAzzGY hCbHBM"
     >
       <h2
         style={
@@ -65,9 +65,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "color": "#59626a",
-              "fontFamily": "\\"Open Sans\\", sans-serif",
+              "fontFamily": "\\"Roboto\\", sans-serif",
               "fontSize": "2rem",
-              "fontWeight": 600,
+              "fontWeight": 700,
             }
           }
         >
@@ -85,12 +85,12 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-gzVnrw eMydYi"
+          className="sc-chPdSV bsIXfA"
         >
           Showing for accounts
         </span>
         <span
-          className="sc-htoDjs eCjlmS"
+          className="sc-kgoBCf dHTJTk"
         >
            
         </span>
@@ -140,8 +140,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -181,9 +181,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -243,7 +243,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "shamrock",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -290,8 +290,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -331,9 +331,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -394,7 +394,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -441,8 +441,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -482,9 +482,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -545,7 +545,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -592,8 +592,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -633,9 +633,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -696,7 +696,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -743,8 +743,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -784,9 +784,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -839,7 +839,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "#8D969E",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -886,8 +886,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -927,9 +927,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -990,7 +990,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -1037,8 +1037,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -1078,9 +1078,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -1141,7 +1141,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }
@@ -1188,8 +1188,8 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                 style={
                   Object {
                     "color": "#59626a",
-                    "fontFamily": "\\"Open Sans\\", sans-serif",
-                    "fontSize": "0.8rem",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
                     "fontWeight": 400,
                   }
                 }
@@ -1229,9 +1229,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Open Sans\\", sans-serif",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 600,
+                      "fontWeight": 700,
                     }
                   }
                 >
@@ -1292,7 +1292,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                     style={
                       Object {
                         "color": "torchRed",
-                        "fontFamily": "\\"Open Sans\\", sans-serif",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "1.25rem",
                       }
                     }

--- a/packages/report/components/ChartFactory/index.jsx
+++ b/packages/report/components/ChartFactory/index.jsx
@@ -4,12 +4,17 @@ import {
   Text,
 } from '@bufferapp/components';
 import { Table as SummaryTable, Title as SummaryTitle } from '@bufferapp/summary-table';
+import { Table as PostsSummary, Title as PostsSummaryTitle } from '@bufferapp/posts-summary-table';
 import styled from 'styled-components';
 
 const CHARTS = {
   'summary-table': {
     chart: SummaryTable,
     title: SummaryTitle,
+  },
+  'posts-summary': {
+    chart: PostsSummary,
+    title: PostsSummaryTitle,
   },
 };
 

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -26,6 +26,7 @@
     "@bufferapp/components": "2.1.0",
     "@bufferapp/report-list": "^0.3.0",
     "@bufferapp/summary-table": "^0.3.0",
+    "@bufferapp/posts-summary-table": "^0.3.0",
     "styled-components": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -2,6 +2,7 @@ const { method } = require('@bufferapp/micro-rpc');
 
 const RPC_ENDPOINTS = {
   'summary-table': require('../summary'), // eslint-disable-line global-require
+  'posts-summary': require('../postsSummary'), // eslint-disable-line global-require
 };
 
 const requestChartData = (chart, startDate, endDate, session) =>

--- a/packages/shared-components/ChartHeader/index.jsx
+++ b/packages/shared-components/ChartHeader/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const header = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'baseline',
+};
+
+const Header = ({ children }) =>
+  <header style={header}>{children}</header>;
+
+Header.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Header;

--- a/packages/shared-components/index.js
+++ b/packages/shared-components/index.js
@@ -11,3 +11,4 @@ export TruncatedNumber from './TruncatedNumber';
 export ModeToggle from './ModeToggle';
 export Button from './Button';
 export MetricsDropdown from './MetricsDropdown';
+export ChartHeader from './ChartHeader';

--- a/packages/summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/summary-table/__snapshots__/snapshot.test.js.snap
@@ -11,7 +11,13 @@ exports[`Snapshots SummaryTable should render a "no data" state 1`] = `
   >
     <div>
       <header
-        className="sc-bwzfXH hcRgMz"
+        style={
+          Object {
+            "alignItems": "baseline",
+            "display": "flex",
+            "justifyContent": "space-between",
+          }
+        }
       >
         <h2
           style={
@@ -130,7 +136,13 @@ exports[`Snapshots SummaryTable should render a loading state 1`] = `
   >
     <div>
       <header
-        className="sc-bwzfXH hcRgMz"
+        style={
+          Object {
+            "alignItems": "baseline",
+            "display": "flex",
+            "justifyContent": "space-between",
+          }
+        }
       >
         <h2
           style={
@@ -283,7 +295,13 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
   >
     <div>
       <header
-        className="sc-bwzfXH hcRgMz"
+        style={
+          Object {
+            "alignItems": "baseline",
+            "display": "flex",
+            "justifyContent": "space-between",
+          }
+        }
       >
         <h2
           style={

--- a/packages/summary-table/components/SummaryTable/index.jsx
+++ b/packages/summary-table/components/SummaryTable/index.jsx
@@ -8,11 +8,11 @@ import {
 import {
   ChartStateNoData as NoData,
   ChartStateLoading as Loading,
+  ChartHeader,
   GridItem,
 } from '@bufferapp/analyze-shared-components';
 
 import AddReport from '@bufferapp/add-report';
-import styled from 'styled-components';
 
 import Title from '../Title';
 
@@ -31,12 +31,6 @@ const gridContainer = {
   position: 'relative',
   margin: '1rem 0 1.5rem',
 };
-
-const Header = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-`;
 
 export const Table = ({ metrics }) =>
   <ul style={gridStyle}>
@@ -64,10 +58,10 @@ const SummaryTable = ({ metrics, loading, profileService, startDate, endDate }) 
 
   return (
     <div>
-      <Header>
+      <ChartHeader>
         <Title profileService={profileService} startDate={startDate} endDate={endDate} />
         <AddReport chart="summary-table" />
-      </Header>
+      </ChartHeader>
       <div id="js-dom-to-png-summary" style={gridContainer}>
         {content}
       </div>

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1370,7 +1370,7 @@ exports[`Snapshots InsightsPage should render reports page 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\", sans-serif",
+            "fontFamily": "\\"Roboto\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -1386,7 +1386,7 @@ exports[`Snapshots InsightsPage should render reports page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-kGXeez ldpPAk"
+    className="sc-iujRgT bHeljQ"
   >
     <div
       style={
@@ -1568,13 +1568,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
       </a>
     </div>
     <div
-      className="sc-kpOJdX LsipW"
+      className="sc-GMQeP hnfwnh"
     >
       <header
-        className="sc-ckVGcZ byWctv"
+        className="sc-cQFLBn kHyciU"
       >
         <button
-          className="sc-bdVaJa eTEyQW"
+          className="sc-bAeIUo kxjPWX"
           onClick={[Function]}
         >
           Back to Reports
@@ -1884,7 +1884,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </div>
       </header>
       <div
-        className="sc-dxgOiQ gGVzZA"
+        className="sc-exAgwC maWqS"
       >
         ...loading
       </div>

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1595,7 +1595,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               className="bi-calendar"
             />
             <span>
-              Past 7 Days
+              From: 10/31/17 - To: 11/06/17
             </span>
             <span
               className="rightSide"
@@ -1603,7 +1603,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               <span
                 className="dateRange"
               >
-                10/30/17 to 11/05/17
+                
               </span>
               <span
                 style={
@@ -1759,7 +1759,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                   className="headerList"
                 >
                   <li
-                    className="headerListItem headerListItemActive"
+                    className="headerListItem headerListItemInactive"
                     data-tip={null}
                   >
                     <button
@@ -1829,7 +1829,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                     </button>
                   </li>
                   <li
-                    className="headerListItem headerListItemInactive"
+                    className="headerListItem headerListItemActive"
                     data-tip={null}
                   >
                     <button

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1370,7 +1370,7 @@ exports[`Snapshots InsightsPage should render reports page 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Roboto\\", sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -1386,7 +1386,7 @@ exports[`Snapshots InsightsPage should render reports page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-RefOD enAibU"
+    className="sc-kGXeez ldpPAk"
   >
     <div
       style={
@@ -1568,13 +1568,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
       </a>
     </div>
     <div
-      className="sc-iQKALj cxrBId"
+      className="sc-kpOJdX LsipW"
     >
       <header
-        className="sc-hrWEMg kVYzHE"
+        className="sc-ckVGcZ byWctv"
       >
         <button
-          className="sc-ibxdXY hpfxac"
+          className="sc-bdVaJa eTEyQW"
           onClick={[Function]}
         >
           Back to Reports
@@ -1884,7 +1884,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </div>
       </header>
       <div
-        className="sc-bwCtUz dHAzbG"
+        className="sc-dxgOiQ gGVzZA"
       >
         ...loading
       </div>

--- a/packages/web/components/ReportsPage/story.jsx
+++ b/packages/web/components/ReportsPage/story.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import createStore, { history } from '@bufferapp/analyze-store';
@@ -9,6 +10,8 @@ import {
 
 import ReportsPage from './index';
 
+const mockTimestamp = moment('2017-11-05').valueOf();
+Date.now = () => mockTimestamp;
 
 storiesOf('ReportsPage')
   .addDecorator(checkA11y)

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,22 +72,22 @@
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
 
-"@storybook/addon-actions@^3.1.2", "@storybook/addon-actions@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.13.tgz#7fae9201514f0efeee710d466828ea3c6bf0ec16"
+"@storybook/addon-actions@^3.1.2", "@storybook/addon-actions@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.14.tgz#ba20befc3cd67ffdb3cd58eed6702102d58602c2"
   dependencies:
-    "@storybook/addons" "^3.2.13"
+    "@storybook/addons" "^3.2.14"
     deep-equal "^1.0.1"
     json-stringify-safe "^5.0.1"
     prop-types "^15.6.0"
-    react-inspector "^2.2.0"
+    react-inspector "^2.2.1"
     uuid "^3.1.0"
 
-"@storybook/addon-links@^3.1.2", "@storybook/addon-links@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.2.13.tgz#925bb46350583a73538ac655f23df6f55019b560"
+"@storybook/addon-links@^3.1.2", "@storybook/addon-links@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.2.14.tgz#a8eb9a99df904fbaa3412eb0ecfbf2c7e257959d"
   dependencies:
-    "@storybook/addons" "^3.2.13"
+    "@storybook/addons" "^3.2.14"
 
 "@storybook/addon-storyshots@3.1.4":
   version "3.1.4"
@@ -98,31 +98,31 @@
     prop-types "^15.5.8"
     read-pkg-up "^2.0.0"
 
-"@storybook/addons@^3.1.2", "@storybook/addons@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.13.tgz#a133103770a7f2330bc931571df1b2ae660f8f71"
+"@storybook/addons@^3.1.2", "@storybook/addons@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.14.tgz#4d765c47e94729a33ca5466c9ee0f159c9f141db"
 
-"@storybook/channel-postmessage@^3.1.2", "@storybook/channel-postmessage@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.2.13.tgz#41d243e8def775696ac9159254b28c7d183b891c"
+"@storybook/channel-postmessage@^3.1.2", "@storybook/channel-postmessage@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.2.14.tgz#b54785d26f67019324f1daf822ed526f26363fc6"
   dependencies:
-    "@storybook/channels" "^3.2.13"
+    "@storybook/channels" "^3.2.14"
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
 
-"@storybook/channels@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.13.tgz#d4e04f99b1bb12cc3203839823218860358be480"
+"@storybook/channels@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.14.tgz#0d7522bff3fdefe534828e80ef3b3b1360057c9e"
 
-"@storybook/components@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.2.13.tgz#0576139f54468c9039da6a05d8ed2f1656f6007e"
+"@storybook/components@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.2.14.tgz#da17f8ee4582fb10fcfec07be5f72b9031534ee1"
   dependencies:
     glamor "^2.20.40"
-    glamorous "^4.9.7"
+    glamorous "^4.11.0"
     prop-types "^15.6.0"
 
-"@storybook/react-fuzzy@^0.4.1":
+"@storybook/react-fuzzy@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@storybook/react-fuzzy/-/react-fuzzy-0.4.3.tgz#36f7536ba97bf08b03cb57f47c58ae2cca330aec"
   dependencies:
@@ -183,16 +183,16 @@
     webpack-hot-middleware "^2.18.0"
 
 "@storybook/react@^3.0.0":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.2.13.tgz#d5b4d24a16a78b74d89bcee22475c755a05693cd"
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.2.14.tgz#42612fb96da4bf84e3367e5371e95a484b54a4fb"
   dependencies:
-    "@storybook/addon-actions" "^3.2.13"
-    "@storybook/addon-links" "^3.2.13"
-    "@storybook/addons" "^3.2.13"
-    "@storybook/channel-postmessage" "^3.2.13"
-    "@storybook/ui" "^3.2.13"
+    "@storybook/addon-actions" "^3.2.14"
+    "@storybook/addon-links" "^3.2.14"
+    "@storybook/addons" "^3.2.14"
+    "@storybook/channel-postmessage" "^3.2.14"
+    "@storybook/ui" "^3.2.14"
     airbnb-js-shims "^1.3.0"
-    autoprefixer "^7.1.5"
+    autoprefixer "^7.1.6"
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
     babel-plugin-react-docgen "^1.8.0"
@@ -201,11 +201,11 @@
     babel-preset-env "^1.6.1"
     babel-preset-minify "^0.2.0"
     babel-preset-react "^6.24.1"
-    babel-preset-react-app "^3.0.3"
+    babel-preset-react-app "^3.1.0"
     babel-preset-stage-0 "^6.24.1"
     babel-runtime "^6.26.0"
     case-sensitive-paths-webpack-plugin "^2.1.1"
-    chalk "^2.2.0"
+    chalk "^2.3.0"
     commander "^2.11.0"
     common-tags "^1.4.0"
     configstore "^3.1.1"
@@ -215,7 +215,7 @@
     file-loader "^0.11.2"
     find-cache-dir "^1.0.0"
     glamor "^2.20.40"
-    glamorous "^4.9.7"
+    glamorous "^4.11.0"
     global "^4.3.2"
     json-loader "^0.5.7"
     json-stringify-safe "^5.0.1"
@@ -239,13 +239,13 @@
     webpack-dev-middleware "^1.12.0"
     webpack-hot-middleware "^2.20.0"
 
-"@storybook/ui@^3.1.3", "@storybook/ui@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.13.tgz#c50150a793802e1f4f344fe3ee7af3998d7c5196"
+"@storybook/ui@^3.1.3", "@storybook/ui@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.14.tgz#3a2fbd770340829d018750ceab75bf85708b9467"
   dependencies:
     "@hypnosphi/fuse.js" "^3.0.9"
-    "@storybook/components" "^3.2.13"
-    "@storybook/react-fuzzy" "^0.4.1"
+    "@storybook/components" "^3.2.14"
+    "@storybook/react-fuzzy" "^0.4.3"
     babel-runtime "^6.26.0"
     deep-equal "^1.0.1"
     events "^1.1.1"
@@ -260,10 +260,10 @@
     prop-types "^15.6.0"
     qs "^6.5.1"
     react-icons "^2.2.7"
-    react-inspector "^2.2.0"
+    react-inspector "^2.2.1"
     react-komposer "^2.0.0"
     react-modal "^2.4.1"
-    react-split-pane "^0.1.65"
+    react-split-pane "^0.1.68"
     react-treebeard "^2.0.3"
     redux "^3.7.2"
 
@@ -276,8 +276,8 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.89.tgz#154be0e6a823760cd6083aa8c48f952e2e63e0b0"
 
 "@types/react@^16.0.18":
-  version "16.0.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.19.tgz#f804a0fcd6d94c17df92cf2fd46671bbbc862329"
+  version "16.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.20.tgz#dc16feb9c0bdf50e439482c6fd3c43d5a1d9f3b1"
 
 JSONStream@^1.0.4:
   version "1.3.1"
@@ -603,9 +603,15 @@ async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4:
+async@^2.1.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
+
+async@^2.1.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
 
@@ -624,7 +630,7 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-autoprefixer@^7.1.1, autoprefixer@^7.1.5:
+autoprefixer@^7.1.1, autoprefixer@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.1.6.tgz#fb933039f74af74a83e71225ce78d9fd58ba84d7"
   dependencies:
@@ -652,8 +658,8 @@ axe-core@2.2.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.2.0.tgz#00b410b3fc899207d4f2f8e3753cff150d34e4bb"
 
 axe-core@^2.0.7:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.4.2.tgz#3156d914051ea32597e584071d9d653b66d1579b"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.5.0.tgz#2f7c662c4d7d07cc8dc81f2f1d3d8288d8628039"
 
 babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -1652,7 +1658,7 @@ babel-preset-minify@^0.2.0:
     babel-plugin-transform-undefined-to-void "^6.8.3"
     lodash.isplainobject "^4.0.6"
 
-babel-preset-react-app@^3.0.0, babel-preset-react-app@^3.0.3:
+babel-preset-react-app@^3.0.0, babel-preset-react-app@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.1.0.tgz#d77f6061ab9d7bf4b3cdc86b7cde9ded0df03e48"
   dependencies:
@@ -2039,10 +2045,10 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     electron-to-chromium "^1.2.7"
 
 browserslist@^2.1.2, browserslist@^2.5.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.6.1.tgz#cc65a05ad6131ebda26f076f2822ba1bc826376b"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.7.0.tgz#dc375dc70048fec3d989042a35022342902eff00"
   dependencies:
-    caniuse-lite "^1.0.30000755"
+    caniuse-lite "^1.0.30000757"
     electron-to-chromium "^1.3.27"
 
 bser@1.0.2:
@@ -2167,9 +2173,9 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000713"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000713.tgz#ea01761840b5f148faf94ec5f34d0aa1d321966f"
 
-caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000755:
-  version "1.0.30000756"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000756.tgz#3da701c1521b9fab87004c6de7c97fa47dbeaad2"
+caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000757:
+  version "1.0.30000758"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000758.tgz#e261140076651049cf6891ed4bc649b5c8c26c69"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2212,7 +2218,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.2.0:
+chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -4144,7 +4150,7 @@ glamor@^2.20.40:
     prop-types "^15.5.10"
     through "^2.3.8"
 
-glamorous@^4.9.7:
+glamorous@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-4.11.0.tgz#cb846dda1450c895c59a34060fb19e3251ed619f"
   dependencies:
@@ -6670,10 +6676,10 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.0, postcss@^6.0.13:
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.13.tgz#b9ecab4ee00c89db3ec931145bd9590bbf3f125f"
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
   dependencies:
-    chalk "^2.1.0"
+    chalk "^2.3.0"
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
@@ -6992,9 +6998,9 @@ react-images@0.5.5:
     react-scrolllock "^1.0.5"
     react-transition-group "^1.1.3"
 
-react-inspector@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.0.tgz#2aa0778c3512063f598d7a89a28a5d5c7733cad7"
+react-inspector@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.1.tgz#c24f9a0131960b8e63c8392254d34df0717aabdf"
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
@@ -7117,7 +7123,7 @@ react-simple-dropdown@3.0.0:
     classnames "^2.1.2"
     prop-types "^15.5.8"
 
-react-split-pane@^0.1.65:
+react-split-pane@^0.1.68:
   version "0.1.68"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.68.tgz#a4ed40b0e77f0578cb6c9f9e65edd32726e4b16a"
   dependencies:
@@ -7164,8 +7170,8 @@ react-transition-group@^1.1.2, react-transition-group@^1.1.3:
     warning "^3.0.0"
 
 react-treebeard@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-treebeard/-/react-treebeard-2.0.3.tgz#cd644209c1be2fe2be3ae4bca8350ed6abf293d6"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-treebeard/-/react-treebeard-2.1.0.tgz#fbd5cf51089b6f09a9b18350ab3bddf736e57800"
   dependencies:
     babel-runtime "^6.23.0"
     deep-equal "^1.0.1"
@@ -8637,11 +8643,11 @@ webpack-sources@^0.2.3:
     source-map "~0.5.3"
 
 webpack-sources@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
   dependencies:
     source-list-map "^2.0.0"
-    source-map "~0.5.3"
+    source-map "~0.6.1"
 
 webpack@2.6.1:
   version "2.6.1"


### PR DESCRIPTION
### Purpose

To add "posts-summary-table" support for reports. Creating a report with the posts-summary-table package, and viewing it, works as expected.