### PR TITLE
Add Instagram post-summary

### DIFF
--- a/packages/posts-summary-table/components/PostsSummaryTable/index.jsx
+++ b/packages/posts-summary-table/components/PostsSummaryTable/index.jsx
@@ -27,7 +27,15 @@ const gridContainer = {
 
 export const Table = ({ metrics }) =>
   <ul style={gridStyle}>
-    {metrics.map(metric => <GridItem key={metric.label} metric={metric} gridWidth={'33.33%'} />)}
+    {metrics.map((metric) => {
+      const itemProps = {
+        key: metric.label,
+        metric,
+        gridWidth: '33.33%',
+      };
+      if (metrics.length === 5) itemProps.gridWidth = '20%';
+      return (<GridItem {...itemProps} />);
+    })}
   </ul>;
 
 Table.propTypes = {

--- a/packages/posts-summary-table/middleware.js
+++ b/packages/posts-summary-table/middleware.js
@@ -26,6 +26,7 @@ export default store => next => (action) => { // eslint-disable-line no-unused-v
         name: 'posts_summary',
         args: {
           profileId: action.id,
+          profileService: action.profileService,
           startDate: getState().date.startDate,
           endDate: getState().date.endDate,
         },
@@ -36,6 +37,7 @@ export default store => next => (action) => { // eslint-disable-line no-unused-v
         name: 'posts_summary',
         args: {
           profileId: getState().profiles.selectedProfileId,
+          profileService: getState().profiles.selectedProfileService,
           startDate: action.startDate,
           endDate: action.endDate,
         },

--- a/packages/profile-selector/middleware.js
+++ b/packages/profile-selector/middleware.js
@@ -71,7 +71,7 @@ export default ({ dispatch, getState }) => next => (action) => {
           allProfiles,
           action.profileService,
         );
-        dispatch(profilesActions.selectProfile(filteredProfiles[0].id));
+        dispatch(profilesActions.selectProfile(filteredProfiles[0].id, action.profileService));
       } else {
         // do not filter profiles & select the first one
         dispatch(profilesActions.selectProfile(allProfiles[0].id));

--- a/packages/profile-selector/middleware.test.js
+++ b/packages/profile-selector/middleware.test.js
@@ -110,18 +110,6 @@ describe('middleware', () => {
     expect(next).toHaveBeenCalledWith(action);
   });
 
-  it('should select a profile after a service is selected on side-navbar', () => {
-    const { store, next, invoke } = getMiddlewareElements();
-    const action = {
-      type: `${profileActionTypes.SELECT_PROFILE_SERVICE}`,
-      profileService: 'facebook',
-
-    };
-    invoke(action);
-    expect(store.dispatch).toHaveBeenCalledWith(profileActions.selectProfile('122222222'));
-    expect(next).toHaveBeenCalledWith(action);
-  });
-
   it('should select the first profile if profileService is not specified (comparison page)', () => {
     const { store, next, invoke } = getMiddlewareElements();
     const action = {
@@ -161,8 +149,13 @@ describe('middleware', () => {
       profileService: 'facebook',
 
     };
+    const expectedAction = {
+      type: `${profileActionTypes.SELECT_PROFILE}`,
+      profileService: 'facebook',
+      id: '122222222',
+    };
     invoke(action);
-    expect(store.dispatch).toHaveBeenCalledWith(profileActions.selectProfile('122222222'));
+    expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
     expect(next).toHaveBeenCalledWith(action);
   });
 

--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -4,63 +4,93 @@ const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 const LABELS = {
-  // common metric labels
-  posts_count: 'Posts',
-  // facebook
-  post_impressions: 'Post Impressions',
-  post_reach: 'Post Reach',
-  reactions: 'Reactions',
-  comments: 'Comments',
-  shares: 'Shares',
-  // twitter
-  retweets: 'Retweets',
-  impressions: 'Impressions',
-  favorites: 'Likes',
-  replies: 'Replies',
-  url_clicks: 'Clicks',
+  facebook: {
+    posts_count: 'Posts',
+    post_impressions: 'Post Impressions',
+    post_reach: 'Post Reach',
+    reactions: 'Reactions',
+    comments: 'Comments',
+    shares: 'Shares',
+  },
+  twitter: {
+    posts_count: 'Posts',
+    retweets: 'Retweets',
+    impressions: 'Impressions',
+    favorites: 'Likes',
+    replies: 'Replies',
+    url_clicks: 'Clicks',
+  },
+  instagram: {
+    posts_count: 'Posts',
+    likes: 'Likes',
+    comments: 'Comments',
+    followers: 'Total Followers',
+    new_followers: 'New Followers',
+  },
 };
 
-const requestPostsSummary = (profileId, dateRange, accessToken) =>
+function shouldUseAnalyzeApi (profileService) {
+  return profileService === 'instagram';
+}
+
+const requestPostsSummary = (profileId, profileService, dateRange, accessToken) =>
   rp({
-    uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/posts_summary.json`,
-    method: 'GET',
+    uri: (shouldUseAnalyzeApi(profileService) ?
+      `${process.env.ANALYZE_API_ADDR}/metrics/totals` :
+      `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/posts_summary.json`
+    ),
+    method: (shouldUseAnalyzeApi(profileService) ?
+      'POST' :
+      'GET'
+    ),
     strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
     qs: {
       access_token: accessToken,
       start_date: dateRange.start,
       end_date: dateRange.end,
+      profile_id: profileId,
     },
     json: true,
   });
 
-const excludeFollowerCount = metrics => metrics.filter(metric => metric !== 'followers');
+const filterMetrics = metrics => metrics.filter(metric => metric.label !== undefined);
 
 const percentageDifference = (value, pastValue) => {
   const difference = value - pastValue;
   return Math.ceil((difference / pastValue) * 100);
 };
 
-const summarize = (metric, currentPeriod, pastPeriod) => {
+const summarize = (metric, currentPeriod, pastPeriod, profileService) => {
   const pastValue = pastPeriod[metric];
   const value = currentPeriod[metric];
   return {
     value,
     diff: percentageDifference(value, pastValue),
-    label: LABELS[metric],
+    label: LABELS[profileService][metric],
   };
 };
 
 module.exports = method(
   'posts_summary',
   'fetch analytics posts summary for profiles and pages',
-  ({ profileId, startDate, endDate }, { session }) => {
+  ({ profileId, profileService, startDate, endDate }, { session }) => {
     const end = moment.unix(endDate).format('MM/DD/YYYY');
     const start = moment.unix(startDate).format('MM/DD/YYYY');
     const dateRange = new DateRange(start, end);
     const previousDateRange = dateRange.getPreviousDateRange();
 
-    const currentPeriod = requestPostsSummary(profileId, dateRange, session.analyze.accessToken);
-    const previousPeriod = requestPostsSummary(profileId, previousDateRange, session.analyze.accessToken);
+    const currentPeriod = requestPostsSummary(
+      profileId,
+      profileService,
+      dateRange,
+      session.analyze.accessToken,
+    );
+    const previousPeriod = requestPostsSummary(
+      profileId,
+      profileService,
+      previousDateRange,
+      session.analyze.accessToken,
+    );
 
     return Promise
       .all([currentPeriod, previousPeriod])
@@ -68,9 +98,9 @@ module.exports = method(
         const currentPeriodResult = response[0].response;
         const pastPeriodResult = response[1].response;
         const metrics = Object.keys(currentPeriodResult);
-        return excludeFollowerCount(metrics).map(metric =>
-          summarize(metric, currentPeriodResult, pastPeriodResult),
-        );
+        return filterMetrics(metrics.map(metric =>
+          summarize(metric, currentPeriodResult, pastPeriodResult, profileService),
+        ));
       })
       .catch(() => []);
   },

--- a/packages/server/rpc/postsSummary/index.test.js
+++ b/packages/server/rpc/postsSummary/index.test.js
@@ -21,7 +21,7 @@ describe('rpc/posts_summary', () => {
       .toBe('fetch analytics posts summary for profiles and pages');
   });
 
-  it('should request for the past week', () => {
+  it('should request metrics to Analyze Api for Instagram', () => {
     const end = moment().subtract(1, 'days').unix();
     const start = moment().subtract(7, 'days').unix();
 
@@ -29,6 +29,40 @@ describe('rpc/posts_summary', () => {
       startDate: start,
       endDate: end,
       profileId,
+      profileService: 'instagram',
+    }, {
+      session: {
+        analyze: {
+          accessToken: token,
+        },
+      },
+    });
+
+    expect(rp.mock.calls[0])
+      .toEqual([{
+        uri: `${process.env.ANALYZE_API_ADDR}/metrics/totals`,
+        method: 'POST',
+        strictSSL: false,
+        qs: {
+          access_token: token,
+          start_date: moment.unix(start).format('MM/DD/YYYY'),
+          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          profile_id: profileId,
+        },
+        json: true,
+      }]);
+  });
+
+  it('should request for the past week', () => {
+    rp.mockClear();
+    const end = moment().subtract(1, 'days').unix();
+    const start = moment().subtract(7, 'days').unix();
+
+    postsSummary.fn({
+      startDate: start,
+      endDate: end,
+      profileId,
+      profileService: 'twitter',
     }, {
       session: {
         analyze: {
@@ -46,6 +80,7 @@ describe('rpc/posts_summary', () => {
           access_token: token,
           start_date: moment.unix(start).format('MM/DD/YYYY'),
           end_date: moment.unix(end).format('MM/DD/YYYY'),
+          profile_id: profileId,
         },
         json: true,
       }]);
@@ -59,6 +94,7 @@ describe('rpc/posts_summary', () => {
       startDate,
       endDate,
       profileId,
+      profileService: 'twitter',
     }, {
       session: {
         analyze: {
@@ -79,6 +115,7 @@ describe('rpc/posts_summary', () => {
           access_token: token,
           start_date: start,
           end_date: end,
+          profile_id: profileId,
         },
         json: true,
       }]);
@@ -88,7 +125,10 @@ describe('rpc/posts_summary', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_RESPONSE));
 
-    const postsSummaryData = await postsSummary.fn({ profileId }, {
+    const postsSummaryData = await postsSummary.fn({
+      profileId,
+      profileService: 'facebook',
+    }, {
       session: {
         analyze: {
           accessToken: token,


### PR DESCRIPTION
### Purpose
To add Upadates summary for Instagram, using Analyze-api.

### Notes
This also fix a bug, where the profileService was missing, when switching social network from the navSidebar.
### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
