### PR TITLE
add Compare chart to Instagram Overview

### DIFF
--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -5,28 +5,52 @@ const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 const METRICS_CONFIG = require('./metricsConfig');
 
-const requestTotals = (profileId, dateRange, accessToken) =>
+function shouldUseAnalyzeApi (profileService) {
+  return profileService === 'instagram';
+}
+
+const requestTotals = (profileId, profileService, dateRange, accessToken) =>
   rp({
-    uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`,
-    method: 'GET',
+    uri: (shouldUseAnalyzeApi(profileService) ?
+      `${process.env.ANALYZE_API_ADDR}/metrics/totals` :
+      `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`
+    ),
+    method: (shouldUseAnalyzeApi(profileService) ?
+      'POST' :
+      'GET'
+    ),
     strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
     qs: {
       access_token: accessToken,
       start_date: dateRange.start,
       end_date: dateRange.end,
+      profile_id: (shouldUseAnalyzeApi(profileService) ?
+        profileId :
+        null
+      ),
     },
     json: true,
   });
 
-const requestDailyTotals = (profileId, dateRange, accessToken) =>
+const requestDailyTotals = (profileId, profileService, dateRange, accessToken) =>
   rp({
-    uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/daily_totals.json`,
-    method: 'GET',
+    uri: (shouldUseAnalyzeApi(profileService) ?
+      `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals` :
+      `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/daily_totals.json`
+    ),
+    method: (shouldUseAnalyzeApi(profileService) ?
+      'POST' :
+      'GET'
+    ),
     strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
     qs: {
       access_token: accessToken,
       start_date: dateRange.start,
       end_date: dateRange.end,
+      profile_id: (shouldUseAnalyzeApi(profileService) ?
+        profileId :
+        null
+      ),
     },
     json: true,
   });
