### PR TITLE
show metrics list on content type preset tooltip

### DIFF
--- a/packages/server/rpc/contextual/presets.js
+++ b/packages/server/rpc/contextual/presets.js
@@ -15,6 +15,7 @@ module.exports = {
       label: 'What type of content is working?',
       description: 'Find out what type of content reasonates well with your audience.',
       hideDate: true,
+      showMetricsList: true,
       rewardWording: 'Your {category} posts earned on average:',
       type: 'column',
     },


### PR DESCRIPTION
### Purpose
To fix the missing metrics list from the Content Type preset tooltip

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
