### PR TITLE
Set report name as PDF filename

### DIFF
--- a/packages/pdf-export/middleware.js
+++ b/packages/pdf-export/middleware.js
@@ -2,8 +2,8 @@ import { actionTypes } from './actions';
 
 const getExportURL = ({ startDate, endDate }, name) => {
   const { origin, pathname } = window.location;
-  const exportURL = encodeURIComponent(`${origin}/export${pathname}?name=${name}&start_date=${startDate}&end_date=${endDate}`);
-  return `${origin}/report_to_pdf?url=${exportURL}`;
+  const exportURL = encodeURIComponent(`${origin}/export${pathname}?start_date=${startDate}&end_date=${endDate}`);
+  return `${origin}/report_to_pdf?name=${name}&url=${exportURL}`;
 };
 
 export default store => next => (action) => { // eslint-disable-line no-unused-vars

--- a/packages/pdf-export/middleware.js
+++ b/packages/pdf-export/middleware.js
@@ -1,15 +1,16 @@
 import { actionTypes } from './actions';
 
-const getExportURL = ({ startDate, endDate }) => {
+const getExportURL = ({ startDate, endDate }, name) => {
   const { origin, pathname } = window.location;
-  const exportURL = encodeURIComponent(`${origin}/export${pathname}?start_date=${startDate}&end_date=${endDate}`);
+  const exportURL = encodeURIComponent(`${origin}/export${pathname}?name=${name}&start_date=${startDate}&end_date=${endDate}`);
   return `${origin}/report_to_pdf?url=${exportURL}`;
 };
 
 export default store => next => (action) => { // eslint-disable-line no-unused-vars
+  const { date, report } = store.getState();
   switch (action.type) {
     case actionTypes.EXPORT_TO_PDF:
-      window.open(getExportURL(store.getState().date), '_blank');
+      window.open(getExportURL(date, report.name), '_blank');
       break;
     default:
       break;

--- a/packages/pdf-export/middleware.test.js
+++ b/packages/pdf-export/middleware.test.js
@@ -18,6 +18,9 @@ describe('middleware', () => {
         startDate: 5678,
         endDate: 9876,
       },
+      report: {
+        name: 'A report',
+      },
     })),
   };
   it('should exist', () => {
@@ -33,7 +36,7 @@ describe('middleware', () => {
     const action = {
       type: actionTypes.EXPORT_TO_PDF,
     };
-    const exportURL = encodeURIComponent('https://analyze.buffer.com/export/report/1234?start_date=5678&end_date=9876');
+    const exportURL = encodeURIComponent('https://analyze.buffer.com/export/report/1234?name=A report&start_date=5678&end_date=9876');
     const expectedURL = `https://analyze.buffer.com/report_to_pdf?url=${exportURL}`;
     middleware(store)(next)(action);
     expect(global.open).toHaveBeenCalledWith(expectedURL, '_blank');

--- a/packages/pdf-export/middleware.test.js
+++ b/packages/pdf-export/middleware.test.js
@@ -36,8 +36,8 @@ describe('middleware', () => {
     const action = {
       type: actionTypes.EXPORT_TO_PDF,
     };
-    const exportURL = encodeURIComponent('https://analyze.buffer.com/export/report/1234?name=A report&start_date=5678&end_date=9876');
-    const expectedURL = `https://analyze.buffer.com/report_to_pdf?url=${exportURL}`;
+    const exportURL = encodeURIComponent('https://analyze.buffer.com/export/report/1234?start_date=5678&end_date=9876');
+    const expectedURL = `https://analyze.buffer.com/report_to_pdf?name=A report&url=${exportURL}`;
     middleware(store)(next)(action);
     expect(global.open).toHaveBeenCalledWith(expectedURL, '_blank');
   });

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -109,6 +109,7 @@ app.get('/report_to_pdf', (req, res) => {
       } else {
         const pdf = Buffer.from(payload.contents, 'base64');
         res.type('application/pdf');
+        res.setHeader(`Content-disposition', 'attachment; filename=${req.query.name}`);
         res.end(pdf, 'binary');
       }
     }

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -110,7 +110,7 @@ app.get('/report_to_pdf', (req, res) => {
       } else {
         const pdf = Buffer.from(payload.contents, 'base64');
         res.type('application/pdf');
-        res.header('Content-disposition', `inline; filename=${req.query.name}`);
+        res.header('Content-disposition', `inline; filename=${req.query.name}.pdf`);
         res.end(pdf, 'binary');
       }
     }

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -100,6 +100,7 @@ app.get('/report_to_pdf', (req, res) => {
     region: 'us-east-1',
   });
   lambda.invoke(params, (err, data) => {
+    res.header('Content-disposition', `inline; filename=${req.query.name}`);
     if (err) {
       res.send(err);
     } else {
@@ -109,7 +110,7 @@ app.get('/report_to_pdf', (req, res) => {
       } else {
         const pdf = Buffer.from(payload.contents, 'base64');
         res.type('application/pdf');
-        res.setHeader(`Content-disposition', 'attachment; filename=${req.query.name}`);
+        res.header('Content-disposition', `inline; filename=${req.query.name}`);
         res.end(pdf, 'binary');
       }
     }


### PR DESCRIPTION
  ### Purpose

To set the report name as the name of the PDF file when exporting a report to PDF.