### PR TITLE
Prevent chart rerender on dropdown open

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,11 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+# Tab indentation for JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
 # Tab indentation for JSX files
 [*.jsx]
 indent_style = space

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,6 @@
     "no-underscore-dangle": 0,
     "space-before-function-paren": 0,
     "import/no-extraneous-dependencies": 0,
-		"react/prefer-stateless-function": 0
+    "react/prefer-stateless-function": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "no-param-reassign": 0,
     "no-underscore-dangle": 0,
     "space-before-function-paren": 0,
-    "import/no-extraneous-dependencies": 0
+    "import/no-extraneous-dependencies": 0,
+		"react/prefer-stateless-function": 0
   }
 }

--- a/packages/compare-chart/components/Chart/index.jsx
+++ b/packages/compare-chart/components/Chart/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import ReactHighcharts from 'react-highcharts';
 import moment from 'moment';
 
@@ -134,10 +134,10 @@ function filterDailyDataMetrics(dailyData, metricLabel) {
   }));
 }
 
-
-const Chart =
-  ({ daily, totalPeriodDaily, selectedMetricLabel,
-    dailyMode, timezone, visualizePreviousPeriod, profileService }) => {
+class Chart extends PureComponent {
+  render() {
+    const { daily, totalPeriodDaily, selectedMetricLabel,
+      dailyMode, timezone, visualizePreviousPeriod, profileService } = this.props;
     const dailyData = dailyMode === 1 ? totalPeriodDaily : daily;
     const filteredDailyData = filterDailyDataMetrics(dailyData, selectedMetricLabel);
     const charOptions = prepareChartOptions(
@@ -147,7 +147,8 @@ const Chart =
       profileService,
     );
     return (<ReactHighcharts config={charOptions} />);
-  };
+  }
+}
 
 Chart.propTypes = {
   totalPeriodDaily: PropTypes.arrayOf(PropTypes.shape({

--- a/packages/contextual-compare/components/ContextualCompare/index.jsx
+++ b/packages/contextual-compare/components/ContextualCompare/index.jsx
@@ -39,7 +39,16 @@ const ContextualCompare = ({
       {data.length === 0 && !loading && <NoData />}
       {data.length >= 1 && !loading && <div>
         <Header {...props} />
-        <Chart {...props} pngExportId="contextual" data={data} />
+        <Chart
+          mode={props.mode}
+          presets={props.presets}
+          profileService={props.profileService}
+          selectedMetrics={props.selectedMetrics}
+          selectedPreset={props.selectedPreset}
+          timezone={props.timezone}
+          pngExportId="contextual"
+          data={data}
+        />
       </div>}
     </div>
   </ChartCard>
@@ -47,9 +56,11 @@ const ContextualCompare = ({
 
 ContextualCompare.defaultProps = {
   loading: false,
+  presets: null,
 };
 
 ContextualCompare.propTypes = {
+  timezone: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   profileService: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({
@@ -65,6 +76,16 @@ ContextualCompare.propTypes = {
     label: PropTypes.string.isRequired,
   })).isRequired,
   mode: PropTypes.number.isRequired,
+  presets: PropTypes.arrayOf(PropTypes.shape({
+    day: PropTypes.string,
+    data: PropTypes.arrayOf(PropTypes.shape({
+      metrics: PropTypes.arrayOf(PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        label: PropTypes.string,
+        value: PropTypes.number.isRequired,
+      })),
+    })),
+  })),
 };
 
 const ContextualCompareStyled = styled(ContextualCompare)`

--- a/packages/hourly-chart/components/HourlyChart/index.jsx
+++ b/packages/hourly-chart/components/HourlyChart/index.jsx
@@ -32,7 +32,7 @@ const gridContainer = {
   position: 'relative',
 };
 
-export class ChartContent extends React.Component {
+export class ChartContent extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -105,7 +105,12 @@ const HourlyChart = props =>
       {!props.loading &&
         <div>
           <Header {...props} />
-          <ChartContent {...props} />
+          <ChartContent
+            postsCount={props.postsCount}
+            timezone={props.timezone}
+            selectedMetric={props.selectedMetric}
+            secondaryMetric={props.secondaryMetric}
+          />
         </div>
       }
     </div>
@@ -113,10 +118,23 @@ const HourlyChart = props =>
 
 HourlyChart.defaultProps = {
   loading: false,
+  secondaryMetric: null,
+  postsCount: [],
+  timezone: 'America/Los_Angeles',
 };
 
 HourlyChart.propTypes = {
   loading: PropTypes.bool,
+  selectedMetric: PropTypes.shape({
+    label: PropTypes.string,
+    hourlyMetrics: PropTypes.arrayOf(PropTypes.number),
+  }).isRequired,
+  secondaryMetric: PropTypes.shape({
+    label: PropTypes.string,
+    hourlyMetrics: PropTypes.arrayOf(PropTypes.number),
+  }),
+  postsCount: PropTypes.arrayOf(PropTypes.number),
+  timezone: PropTypes.string,
 };
 
 export default HourlyChart;

--- a/packages/hourly-chart/components/HourlyEngagementChart/index.jsx
+++ b/packages/hourly-chart/components/HourlyEngagementChart/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import ReactHighcharts from 'react-highcharts';
@@ -13,54 +13,57 @@ import {
   secondarySeriesConfig,
 } from './config';
 
-const HourlyEngagementChart = ({ metric, secondaryMetric, posts, chartRef }) => {
-  let hour = moment().startOf('day').subtract(1, 'hour');
-  const metricByHour = metric.hourlyMetrics.map((hourlyMetric, index) => {
-    hour.add(1, 'hour');
-    return {
-      x: hour.valueOf(),
-      y: hourlyMetric,
-      totalUpdates: posts[index],
-      color: color[metric.label],
-    };
-  });
-  const config = {
-    ...chartConfig,
-    series: [{
-      ...primarySeriesConfig,
-      color: color[metric.label],
-      name: metric.label,
-      data: metricByHour,
-    }],
-  };
-  if (secondaryMetric) {
-    hour = moment().startOf('day').subtract(1, 'hour');
-    const secondaryMetricByHour = secondaryMetric.hourlyMetrics.map((hourlyMetric, index) => {
+class HourlyEngagementChart extends PureComponent {
+  render() {
+    const { metric, secondaryMetric, posts, chartRef } = this.props;
+    let hour = moment().startOf('day').subtract(1, 'hour');
+    const metricByHour = metric.hourlyMetrics.map((hourlyMetric, index) => {
       hour.add(1, 'hour');
       return {
         x: hour.valueOf(),
         y: hourlyMetric,
         totalUpdates: posts[index],
-        color: color[secondaryMetric.label],
+        color: color[metric.label],
       };
     });
-    const baseColor = ReactHighcharts.Highcharts.Color(color[secondaryMetric.label]);
-    const fillColor = baseColor ? baseColor.brighten(0.1).get('rgba') : null;
-    config.series.push({
-      ...secondarySeriesConfig,
-      yAxis: (secondaryMetric.label === 'Impressions') ? 1 : 0,
-      marker: {
-        lineColor: color[secondaryMetric.label],
-        fillColor,
-      },
-      color: color[secondaryMetric.label],
-      name: secondaryMetric.label,
-      data: secondaryMetricByHour,
-    });
-  }
+    const config = {
+      ...chartConfig,
+      series: [{
+        ...primarySeriesConfig,
+        color: color[metric.label],
+        name: metric.label,
+        data: metricByHour,
+      }],
+    };
+    if (secondaryMetric) {
+      hour = moment().startOf('day').subtract(1, 'hour');
+      const secondaryMetricByHour = secondaryMetric.hourlyMetrics.map((hourlyMetric, index) => {
+        hour.add(1, 'hour');
+        return {
+          x: hour.valueOf(),
+          y: hourlyMetric,
+          totalUpdates: posts[index],
+          color: color[secondaryMetric.label],
+        };
+      });
+      const baseColor = ReactHighcharts.Highcharts.Color(color[secondaryMetric.label]);
+      const fillColor = baseColor ? baseColor.brighten(0.1).get('rgba') : null;
+      config.series.push({
+        ...secondarySeriesConfig,
+        yAxis: (secondaryMetric.label === 'Impressions') ? 1 : 0,
+        marker: {
+          lineColor: color[secondaryMetric.label],
+          fillColor,
+        },
+        color: color[secondaryMetric.label],
+        name: secondaryMetric.label,
+        data: secondaryMetricByHour,
+      });
+    }
 
-  return <ReactHighcharts ref={chartRef} isPureConfig config={config} />;
-};
+    return <ReactHighcharts ref={chartRef} isPureConfig config={config} />;
+  }
+}
 
 HourlyEngagementChart.defaultProps = {
   posts: [],

--- a/packages/shared-components/CommonChart/index.jsx
+++ b/packages/shared-components/CommonChart/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import ReactHighcharts from 'react-highcharts';
 import moment from 'moment';
 
@@ -224,38 +224,42 @@ function prepareChartOptions(
   );
 }
 
-const Chart = ({
-  data,
-  mode,
-  presets,
-  profileService,
-  pngExportId,
-  selectedMetrics,
-  selectedPreset,
-  timezone,
-}) => {
-  const isCustomMode = mode === 1;
-  const charOptions = prepareChartOptions(
-    data,
-    isCustomMode,
-    presets,
-    profileService,
-    selectedMetrics,
-    selectedPreset,
-    timezone,
-  );
-  return (
-    <div id={`js-dom-to-png-${pngExportId}`}>
-      <ReactHighcharts config={charOptions} />
-      <Footer
-        selectedMetrics={selectedMetrics}
-        mode={mode}
-        presets={presets}
-        selectedPreset={selectedPreset}
-      />
-    </div>
-  );
-};
+class Chart extends PureComponent {
+  render() {
+    const {
+      data,
+      mode,
+      presets,
+      profileService,
+      pngExportId,
+      selectedMetrics,
+      selectedPreset,
+      timezone,
+    } = this.props;
+
+    const isCustomMode = mode === 1;
+    const charOptions = prepareChartOptions(
+      data,
+      isCustomMode,
+      presets,
+      profileService,
+      selectedMetrics,
+      selectedPreset,
+      timezone,
+    );
+    return (
+      <div id={`js-dom-to-png-${pngExportId}`}>
+        <ReactHighcharts config={charOptions} />
+        <Footer
+          selectedMetrics={selectedMetrics}
+          mode={mode}
+          presets={presets}
+          selectedPreset={selectedPreset}
+        />
+      </div>
+    );
+  }
+}
 
 Chart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
### Purpose

To prevent charts from re-rendering when performing actions on the package.

### Notes

By definition, the nested structures we have (mainly, the data for the chart itself) never changes for any given combination of the other props. So we can just use `PureComponent`s and use shallow comparisons. If another prop changes (like `selectedMetric`) a re-render will be caused as expected.