### PR TITLE
Fix "getReport" RPC endpoint

### DIFF
--- a/packages/report-list/__snapshots__/snapshot.test.js.snap
+++ b/packages/report-list/__snapshots__/snapshot.test.js.snap
@@ -66,7 +66,7 @@ exports[`Snapshots Report renders the report 1`] = `
           <span
             className="sc-bxivhb hlPYmz"
           >
-            October 10, 2017
+            October 11, 2017
           </span>
         </span>
       </span>
@@ -161,7 +161,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
             <span
               className="sc-bxivhb hlPYmz"
             >
-              November 7, 2017
+              November 8, 2017
             </span>
           </span>
         </span>
@@ -231,7 +231,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
             <span
               className="sc-bxivhb hlPYmz"
             >
-              October 10, 2017
+              October 11, 2017
             </span>
           </span>
         </span>

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -8,12 +8,11 @@ const RPC_ENDPOINTS = {
 };
 
 const requestChartData = (chart, startDate, endDate, session) =>
-  RPC_ENDPOINTS[chart.chart_id].fn({
+  RPC_ENDPOINTS[chart.chart_id].fn(Object.assign({
     profileId: chart.profile_id,
     startDate,
     endDate,
-    ...chart.state,
-  }, { session });
+  }, chart.state), { session });
 
 module.exports = method(
   'get_report',

--- a/packages/server/rpc/getReport/index.test.js
+++ b/packages/server/rpc/getReport/index.test.js
@@ -82,4 +82,32 @@ describe('rpc/get_report', () => {
     expect(report[0].metrics).toEqual(metricsEmbeddedInObject.metrics);
     expect(report[0].posts).toEqual(metricsEmbeddedInObject.posts);
   });
+
+  it('destructures over state as arguments for the charts rpc method', async () => {
+    const charts = [{
+      chart_id: 'summary-table',
+      profile_id: '12351wa',
+      state: {
+        service: 'facebook',
+      },
+    }];
+
+    const endDate = moment().subtract(1, 'days').unix();
+    const startDate = moment().subtract(7, 'days').unix();
+    const metricsEmbeddedInObject = {
+      metrics: [1, 2, 3, 4],
+      posts: ['a post', 'another post'],
+    };
+    summary.fn = jest.fn();
+    summary.fn.mockReturnValueOnce(Promise.resolve(metricsEmbeddedInObject));
+
+    await getReport.fn({ startDate, endDate, charts }, { session });
+
+    expect(summary.fn.mock.calls[0][0]).toEqual({
+      profileId: '12351wa',
+      service: 'facebook',
+      endDate,
+      startDate,
+    });
+  });
 });

--- a/packages/summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/summary-table/__snapshots__/snapshot.test.js.snap
@@ -427,7 +427,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     }
                   >
                     <span>
-                      150.0
+                      150
                     </span>
                   </span>
                 </span>
@@ -488,7 +488,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        25.0
+                        25
                       </span>
                       %
                     </span>
@@ -577,7 +577,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     }
                   >
                     <span>
-                      901.0
+                      901
                     </span>
                   </span>
                 </span>
@@ -639,7 +639,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        39.0
+                        39
                       </span>
                       %
                     </span>
@@ -728,7 +728,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     }
                   >
                     <span>
-                      1,010.0
+                      1,010
                     </span>
                   </span>
                 </span>
@@ -790,7 +790,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        55.0
+                        55
                       </span>
                       %
                     </span>
@@ -941,7 +941,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        26.0
+                        26
                       </span>
                       %
                     </span>
@@ -1030,7 +1030,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     }
                   >
                     <span>
-                      0.0
+                      0
                     </span>
                   </span>
                 </span>
@@ -1084,7 +1084,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        0.0
+                        0
                       </span>
                       %
                     </span>
@@ -1235,7 +1235,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        33.0
+                        33
                       </span>
                       %
                     </span>
@@ -1324,7 +1324,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     }
                   >
                     <span>
-                      2,313.0
+                      2,313
                     </span>
                   </span>
                 </span>
@@ -1386,7 +1386,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        28.0
+                        28
                       </span>
                       %
                     </span>
@@ -1475,7 +1475,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     }
                   >
                     <span>
-                      658.0
+                      658
                     </span>
                   </span>
                 </span>
@@ -1537,7 +1537,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                       }
                     >
                       <span>
-                        9.0
+                        9
                       </span>
                       %
                     </span>

--- a/packages/top-posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/top-posts-table/__snapshots__/snapshot.test.js.snap
@@ -218,7 +218,7 @@ exports[`Snapshots MetricGraph should render MetricGraph with maxValue greater t
             }
           >
             <span>
