### PR TITLE
Add Post Reach metric to FB compare chart

### DIFF
--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -201,7 +201,7 @@ describe('rpc/compare', () => {
       },
     });
 
-    expect(data.totals.length).toBe(9);
+    expect(data.totals.length).toBe(10);
     expect(data.totals[0]).toEqual({
       diff: 0,
       label: 'Posts',
@@ -227,7 +227,7 @@ describe('rpc/compare', () => {
       },
     });
 
-    expect(data.totals.length).toBe(9);
+    expect(data.totals.length).toBe(10);
     expect(data.totals[0]).toEqual({
       diff: 300,
       label: 'Posts',

--- a/packages/server/rpc/compare/metricsConfig.js
+++ b/packages/server/rpc/compare/metricsConfig.js
@@ -60,6 +60,11 @@ const facebookConfig = {
     color: '#8AC6DE',
   },
 
+  post_reach: {
+    label: 'Post Reach',
+    color: '#57aae5',
+  },
+
   post_clicks: {
     label: 'Post Clicks',
     color: '#98E8B2',
@@ -139,6 +144,7 @@ module.exports = {
       'posts_count',
       'page_engagements',
       'post_impressions',
+      'post_reach',
       'post_clicks',
       'reactions',
       'shares',


### PR DESCRIPTION
### Purpose

Related to this [flow card](https://beta.getflow.com/organizations/369191/teams/339227/tasks/27628823). 

Screenshot: 

<img width="880" alt="image 2018-01-05 at 4 32 01 pm" src="https://user-images.githubusercontent.com/3679842/34629418-0bbc0a9e-f236-11e7-974a-370c81bf3fc7.png">


### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
