### PR TITLE
PDF exports should respect the selected date range

### DIFF
--- a/packages/date-picker/middleware.js
+++ b/packages/date-picker/middleware.js
@@ -1,8 +1,34 @@
-import { actions } from '@bufferapp/async-data-fetch';
+import { actions, actionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes as profileActionTypes } from '@bufferapp/analyze-profile-selector';
+import { actions as dateActions } from './reducer';
 
-export default ({ dispatch }) => next => (action) => {
+const getStartDate = (query) => {
+  let startDate = query.match(/start_date=(.*)&/);
+  if (startDate) {
+    startDate = parseInt(startDate[1], 10);
+  }
+  return startDate;
+};
+const getEndDate = (query) => {
+  let endDate = query.match(/end_date=(.*)$/);
+  if (endDate) {
+    endDate = parseInt(endDate[1], 10);
+  }
+  return endDate;
+};
+
+export default ({ dispatch, getState }) => next => (action) => {
+  let startDate;
+  let endDate;
+  const state = getState();
   switch (action.type) {
+    case `user_${actionTypes.FETCH_SUCCESS}`:
+      startDate = getStartDate(state.router.location.search);
+      endDate = getEndDate(state.router.location.search);
+      if (startDate && endDate) {
+        dispatch(dateActions.setDateRange(startDate, endDate));
+      }
+      break;
     case profileActionTypes.SELECT_PROFILE:
       dispatch(actions.fetch({
         name: 'analytics_start_date',

--- a/packages/date-picker/middleware.test.js
+++ b/packages/date-picker/middleware.test.js
@@ -1,12 +1,18 @@
-import { actions } from '@bufferapp/async-data-fetch';
+import { actions, actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
 import { actionTypes } from '@bufferapp/analyze-profile-selector';
+import { actions as dateActions } from './reducer';
 import middleware from './middleware';
 
 describe('middleware', () => {
+  let state = {};
   const next = jest.fn();
   const store = {
     dispatch: jest.fn(),
+    getState: jest.fn(() => state),
   };
+  beforeEach(() => {
+    state = {};
+  });
   it('should exist', () => {
     expect(middleware).toBeDefined();
   });
@@ -31,5 +37,22 @@ describe('middleware', () => {
       },
     }));
     expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('should set the date range on user_FETCH_SUCCESS if there are start_date and end_date available as search parameters', () => {
+    state.router = {
+      location: {
+        search: '?start_date=1234&end_date=5678',
+      },
+    };
+    const action = {
+      type: `user_${asyncDataFetchActionTypes.FETCH_SUCCESS}`,
+    };
+    middleware(store)(next)(action);
+    expect(store.dispatch).toHaveBeenCalledWith(dateActions.setDateRange(1234, 5678));
+  });
+
+  afterEach(() => {
+    store.dispatch.mockReset();
   });
 });

--- a/packages/pdf-export/middleware.js
+++ b/packages/pdf-export/middleware.js
@@ -1,14 +1,14 @@
 import { actionTypes } from './actions';
 
-const getExportURL = () => {
+const getExportURL = ({ startDate, endDate }) => {
   const { origin, pathname } = window.location;
-  return `${origin}/report_to_pdf?url=${origin}/export${pathname}`;
+  return `${origin}/report_to_pdf?url=${origin}/export${pathname}?start_date=${startDate}&end_date=${endDate}`;
 };
 
 export default store => next => (action) => { // eslint-disable-line no-unused-vars
   switch (action.type) {
     case actionTypes.EXPORT_TO_PDF:
-      window.open(getExportURL(), '_blank');
+      window.open(getExportURL(store.getState().date), '_blank');
       break;
     default:
       break;

--- a/packages/pdf-export/middleware.js
+++ b/packages/pdf-export/middleware.js
@@ -2,7 +2,8 @@ import { actionTypes } from './actions';
 
 const getExportURL = ({ startDate, endDate }) => {
   const { origin, pathname } = window.location;
-  return `${origin}/report_to_pdf?url=${origin}/export${pathname}?start_date=${startDate}&end_date=${endDate}`;
+  const exportURL = encodeURIComponent(`${origin}/export${pathname}?start_date=${startDate}&end_date=${endDate}`);
+  return `${origin}/report_to_pdf?url=${exportURL}`;
 };
 
 export default store => next => (action) => { // eslint-disable-line no-unused-vars

--- a/packages/pdf-export/middleware.test.js
+++ b/packages/pdf-export/middleware.test.js
@@ -33,7 +33,9 @@ describe('middleware', () => {
     const action = {
       type: actionTypes.EXPORT_TO_PDF,
     };
+    const exportURL = encodeURIComponent('https://analyze.buffer.com/export/report/1234?start_date=5678&end_date=9876');
+    const expectedURL = `https://analyze.buffer.com/report_to_pdf?url=${exportURL}`;
     middleware(store)(next)(action);
-    expect(global.open).toHaveBeenCalledWith('https://analyze.buffer.com/report_to_pdf?url=https://analyze.buffer.com/export/report/1234?start_date=5678&end_date=9876', '_blank');
+    expect(global.open).toHaveBeenCalledWith(expectedURL, '_blank');
   });
 });

--- a/packages/pdf-export/middleware.test.js
+++ b/packages/pdf-export/middleware.test.js
@@ -13,7 +13,12 @@ describe('middleware', () => {
   const next = jest.fn();
   const store = {
     dispatch: jest.fn(),
-    getState: jest.fn(() => {}),
+    getState: jest.fn(() => ({
+      date: {
+        startDate: 5678,
+        endDate: 9876,
+      },
+    })),
   };
   it('should exist', () => {
     expect(middleware).toBeDefined();
@@ -24,11 +29,11 @@ describe('middleware', () => {
     };
     middleware(store)(next)(action);
   });
-  it('should work', () => {
+  it('EXPORT_TO_PDF should open a new tab with the export url for that report', () => {
     const action = {
       type: actionTypes.EXPORT_TO_PDF,
     };
     middleware(store)(next)(action);
-    expect(global.open).toHaveBeenCalledWith('https://analyze.buffer.com/report_to_pdf?url=https://analyze.buffer.com/export/report/1234', '_blank');
+    expect(global.open).toHaveBeenCalledWith('https://analyze.buffer.com/report_to_pdf?url=https://analyze.buffer.com/export/report/1234?start_date=5678&end_date=9876', '_blank');
   });
 });

--- a/packages/report/middleware.js
+++ b/packages/report/middleware.js
@@ -12,6 +12,7 @@ const getReportId = (pathname) => {
   return routeMatch ? routeMatch[1] : null;
 };
 const isReportDetailRoute = pathname => getReportId(pathname) !== null;
+const isExportRoute = pathname => pathname.match(/export\/reports/) !== null;
 
 const getReport = (reportId, reports) =>
   reports.find(report => report._id === reportId);
@@ -46,14 +47,16 @@ export default store => next => (action) => { // eslint-disable-line no-unused-v
       };
       break;
     case dateActionTypes.SET_DATE_RANGE:
-      store.dispatch(actions.fetch({
-        name: 'get_report',
-        args: {
-          ...state.report,
-          startDate: action.startDate,
-          endDate: action.endDate,
-        },
-      }));
+      if (!isExportRoute(state.router.location.pathname)) {
+        store.dispatch(actions.fetch({
+          name: 'get_report',
+          args: {
+            ...state.report,
+            startDate: action.startDate,
+            endDate: action.endDate,
+          },
+        }));
+      }
       break;
     case `list_reports_${asyncDataFetchActionTypes.FETCH_SUCCESS}`:
       if (isReportDetailRoute(state.router.location.pathname)) {

--- a/packages/report/middleware.test.js
+++ b/packages/report/middleware.test.js
@@ -36,6 +36,11 @@ describe('middleware', () => {
         ],
       }],
     },
+    router: {
+      location: {
+        pathname: '',
+      },
+    },
     profiles: {
       profiles: [{
         id: 'profile1',
@@ -62,22 +67,39 @@ describe('middleware', () => {
     middleware(store)(next)(action);
   });
 
-  it('shoud dispatch a new data fetch for once date range is changed', () => {
-    const action = {
-      type: dateActionTypes.SET_DATE_RANGE,
-      startDate: '10/10/2016',
-      endDate: '20/10/2016',
-    };
-    middleware(store)(next)(action);
-    expect(store.dispatch).toHaveBeenCalledWith(actions.fetch({
-      name: 'get_report',
-      args: {
-        id: state.report.id,
+  describe('SET_DATE_RANGE', () => {
+    it('shoud dispatch a new data fetch for the report once date range is changed', () => {
+      const action = {
+        type: dateActionTypes.SET_DATE_RANGE,
         startDate: '10/10/2016',
         endDate: '20/10/2016',
-      },
-    }));
-    expect(next).toHaveBeenCalledWith(action);
+      };
+      middleware(store)(next)(action);
+      expect(store.dispatch).toHaveBeenCalledWith(actions.fetch({
+        name: 'get_report',
+        args: {
+          id: state.report.id,
+          startDate: '10/10/2016',
+          endDate: '20/10/2016',
+        },
+      }));
+      expect(next).toHaveBeenCalledWith(action);
+    });
+
+    it('should not dispatch the data fetch if the view is an export view', () => {
+      state.router = {
+        location: {
+          pathname: '/export/reports/1234',
+        },
+      };
+      const action = {
+        type: dateActionTypes.SET_DATE_RANGE,
+        startDate: '10/10/2016',
+        endDate: '20/10/2016',
+      };
+      middleware(store)(next)(action);
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
   });
 
   it('VIEW_REPORT dispatches a new data fetch', () => {

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -86,7 +86,7 @@ app.get('/report_to_pdf', (req, res) => {
   const params = {
     FunctionName: 'reportToPDF',
     Payload: JSON.stringify({
-      url: req.query.url,
+      url: decodeURIComponent(req.query.url),
       orientation: 'portrait',
       javascriptDelay: 30000,
       cookie: {

--- a/packages/web/components/ReportsPage/story.jsx
+++ b/packages/web/components/ReportsPage/story.jsx
@@ -14,7 +14,13 @@ import ReportsPage from './index';
 storiesOf('ReportsPage')
   .addDecorator(checkA11y)
   .addDecorator((getStory) => {
-    const store = createStore();
+    const store = createStore({
+      router: {
+        location: {
+          pathname: '',
+        },
+      },
+    });
     store.dispatch(
       actions.setDateRange(
         moment('2017-11-05')


### PR DESCRIPTION
### Purpose

To allow PDF exports of reports with date ranges different than 7 days.

### Notes

If there is a date range defined as query string on the URL (generated automatically through the PDF export button middleware), we'll use it as the source of truth for defining the state of the date reducer.