-              30.0
+              30
             </span>
           </span>
           <span
@@ -279,7 +279,7 @@ exports[`Snapshots MetricGraph should render MetricGraph with maxValue less than
             }
           >
             <span>
-              30.0
+              30
             </span>
           </span>
           <span
@@ -488,7 +488,7 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
                 }
               >
                 <span>
-                  122.0
+                  122
                 </span>
               </span>
               <span
@@ -535,7 +535,7 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
                 }
               >
                 <span>
-                  123.0
+                  123
                 </span>
               </span>
               <span
@@ -582,7 +582,7 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
                 }
               >
                 <span>
-                  10.0
+                  10
                 </span>
               </span>
               <span
@@ -629,7 +629,7 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
                 }
               >
                 <span>
-                  233.0
+                  233
                 </span>
               </span>
               <span
@@ -5530,7 +5530,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            3,067.0
+                            3,067
                           </span>
                         </span>
                         <span
@@ -5577,7 +5577,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            222.0
+                            222
                           </span>
                         </span>
                         <span
@@ -5624,7 +5624,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            35.0
+                            35
                           </span>
                         </span>
                         <span
@@ -5671,7 +5671,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            233.0
+                            233
                           </span>
                         </span>
                         <span
@@ -5890,7 +5890,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            1,666.0
+                            1,666
                           </span>
                         </span>
                         <span
@@ -5937,7 +5937,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            196.0
+                            196
                           </span>
                         </span>
                         <span
@@ -5984,7 +5984,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            15.0
+                            15
                           </span>
                         </span>
                         <span
@@ -6031,7 +6031,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            54.0
+                            54
                           </span>
                         </span>
                         <span
@@ -6129,7 +6129,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            8,582.0
+                            8,582
                           </span>
                         </span>
                         <span
@@ -6244,7 +6244,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            534.0
+                            534
                           </span>
                         </span>
                         <span
@@ -6291,7 +6291,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            107.0
+                            107
                           </span>
                         </span>
                         <span
@@ -6338,7 +6338,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            6.0
+                            6
                           </span>
                         </span>
                         <span
@@ -6385,7 +6385,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            30.0
+                            30
                           </span>
                         </span>
                         <span
@@ -6483,7 +6483,7 @@ exports[`Snapshots TopPostsTable should render the top posts table 1`] = `
                           }
                         >
                           <span>
-                            6,095.0
+                            6,095
                           </span>
                         </span>
                         <span
@@ -7791,7 +7791,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            3,067.0
+                            3,067
                           </span>
                         </span>
                         <span
@@ -7838,7 +7838,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            222.0
+                            222
                           </span>
                         </span>
                         <span
@@ -7885,7 +7885,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            35.0
+                            35
                           </span>
                         </span>
                         <span
@@ -7932,7 +7932,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            233.0
+                            233
                           </span>
                         </span>
                         <span
@@ -8151,7 +8151,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            1,666.0
+                            1,666
                           </span>
                         </span>
                         <span
@@ -8198,7 +8198,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            196.0
+                            196
                           </span>
                         </span>
                         <span
@@ -8245,7 +8245,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            15.0
+                            15
                           </span>
                         </span>
                         <span
@@ -8292,7 +8292,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            54.0
+                            54
                           </span>
                         </span>
                         <span
@@ -8390,7 +8390,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            8,582.0
+                            8,582
                           </span>
                         </span>
                         <span
@@ -8505,7 +8505,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            534.0
+                            534
                           </span>
                         </span>
                         <span
@@ -8552,7 +8552,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            107.0
+                            107
                           </span>
                         </span>
                         <span
@@ -8599,7 +8599,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            6.0
+                            6
                           </span>
                         </span>
                         <span
@@ -8646,7 +8646,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            30.0
+                            30
                           </span>
                         </span>
                         <span
@@ -8744,7 +8744,7 @@ exports[`Snapshots TopPostsTable should render the top posts table with default 
                           }
                         >
                           <span>
-                            6,095.0
+                            6,095
                           </span>
                         </span>
                         <span


### PR DESCRIPTION
### Purpose

Merge chart state with chart parameters on RPC endpoint with `Object.assign` rather than using the object spread syntax.