@@ -93,12 +117,18 @@ function formatDaily(
   const previousPeriodDays = Object.keys(previousPeriodDailyTotalsResult);
   const daily = Array.from(currentPeriodDays, (day, index) => ({
     day,
-    previousPeriodDay: previousPeriodDays[index],
+    previousPeriodDay: previousPeriodDays[index] ?
+      previousPeriodDays[index] :
+      null,
     currentPeriodMetrics: currentPeriodDailyTotalsResult[day],
-    previousPeriodMetrics: previousPeriodDailyTotalsResult[previousPeriodDays[index]],
+    previousPeriodMetrics: previousPeriodDays[index] ?
+      previousPeriodDailyTotalsResult[previousPeriodDays[index]] :
+      null,
     currentPeriodPostCount: currentPeriodDailyTotalsResult[day].posts_count,
-    previousPeriodPostCount: previousPeriodDailyTotalsResult[previousPeriodDays[index]].posts_count,
-  })).map((data) => {
+    previousPeriodPostCount: previousPeriodDays[index] ?
+      previousPeriodDailyTotalsResult[previousPeriodDays[index]].posts_count :
+      null,
+  })).filter(data => data.previousPeriodDay !== null).map((data) => {
     const metricKeys = METRICS_CONFIG[profileService].orderedKeys;
     return {
       day: data.day,
@@ -144,6 +174,12 @@ function formatTotalPeriodDaily(formattedDailyData) {
   return totalPeriodDaily;
 }
 
+function shouldComputeTotalPeriodDaily (profileService) {
+  return profileService === 'twitter' ||
+  profileService === 'instagram';
+}
+
+
 function formatData(
   currentPeriodResult,
   currentPeriodPostCount,
@@ -167,7 +203,9 @@ function formatData(
     profileService,
   );
 
-  const totalPeriodDaily = profileService === 'twitter' ? formatTotalPeriodDaily(daily) : [];
+  const totalPeriodDaily = shouldComputeTotalPeriodDaily(profileService) ?
+    formatTotalPeriodDaily(daily) :
+    [];
 
   return {
     totals,
@@ -185,12 +223,27 @@ module.exports = method(
     const dateRange = new DateRange(start, end);
     const previousDateRange = dateRange.getPreviousDateRange();
 
-    const currentPeriodTotals = requestTotals(profileId, dateRange, session.analyze.accessToken);
-    const previousPeriodTotals = requestTotals(profileId, previousDateRange, session.analyze.accessToken);
-
-    const currentPeriodDailyTotals = requestDailyTotals(profileId, dateRange, session.analyze.accessToken);
+    const currentPeriodTotals = requestTotals(
+      profileId,
+      profileService,
+      dateRange,
+      session.analyze.accessToken,
+    );
+    const previousPeriodTotals = requestTotals(
+      profileId,
+      profileService,
+      previousDateRange,
+      session.analyze.accessToken,
+    );
+    const currentPeriodDailyTotals = requestDailyTotals(
+      profileId,
+      profileService,
+      dateRange,
+      session.analyze.accessToken,
+    );
     const previousPeriodDailyTotals = requestDailyTotals(
       profileId,
+      profileService,
       previousDateRange,
       session.analyze.accessToken,
     );

--- a/packages/server/rpc/compare/metricsConfig.js
+++ b/packages/server/rpc/compare/metricsConfig.js
@@ -91,6 +91,33 @@ const facebookConfig = {
   },
 };
 
+const instagramConfig = {
+  posts_count: {
+    label: 'Posts',
+    color: '#3A92D3',
+  },
+
+  likes: {
+    label: 'Likes',
+    color: '#FD8F90',
+  },
+
+  comments: {
+    label: 'Comments',
+    color: '#EFDF00',
+  },
+
+  followers: {
+    label: 'Total Fans',
+    color: '#FDA3F3',
+  },
+
+  new_followers: {
+    label: 'New Fans',
+    color: '#D7B5FD',
+  },
+};
+
 module.exports = {
   twitter: {
     config: twitterConfig,
@@ -115,6 +142,16 @@ module.exports = {
       'post_clicks',
       'reactions',
       'shares',
+      'comments',
+      'followers',
+      'new_followers',
+    ],
+  },
+  instagram: {
+    config: instagramConfig,
+    orderedKeys: [
+      'posts_count',
+      'likes',
       'comments',
       'followers',
       'new_followers',

--- a/packages/server/rpc/compare/mockResponses.js
+++ b/packages/server/rpc/compare/mockResponses.js
@@ -222,3 +222,33 @@ export const PAST_PERIOD_DAILY_RESPONSE = {
   },
   success: true,
 };
+
+export const PAST_PERIOD_DAILY_PARTIAL_RESPONSE = {
+  response: {
+    1503446400000: {
+      posts_count: 1,
+      shares: 21,
+      comments: 22,
+      followers: 99384,
+      new_followers: 68,
+      page_engagements: 322,
+      post_impressions: 45547,
+      post_clicks: 1812,
+      post_reach: 37170,
+      reactions: 181,
+    },
+    1503532800000: {
+      posts_count: 3,
+      shares: 0,
+      comments: 0,
+      followers: 99444,
+      new_followers: 79,
+      page_engagements: 493,
+      post_impressions: 63845,
+      post_clicks: 2599,
+      post_reach: 45702,
+      reactions: 288,
+    },
+  },
+  success: true,
+};

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1646,7 +1646,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               className="bi-calendar"
             />
             <span>
-              From: 11/14/17 - To: 11/20/17
+              From: 11/15/17 - To: 11/21/17
             </span>
             <span
               className="rightSide"

--- a/packages/web/components/OverviewTab/index.jsx
+++ b/packages/web/components/OverviewTab/index.jsx
@@ -12,7 +12,7 @@ import ContextualCompare from '@bufferapp/contextual-compare';
 const OverviewTab = ({ match }) => (
   <div>
     <SummaryTable profileService={match.params.service} />
-    <AverageTable />
+    {match.params.service !== 'instagram' && <AverageTable />}
     {match.params.service === 'twitter' && <HourlyChart />}
     <CompareChart />
     {match.params.service === 'facebook' && <ContextualCompare /> }

--- a/packages/web/components/OverviewTab/index.test.jsx
+++ b/packages/web/components/OverviewTab/index.test.jsx
@@ -62,4 +62,24 @@ describe('web/OverviewTab', () => {
     expect(component.find(TopPostsTable).length)
       .toBe(1);
   });
+  it('should render the overview for instagram', () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({});
+    const match = {
+      params: {
+        service: 'instagram',
+        id: 'afs42',
+      },
+    };
+    const component = shallow(<OverviewTab
+      match={match}
+      store={store}
+    />).dive();
+    expect(component.find(SummaryTable).length)
+      .toBe(1);
+    expect(component.find(CompareChart).length)
+      .toBe(1);
+    expect(component.find(TopPostsTable).length)
+      .toBe(1);
+  });
 });


### PR DESCRIPTION
### Purpose
Uses Analyze-api endpoint to populate the Metrics Breakdown chart for Instagram.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
