### PR TITLE
add ReportsStore Decorator

### DIFF
--- a/packages/average-table/components/AverageTable/story.jsx
+++ b/packages/average-table/components/AverageTable/story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { ReportsStore } from '@bufferapp/analyze-decorators';
 import { checkA11y } from 'storybook-addon-a11y';
 import AverageTable from './index';
 import mockDailyData from './mock/dailyData';
@@ -30,6 +31,8 @@ const metrics = {
 
 storiesOf('AverageTable')
   .addDecorator(checkA11y)
+  .addDecorator(ReportsStore)
+  .addDecorator(ReportsStore)
   .add('should render the average table', () => (
     <div
       style={{

--- a/packages/average-table/components/AverageTable/story.jsx
+++ b/packages/average-table/components/AverageTable/story.jsx
@@ -32,7 +32,6 @@ const metrics = {
 storiesOf('AverageTable')
   .addDecorator(checkA11y)
   .addDecorator(ReportsStore)
-  .addDecorator(ReportsStore)
   .add('should render the average table', () => (
     <div
       style={{

--- a/packages/average-table/package.json
+++ b/packages/average-table/package.json
@@ -26,6 +26,7 @@
     "@bufferapp/analyze-png-export": "^0.9.0",
     "@bufferapp/analyze-profile-selector": "^0.15.0",
     "@bufferapp/analyze-shared-components": "^0.15.0",
+    "@bufferapp/analyze-decorators": "^0.1.0",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
     "@bufferapp/components": "^2.1.1",
     "@bufferapp/summary-table": "^0.15.0"

--- a/packages/compare-chart/components/CompareChart/story.jsx
+++ b/packages/compare-chart/components/CompareChart/story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { action as actionLogger } from '@storybook/addon-actions';
+import { ReportsStore } from '@bufferapp/analyze-decorators';
 
 import CompareChart from './index';
 import mockDailyData from '../../mocks/dailyData';
@@ -9,6 +10,7 @@ import mockTotals from '../../mocks/totals';
 
 storiesOf('CompareChart')
   .addDecorator(checkA11y)
+  .addDecorator(ReportsStore)
   .add('should render the compare chart', () => (
     <div
       style={{

--- a/packages/compare-chart/package.json
+++ b/packages/compare-chart/package.json
@@ -27,6 +27,7 @@
     "@bufferapp/analyze-profile-selector": "^0.15.0",
     "@bufferapp/analyze-shared-components": "^0.15.0",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
+    "@bufferapp/analyze-decorators": "^0.1.0",
     "react-highcharts": "^12.0.0",
     "react-simple-dropdown": "3.0.0"
   },

--- a/packages/contextual-compare/components/ContextualCompare/story.jsx
+++ b/packages/contextual-compare/components/ContextualCompare/story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { action as actionLogger } from '@storybook/addon-actions';
+import { ReportsStore } from '@bufferapp/analyze-decorators';
 import ContextualCompare from './index';
 
 import mockDailyData from '../../mocks/dailyData';
@@ -13,6 +14,7 @@ selectedMetrics[0].squaredIcon = true;
 
 storiesOf('ContextualCompare')
   .addDecorator(checkA11y)
+  .addDecorator(ReportsStore)
   .add('[TESTED] Should render in Presets mode with multiple metrics for each category', () => (
     <div
       style={{

--- a/packages/contextual-compare/package.json
+++ b/packages/contextual-compare/package.json
@@ -26,6 +26,7 @@
     "@bufferapp/analyze-profile-selector": "^0.15.0",
     "@bufferapp/analyze-shared-components": "^0.15.0",
     "@bufferapp/async-data-fetch": "0.5.25",
+    "@bufferapp/analyze-decorators": "^0.1.0",
     "react-highcharts": "^12.0.0",
     "styled-components": "^2.2.0"
   },

--- a/packages/decorators/components/ReportsStore/index.jsx
+++ b/packages/decorators/components/ReportsStore/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+const storeFake = state => ({
+  default: () => {},
+  subscribe: () => {},
+  dispatch: () => {},
+  getState: () => ({ ...state }),
+});
+const store = storeFake({
+  i18n: {
+    translations: {},
+  },
+  reportList: {},
+});
+
+export default storyFn => (
+  <Provider store={store}>
+    {storyFn()}
+  </Provider>
+);

--- a/packages/decorators/index.js
+++ b/packages/decorators/index.js
@@ -1,0 +1,4 @@
+// default export = container
+export default {};
+
+export ReportsStore from './components/ReportsStore';

--- a/packages/decorators/index.test.jsx
+++ b/packages/decorators/index.test.jsx
@@ -1,0 +1,8 @@
+import { ReportsStore } from './index';
+
+describe('DatePicker', () => {
+  it('should export ReportsStore', () => {
+    expect(ReportsStore)
+      .toBeDefined();
+  });
+});

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bufferapp/analyze-decorators",
+  "version": "0.1.0",
+  "description": "Storybooks decators",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules",
+    "test": "yarn run lint && sh ../../package_test.sh",
+    "test-watch": "jest --watch"
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!@bufferapp/*)"
+    ],
+    "verbose": true,
+    "moduleNameMapper": {
+      "\\.(css|less)$": "identity-obj-proxy"
+    }
+  },
+  "author": "federicoweber@gmail.com",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "eslint": "3.19.0",
+    "jest": "19.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/hourly-chart/components/HourlyChart/story.jsx
+++ b/packages/hourly-chart/components/HourlyChart/story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
+import { ReportsStore } from '@bufferapp/analyze-decorators';
 import HourlyChart from './index';
 
 const wrapper = {
@@ -47,6 +48,7 @@ const mockPostCount =
 
 storiesOf('HourlyChart')
   .addDecorator(checkA11y)
+  .addDecorator(ReportsStore)
   .add('loading state', () => (
     <div style={wrapper}>
       <HourlyChart loading />

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -46,9 +46,9 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         <span
           className="sc-kGXeez jKZzuZ"
         >
-          January 26, 49385
+          Invalid date
            to 
-          June 21, 49464
+          Invalid date
         </span>
       </span>
     </span>
@@ -1358,9 +1358,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         <span
           className="sc-kGXeez jKZzuZ"
         >
-          January 26, 49385
+          Invalid date
            to 
-          June 21, 49464
+          Invalid date
         </span>
       </span>
     </span>

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -46,9 +46,9 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         <span
           className="sc-kGXeez jKZzuZ"
         >
-          Invalid date
+          January 26, 49385
            to 
-          Invalid date
+          June 21, 49464
         </span>
       </span>
     </span>
@@ -1358,9 +1358,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         <span
           className="sc-kGXeez jKZzuZ"
         >
-          Invalid date
+          January 26, 49385
            to 
-          Invalid date
+          June 21, 49464
         </span>
       </span>
     </span>

--- a/packages/report/components/Report/story.jsx
+++ b/packages/report/components/Report/story.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import moment from 'moment-timezone';
+import timezoneMock from 'timezone-mock';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { action } from '@storybook/addon-actions';
 import Report from './index';
+
+timezoneMock.register('US/Eastern');
 
 const report = {
   name: 'Weekly Sync Report',
@@ -62,8 +65,8 @@ const report = {
 };
 
 const dateRange = {
-  startDate: moment.tz(1496275200000, 'etc/UTC').format('x'),
-  endDate: moment.tz(1498780800000, 'etc/UTC').format('x'),
+  startDate: moment.tz(1509321600, 'US/Eastern').format('x'),
+  endDate: moment.tz(1509494400, 'US/Eastern').format('x'),
 };
 
 storiesOf('Report')

--- a/packages/report/components/Report/story.jsx
+++ b/packages/report/components/Report/story.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import moment from 'moment-timezone';
-import timezoneMock from 'timezone-mock';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { action } from '@storybook/addon-actions';
 import Report from './index';
-
-timezoneMock.register('US/Eastern');
 
 const report = {
   name: 'Weekly Sync Report',
@@ -65,8 +62,8 @@ const report = {
 };
 
 const dateRange = {
-  startDate: moment.tz(1496275200000, 'US/Eastern').format('x'),
-  endDate: moment.tz(1498780800000, 'US/Eastern').format('x'),
+  startDate: moment.tz(1496275200000, 'etc/UTC').format('x'),
+  endDate: moment.tz(1498780800000, 'etc/UTC').format('x'),
 };
 
 storiesOf('Report')

--- a/packages/summary-table/components/SummaryTable/story.jsx
+++ b/packages/summary-table/components/SummaryTable/story.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { ReportsStore } from '@bufferapp/analyze-decorators';
 import { checkA11y } from 'storybook-addon-a11y';
 import SummaryTable from './index';
 
 storiesOf('SummaryTable')
   .addDecorator(checkA11y)
+  .addDecorator(ReportsStore)
   .add('should render the summary table', () => (
     <div
       style={{

--- a/packages/summary-table/package.json
+++ b/packages/summary-table/package.json
@@ -27,6 +27,7 @@
     "@bufferapp/analyze-png-export": "^0.9.0",
     "@bufferapp/analyze-profile-selector": "^0.15.0",
     "@bufferapp/analyze-shared-components": "^0.15.0",
+    "@bufferapp/analyze-decorators": "^0.1.0",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
     "@bufferapp/components": "2.1.1",
     "@bufferapp/nav-sidebar": "^0.15.0",

--- a/packages/top-posts-table/package.json
+++ b/packages/top-posts-table/package.json
@@ -27,6 +27,7 @@
     "@bufferapp/analyze-png-export": "^0.9.0",
     "@bufferapp/analyze-profile-selector": "^0.15.0",
     "@bufferapp/analyze-shared-components": "^0.15.0",
+    "@bufferapp/analyze-decorators": "^0.1.0",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
     "@bufferapp/components": "2.1.1",
     "@bufferapp/nav-sidebar": "^0.15.0",

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1646,7 +1646,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               className="bi-calendar"
             />
             <span>
-              From: 11/10/17 - To: 11/16/17
+              From: 11/11/17 - To: 11/17/17
             </span>
             <span
               className="rightSide"

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1171,7 +1171,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
 </span>
 `;
 
-exports[`Snapshots InsightsPage should render reports page 1`] = `
+exports[`Snapshots InsightsPage should render Insights page 1`] = `
 <span>
   <div
     style={

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1646,7 +1646,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               className="bi-calendar"
             />
             <span>
-              From: 11/08/17 - To: 11/14/17
+              From: 11/10/17 - To: 11/16/17
             </span>
             <span
               className="rightSide"

--- a/packages/web/components/InsightsPage/story.jsx
+++ b/packages/web/components/InsightsPage/story.jsx
@@ -19,7 +19,7 @@ storiesOf('InsightsPage')
       </Router>
     </Provider>),
   )
-  .add('should render reports page', () => (
+  .add('should render Insights page', () => (
     <InsightsPage
       location={{
         pathname: '/insights/twitter',

--- a/packages/web/components/ReportsPage/story.jsx
+++ b/packages/web/components/ReportsPage/story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import createStore, { history } from '@bufferapp/analyze-store';
@@ -10,7 +10,7 @@ import {
 
 import ReportsPage from './index';
 
-const mockTimestamp = moment('2017-11-05').valueOf();
+const mockTimestamp = moment('2017-11-05').tz('etc/UTC').valueOf();
 Date.now = () => mockTimestamp;
 
 storiesOf('ReportsPage')


### PR DESCRIPTION
### Purpose
To fix Storybooks for Components that require `reportList` and `i18n` stores.

### Notes
Hey @msanroman working on the Summary I noticed that Storybook was complaining about a missing store; because `AddReport` is directly accessing it from the `Provider`. 
This is totally fine, and on the snapshot tests it's working great because we are mocking `AddReport`.

To make Storybook work properly in this case I've added a small decorator that wraps the story into a  `Provider ` component. 
Calling it `ReportsStore`, as of now we are using it only for that purpose but we can probably make a more generic one down the line.


If this approach is fine with you I will add the decorator to the rest of the components that are using it before merging this in.

### Review


#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
