### PR TITLE
Added Fullstory support

### DIFF
--- a/packages/server/index.html
+++ b/packages/server/index.html
@@ -12,6 +12,7 @@
       }
     </style>
     {{{bugsnagScript}}}
+    {{{fullStoryScript}}}
   </head>
   <body>
     <div id="root"></div>

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -44,9 +44,29 @@ if (isProduction) {
   };
 }
 
+
+const fullStoryScript = `<script>
+window['_fs_debug'] = false;
+window['_fs_host'] = 'fullstory.com';
+window['_fs_org'] = '9F6GW';
+window['_fs_namespace'] = 'FS';
+(function(m,n,e,t,l,o,g,y){
+  if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+  g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
+  o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
+  y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+  g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
+  g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+  g.clearUserCookie=function(c,d,i){if(!c || document.cookie.match('fs_uid=[\`;\`]*\`[\`;\`]*\`[\`;\`]*\`')){
+  d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+
+  ';path=/;expires='+new Date(0).toUTCString();i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}}};
+})(window,document,window['_fs_namespace'],'script','user');
+</script>`;
+
 const html = fs.readFileSync(join(__dirname, 'index.html'), 'utf8')
   .replace('{{{bundle}}}', staticAssets['bundle.js'])
-  .replace('{{{bugsnagScript}}}', bugsnagScript);
+  .replace('{{{bugsnagScript}}}', bugsnagScript)
+  .replace('{{{fullStoryScript}}}', fullStoryScript);
 
 app.use(logMiddleware({ name: 'BufferAnalyze' }));
 app.use(cookieParser());

--- a/packages/store/initMiddleware.js
+++ b/packages/store/initMiddleware.js
@@ -1,12 +1,25 @@
 import { actions as performanceActions } from '@bufferapp/performance-tracking';
+import {
+  actions as dataFetchActions,
+  actionTypes as dataFetchActionTypes,
+} from '@bufferapp/async-data-fetch';
 
 export default ({ dispatch }) => next => (action) => {
   next(action);
   switch (action.type) {
     case 'APP_INIT':
-      dispatch(performanceActions.measureFromNavigationStart({ name: 'init' }));
-      break;
+        dispatch(performanceActions.measureFromNavigationStart({ name: 'init' }));
+        dispatch(dataFetchActions.fetch({ name: 'user' }));
+        break;
+    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
+        /* eslint-disable */
+        if (FS) {
+            FS.identify(action.result.id, {
+              email: action.result.email,
+          });
+        }
+        break;
     default:
-      break;
-  }
+    break;
+}
 };

--- a/packages/store/initMiddleware.js
+++ b/packages/store/initMiddleware.js
@@ -1,25 +1,12 @@
 import { actions as performanceActions } from '@bufferapp/performance-tracking';
-import {
-  actions as dataFetchActions,
-  actionTypes as dataFetchActionTypes,
-} from '@bufferapp/async-data-fetch';
 
 export default ({ dispatch }) => next => (action) => {
   next(action);
   switch (action.type) {
     case 'APP_INIT':
-        dispatch(performanceActions.measureFromNavigationStart({ name: 'init' }));
-        dispatch(dataFetchActions.fetch({ name: 'user' }));
-        break;
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`:
-        /* eslint-disable */
-        if (FS) {
-            FS.identify(action.result.id, {
-              email: action.result.email,
-          });
-        }
-        break;
+      dispatch(performanceActions.measureFromNavigationStart({ name: 'init' }));
+      break;
     default:
-    break;
-}
+      break;
+  }
 };

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -26,7 +26,7 @@
     "@bufferapp/analyze-png-export": "^0.22.0",
     "@bufferapp/analyze-profile-selector": "^0.30.2",
     "@bufferapp/analyze-tabs": "^0.22.0",
-    "@bufferapp/app-sidebar": "1.2.3",
+    "@bufferapp/app-sidebar": "1.2.4",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
     "@bufferapp/audience-chart": "^0.30.2",
     "@bufferapp/audience-comparison-chart": "^0.30.2",

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -606,7 +606,7 @@ exports[`Snapshots App should render application 1`] = `
                     onMouseLeave={[Function]}
                   >
                     <a
-                      href="https://buffer.com/wishlist"
+                      href="https://buffersurvey.typeform.com/to/ZEiVmL"
                       role="menuitem"
                       style={
                         Object {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "@bufferapp/analyze-shared-components": "^0.30.2",
     "@bufferapp/analyze-store": "^0.30.2",
     "@bufferapp/analyze-tabs": "^0.22.0",
-    "@bufferapp/app-sidebar": "1.2.3",
+    "@bufferapp/app-sidebar": "1.2.4",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
     "@bufferapp/audience-chart": "^0.30.2",
     "@bufferapp/audience-comparison-chart": "^0.30.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,11 @@
 # yarn lockfile v1
 
 
-"@bufferapp/app-sidebar@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@bufferapp/app-sidebar/-/app-sidebar-1.2.3.tgz#bc02453ff23c6a49715a63ae60f9e3bca54df443"
+"@bufferapp/app-sidebar@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@bufferapp/app-sidebar/-/app-sidebar-1.2.4.tgz#0a63bd367caae8a2602eb7b2aa0dfaadc2c0e6d2"
   dependencies:
-    "@bufferapp/async-data-fetch" "0.7.4"
+    "@bufferapp/async-data-fetch" "1.2.4"
     "@bufferapp/components" "1.1.0-beta.6"
     "@bufferapp/session-manager" "0.5.39"
 
@@ -21,6 +21,10 @@
 "@bufferapp/async-data-fetch@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@bufferapp/async-data-fetch/-/async-data-fetch-0.7.4.tgz#81cee5ae4911be932f88744fc3c30296eeab2a64"
+
+"@bufferapp/async-data-fetch@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@bufferapp/async-data-fetch/-/async-data-fetch-1.2.4.tgz#a79d586fae1207010f8fa4130685c20a561a93f6"
 
 "@bufferapp/chronos@0.6.1":
   version "0.6.1"


### PR DESCRIPTION
### Purpose
Adds FullStory session tracking:

<img width="1390" alt="screen shot 2018-01-10 at 12 19 52 pm" src="https://user-images.githubusercontent.com/4225378/34785942-95a04f22-f600-11e7-8338-5bc7ea2b6773.png">


### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
