### PR TITLE
Directly send perf measures to DataDog

### DIFF
--- a/packages/profile-selector/middleware.js
+++ b/packages/profile-selector/middleware.js
@@ -2,6 +2,7 @@
 import { push, LOCATION_CHANGE } from 'react-router-redux';
 import { actions as reportActions } from '@bufferapp/report-list';
 import { actionTypes } from '@bufferapp/async-data-fetch';
+import { actions as performanceActions } from '@bufferapp/performance-tracking';
 import { actions as profilesActions, actionTypes as profileActionTypes } from './reducer';
 
 
@@ -60,6 +61,7 @@ export default ({ dispatch, getState }) => next => (action) => {
         const firstProfile = action.result[0];
         dispatch(profilesActions.selectProfile(firstProfile.id, firstProfile.service));
       }
+      dispatch(performanceActions.measureFromNavigationStart({ name: 'firstMeaningfulPaint' }));
       break;
     case profileActionTypes.SELECT_PROFILE_SERVICE: {
       const allProfiles = getState().profiles.profiles;

--- a/packages/profile-selector/middleware.test.js
+++ b/packages/profile-selector/middleware.test.js
@@ -1,3 +1,4 @@
+import { actions as performanceActions } from '@bufferapp/performance-tracking';
 import { actionTypes } from '@bufferapp/async-data-fetch';
 import { actions as reportActions } from '@bufferapp/report-list';
 import { push, LOCATION_CHANGE } from 'react-router-redux';
@@ -78,6 +79,16 @@ describe('middleware', () => {
     };
     invoke(action);
     expect(store.dispatch).toHaveBeenCalledWith(profileActions.selectProfile(profileId, 'twitter'));
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('should track first meaningful paint on fetch', () => {
+    const { store, next, invoke } = getMiddlewareElements();
+    const action = {
+      type: `profiles_${actionTypes.FETCH_SUCCESS}`,
+    };
+    invoke(action);
+    expect(store.dispatch).toHaveBeenCalledWith(performanceActions.measureFromNavigationStart({ name: 'firstMeaningfulPaint' }));
     expect(next).toHaveBeenCalledWith(action);
   });
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
     "microrouter": "2.1.1",
     "moment": "^2.18.1",
     "moment-timezone": "0.5.12",
+    "node-dogstatsd": "0.0.6",
     "request": "2.81.0",
     "request-promise": "4.2.1"
   },

--- a/packages/server/rpc/performanceTracking/index.js
+++ b/packages/server/rpc/performanceTracking/index.js
@@ -1,20 +1,21 @@
 const { method } = require('@bufferapp/micro-rpc');
-const rp = require('request-promise');
+const StatsD = require('node-dogstatsd').StatsD;
+
+const dogstatsd = new StatsD('dd-agent.default');
 
 module.exports = method(
   'performance',
   'track performance',
-  ({ data }, { session }) => {
+  ({ data }) => {
     if (!data.tags) data.tags = [];
-    data.tags.push('product:analyze');
+    data.tags.push('app:analyze');
+    data.name = `buffer.perf.${data.name}`;
 
-    return rp({
-      uri: `${process.env.API_ADDR}/1/performance.json`,
-      method: 'POST',
-      strictSSL: !(process.env.NODE_ENV === 'development'),
-      qs: Object.assign({
-        access_token: session.analyze.accessToken,
-      }, data),
-    })
-      .then(result => JSON.parse(result));
+    dogstatsd.histogram(
+      data.name,
+      data.duration,
+      1,
+      data.tags,
+    );
+    return data;
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6090,6 +6090,10 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-dogstatsd@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/node-dogstatsd/-/node-dogstatsd-0.0.6.tgz#d697e4d1903a7ff0c16479cd5d1cde043737e047"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"


### PR DESCRIPTION
### Purpose
To track performances in Data Dog independently from buffer web.
It also adds the tracking of first meaningful paint.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
