### PR TITLE
Task/profile avatars comparison

### DIFF
--- a/packages/add-report/__snapshots__/snapshot.test.js.snap
+++ b/packages/add-report/__snapshots__/snapshot.test.js.snap
@@ -4,11 +4,11 @@ exports[`Snapshots AddReport opened 1`] = `
 <span>
   <div>
     <span
-      className="sc-kgoBCf kXSbXd"
+      className="sc-kpOJdX hSZZjx"
     />
     <span>
       <button
-        className="sc-bdVaJa eTEyQW"
+        className="sc-htpNat jElTWv"
         onClick={[Function]}
       >
         <span
@@ -33,11 +33,11 @@ exports[`Snapshots AddReport unopened 1`] = `
 <span>
   <div>
     <span
-      className="sc-kgoBCf kXSbXd"
+      className="sc-kpOJdX hSZZjx"
     />
     <span>
       <button
-        className="sc-bdVaJa eTEyQW"
+        className="sc-htpNat jElTWv"
         onClick={[Function]}
       >
         <span
@@ -77,10 +77,10 @@ exports[`Snapshots Modal open 1`] = `
       }
     />
     <section
-      className="sc-bwzfXH hsxteo"
+      className="sc-bxivhb fdiPPz"
     >
       <section
-        className="sc-fjdhpX dSYVis"
+        className="sc-cSHVUG cQToET"
       >
         <span
           style={
@@ -95,15 +95,15 @@ exports[`Snapshots Modal open 1`] = `
           Add to a new report
         </span>
         <section
-          className="sc-cSHVUG kztoJN"
+          className="sc-chPdSV fNHSas"
         >
           <input
-            className="sc-kAzzGY bWhoCh"
+            className="sc-kgoBCf ghEiEh"
             placeholder="Please enter title here"
             type="text"
           />
           <button
-            className="sc-bdVaJa eTEyQW"
+            className="sc-htpNat jElTWv"
             onClick={[Function]}
           >
             <span
@@ -135,13 +135,13 @@ exports[`Snapshots Modal open 1`] = `
           </span>
         </div>
         <section
-          className="sc-jzJRlG bUqkSv"
+          className="sc-kAzzGY NDFAc"
         >
           <ol
-            className="sc-jTzLTM jkPlha"
+            className="sc-jzJRlG fDXUjd"
           >
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -175,7 +175,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -188,7 +188,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       Weekly Sync Report
                     </span>
@@ -204,7 +204,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       November 7, 2017
                     </span>
@@ -213,7 +213,7 @@ exports[`Snapshots Modal open 1`] = `
               </button>
             </li>
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -247,7 +247,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -260,7 +260,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       client social media campaign
                     </span>
@@ -276,7 +276,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       October 10, 2017
                     </span>
@@ -285,7 +285,7 @@ exports[`Snapshots Modal open 1`] = `
               </button>
             </li>
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -319,7 +319,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -332,7 +332,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       client social media campaign
                     </span>
@@ -348,7 +348,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       October 10, 2017
                     </span>
@@ -357,7 +357,7 @@ exports[`Snapshots Modal open 1`] = `
               </button>
             </li>
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -391,7 +391,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -404,7 +404,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       client social media campaign
                     </span>
@@ -420,7 +420,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       October 10, 2017
                     </span>
@@ -429,7 +429,7 @@ exports[`Snapshots Modal open 1`] = `
               </button>
             </li>
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -463,7 +463,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -476,7 +476,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       client social media campaign
                     </span>
@@ -492,7 +492,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       October 10, 2017
                     </span>
@@ -501,7 +501,7 @@ exports[`Snapshots Modal open 1`] = `
               </button>
             </li>
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -535,7 +535,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -548,7 +548,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       client social media campaign
                     </span>
@@ -564,7 +564,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       October 10, 2017
                     </span>
@@ -573,7 +573,7 @@ exports[`Snapshots Modal open 1`] = `
               </button>
             </li>
             <li
-              className="sc-VigVT iHSuUu"
+              className="sc-fjdhpX dihBVz"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -607,7 +607,7 @@ exports[`Snapshots Modal open 1`] = `
                 }
               >
                 <span
-                  className="sc-iwsKbI csJBaG"
+                  className="sc-gqjmRU gpCsig"
                 >
                   <span
                     style={
@@ -620,7 +620,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-htoDjs kUnzht"
+                      className="sc-iwsKbI ebSInR"
                     >
                       client social media campaign
                     </span>
@@ -636,7 +636,7 @@ exports[`Snapshots Modal open 1`] = `
                     }
                   >
                     <span
-                      className="sc-dnqmqq eTpfEZ"
+                      className="sc-gZMcBi fVWMTZ"
                     >
                       October 10, 2017
                     </span>

--- a/packages/audience-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/audience-chart/__snapshots__/snapshot.test.js.snap
@@ -54,11 +54,11 @@ exports[`Snapshots AudienceChart [TESTED] Should render 1`] = `
         </h2>
       </header>
       <div
-        className="sc-dnqmqq gOqivX"
+        className="sc-gZMcBi hDWkZz"
       >
         <div>
           <div
-            className="sc-htoDjs juvQWM"
+            className="sc-iwsKbI cslhIm"
           >
             <div
               className="dropdown dropdownContainer"
@@ -568,7 +568,7 @@ exports[`Snapshots AudienceChart [TESTED] should render a "no data" state 1`] = 
         </h2>
       </header>
       <div
-        className="sc-dnqmqq gOqivX"
+        className="sc-gZMcBi hDWkZz"
       >
         <div
           style={
@@ -691,7 +691,7 @@ exports[`Snapshots AudienceChart [TESTED] should render a loading state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-dnqmqq gOqivX"
+        className="sc-gZMcBi hDWkZz"
       >
         <div
           style={

--- a/packages/audience-comparison-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/audience-comparison-chart/__snapshots__/snapshot.test.js.snap
@@ -32,7 +32,7 @@ exports[`Snapshots AudienceComparisonChart should render a "no data" state 1`] =
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -50,7 +50,7 @@ exports[`Snapshots AudienceComparisonChart should render a "no data" state 1`] =
         </h2>
       </header>
       <div
-        className="sc-gZMcBi cCickz"
+        className="sc-VigVT knyrTu"
       >
         <div
           style={
@@ -151,7 +151,7 @@ exports[`Snapshots AudienceComparisonChart should render a loading state 1`] = `
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -169,7 +169,7 @@ exports[`Snapshots AudienceComparisonChart should render a loading state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-iwsKbI MLANU"
+        className="sc-gqjmRU fgNPjU"
       >
         <div
           style={
@@ -307,7 +307,7 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -325,21 +325,21 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
         </h2>
       </header>
       <div
-        className="sc-dnqmqq jhnxZF"
+        className="sc-gZMcBi cCickz"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -347,117 +347,45 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -465,9 +393,9 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -477,41 +405,167 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -520,7 +574,7 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -528,117 +582,45 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      700
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -646,9 +628,9 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
                     height="100%"
                     style={
                       Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -658,42 +640,168 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="torchRed"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Joel Gascoigne
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#FF1E1E",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        10
+                        700
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          10
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -737,7 +845,7 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -755,21 +863,21 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
         </h2>
       </header>
       <div
-        className="sc-htoDjs rfxNx"
+        className="sc-iwsKbI MLANU"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -777,117 +885,45 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -895,9 +931,9 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -907,41 +943,167 @@ exports[`Snapshots AudienceComparisonChart should render the audience comparison
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/audience-comparison-chart/components/AudienceComparisonChart/index.jsx
+++ b/packages/audience-comparison-chart/components/AudienceComparisonChart/index.jsx
@@ -7,12 +7,14 @@ const CHART_NAME = 'Audience';
 const AudienceComparisonChart = ({
   profilesMetricData,
   profileTotals,
+  profiles,
   loading,
 }) =>
   (
     <ComparisonChartWrapper
       profilesMetricData={profilesMetricData}
       profileTotals={profileTotals}
+      profiles={profiles}
       loading={loading}
       chartName={CHART_NAME}
     />
@@ -49,6 +51,12 @@ AudienceComparisonChart.propTypes = {
     profileId: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     service: PropTypes.string,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
   })).isRequired,
 };
 

--- a/packages/audience-comparison-chart/components/AudienceComparisonChart/story.jsx
+++ b/packages/audience-comparison-chart/components/AudienceComparisonChart/story.jsx
@@ -4,12 +4,13 @@ import { checkA11y } from 'storybook-addon-a11y';
 
 import AudienceComparisonChart from './index';
 import mockDailyData from '../../mocks/dailyData';
+import profiles from '../../mocks/profiles';
 
 const profileTotals = [
   {
     currentPeriodTotal: 400,
     currentPeriodDiff: 20,
-    profileId: '1234abcd',
+    profileId: '1',
     username: 'Buffer',
     service: 'facebook',
     metric: {
@@ -20,7 +21,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: '5678abcd',
+    profileId: '2',
     username: 'buffer',
     service: 'twitter',
     metric: {
@@ -41,6 +42,7 @@ storiesOf('AudienceComparisonChart')
       <AudienceComparisonChart
         profilesMetricData={[mockDailyData[0]]}
         profileTotals={[profileTotals[0]]}
+        profiles={profiles}
       />
     </div>
   ))
@@ -53,6 +55,7 @@ storiesOf('AudienceComparisonChart')
       <AudienceComparisonChart
         profilesMetricData={mockDailyData}
         profileTotals={profileTotals}
+        profiles={profiles}
       />
     </div>
   ))
@@ -65,6 +68,7 @@ storiesOf('AudienceComparisonChart')
       <AudienceComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
         loading
       />
     </div>
@@ -78,6 +82,7 @@ storiesOf('AudienceComparisonChart')
       <AudienceComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
       />
     </div>
   ));

--- a/packages/audience-comparison-chart/index.js
+++ b/packages/audience-comparison-chart/index.js
@@ -5,6 +5,7 @@ function mapStateToProps (state) {
   return {
     profilesMetricData: state.audienceComparison.profilesMetricData,
     profileTotals: state.audienceComparison.profileTotals,
+    profiles: state.profiles.profiles,
     loading: state.audienceComparison.loading,
   };
 }

--- a/packages/average-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/average-table/__snapshots__/snapshot.test.js.snap
@@ -371,7 +371,7 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -379,56 +379,48 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Impression average
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Impression average
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -436,79 +428,89 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      150
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        25
+                        150
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          25
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -517,7 +519,7 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -525,56 +527,48 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Click average
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Click average
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -582,80 +576,90 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -664,7 +668,7 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -672,56 +676,48 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Engagement average
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Engagement average
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -729,80 +725,90 @@ exports[`Snapshots AverageTable should render the average table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      901
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        39
+                        901
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          39
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/comments-comparison-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/comments-comparison-chart/__snapshots__/snapshot.test.js.snap
@@ -32,7 +32,7 @@ exports[`Snapshots CommentsComparisonChart should render a "no data" state 1`] =
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -50,7 +50,7 @@ exports[`Snapshots CommentsComparisonChart should render a "no data" state 1`] =
         </h2>
       </header>
       <div
-        className="sc-gZMcBi cCickz"
+        className="sc-VigVT knyrTu"
       >
         <div
           style={
@@ -151,7 +151,7 @@ exports[`Snapshots CommentsComparisonChart should render a loading state 1`] = `
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -169,7 +169,7 @@ exports[`Snapshots CommentsComparisonChart should render a loading state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-iwsKbI MLANU"
+        className="sc-gqjmRU fgNPjU"
       >
         <div
           style={
@@ -307,7 +307,7 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -325,21 +325,21 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
         </h2>
       </header>
       <div
-        className="sc-dnqmqq jhnxZF"
+        className="sc-gZMcBi cCickz"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -347,91 +347,135 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
+                  className="sc-bdVaJa bjwIvU"
+                >
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
+                    style={
+                      Object {
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
+                      }
+                    }
+                  />
+                </span>
+                <div
                   style={
                     Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="twitter"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
                   >
                     <div
-                      className="sc-bZQynM fqsBLH"
+                      className="sc-htoDjs jxuJsQ"
                     >
                       <span
                         style={
                           Object {
                             "color": "#59626a",
                             "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
                           }
                         }
                       >
                         Buffer
                       </span>
                     </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -439,79 +483,89 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      400
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -520,7 +574,7 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -528,117 +582,45 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      700
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -646,9 +628,9 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     height="100%"
                     style={
                       Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -658,42 +640,168 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="torchRed"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Joel Gascoigne
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#FF1E1E",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        10
+                        700
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          10
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -702,7 +810,7 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -710,117 +818,45 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        TestInstagram
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      2,000
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -828,9 +864,9 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#3b5998",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -840,41 +876,167 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="facebook"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        80
+                        2,000
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          80
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -918,7 +1080,7 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -936,21 +1098,21 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
         </h2>
       </header>
       <div
-        className="sc-htoDjs rfxNx"
+        className="sc-iwsKbI MLANU"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -958,117 +1120,45 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -1076,9 +1166,9 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -1088,41 +1178,167 @@ exports[`Snapshots CommentsComparisonChart should render the comments comparison
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/comments-comparison-chart/components/CommentsComparisonChart/index.jsx
+++ b/packages/comments-comparison-chart/components/CommentsComparisonChart/index.jsx
@@ -1,17 +1,19 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { ComparisonChartWrapper } from "@bufferapp/analyze-shared-components";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ComparisonChartWrapper } from '@bufferapp/analyze-shared-components';
 
-const CHART_NAME = "Comments";
+const CHART_NAME = 'Comments';
 
 const CommentsComparisonChart = ({
   profilesMetricData,
   profileTotals,
-  loading
+  profiles,
+  loading,
 }) => (
   <ComparisonChartWrapper
     profilesMetricData={profilesMetricData}
     profileTotals={profileTotals}
+    profiles={profiles}
     loading={loading}
     chartName={CHART_NAME}
   />
@@ -19,7 +21,7 @@ const CommentsComparisonChart = ({
 
 CommentsComparisonChart.defaultProps = {
   loading: false,
-  selectedProfiles: []
+  selectedProfiles: [],
 };
 
 CommentsComparisonChart.propTypes = {
@@ -33,28 +35,34 @@ CommentsComparisonChart.propTypes = {
           metric: PropTypes.shape({
             color: PropTypes.string.isRequired,
             label: PropTypes.string.isRequired,
-            value: PropTypes.number.isRequired
-          })
-        })
+            value: PropTypes.number.isRequired,
+          }),
+        }),
       ),
       service: PropTypes.string.isRequired,
-      timezone: PropTypes.string.isRequired
-    })
+      timezone: PropTypes.string.isRequired,
+    }),
   ).isRequired,
   // props  for generating the right footer
   profileTotals: PropTypes.arrayOf(
     PropTypes.shape({
       metric: PropTypes.shape({
         label: PropTypes.string.isRequired,
-        color: PropTypes.string.isRequired
+        color: PropTypes.string.isRequired,
       }),
       currentPeriodTotal: PropTypes.number.isRequired,
       currentPeriodDiff: PropTypes.number.isRequired,
       profileId: PropTypes.string.isRequired,
       username: PropTypes.string.isRequired,
-      service: PropTypes.string
-    })
-  ).isRequired
+      service: PropTypes.string,
+    }),
+  ).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
+  })).isRequired,
 };
 
 export default CommentsComparisonChart;

--- a/packages/comments-comparison-chart/components/CommentsComparisonChart/story.jsx
+++ b/packages/comments-comparison-chart/components/CommentsComparisonChart/story.jsx
@@ -4,12 +4,15 @@ import { checkA11y } from "storybook-addon-a11y";
 
 import CommentsComparisonChart from "./index";
 import mockDailyData from "../../mocks/dailyData";
+import profiles from "../../mocks/profiles";
+
+console.log(profiles)
 
 const profileTotals = [
   {
     currentPeriodTotal: 400,
     currentPeriodDiff: 20,
-    profileId: "1234abcd",
+    profileId: "1",
     username: "Buffer",
     service: "facebook",
     metric: {
@@ -20,7 +23,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: "5678abcd",
+    profileId: "2",
     username: "buffer",
     service: "twitter",
     metric: {
@@ -31,7 +34,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 2000,
     currentPeriodDiff: 80,
-    profileId: "5678abcd",
+    profileId: "3",
     username: "TestInstagram",
     service: "instagram",
     metric: {
@@ -52,6 +55,7 @@ storiesOf("CommentsComparisonChart")
       <CommentsComparisonChart
         profilesMetricData={[mockDailyData[0]]}
         profileTotals={[profileTotals[0]]}
+        profiles={profiles}
       />
     </div>
   ))
@@ -66,6 +70,7 @@ storiesOf("CommentsComparisonChart")
         <CommentsComparisonChart
           profilesMetricData={mockDailyData}
           profileTotals={profileTotals}
+          profiles={profiles}
         />
       </div>
     )
@@ -79,6 +84,7 @@ storiesOf("CommentsComparisonChart")
       <CommentsComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
         loading
       />
     </div>
@@ -89,6 +95,6 @@ storiesOf("CommentsComparisonChart")
         width: "750px"
       }}
     >
-      <CommentsComparisonChart profilesMetricData={[]} profileTotals={[]} />
+      <CommentsComparisonChart profilesMetricData={[]} profileTotals={[]} profiles={profiles} />
     </div>
   ));

--- a/packages/comments-comparison-chart/index.js
+++ b/packages/comments-comparison-chart/index.js
@@ -5,6 +5,7 @@ function mapStateToProps (state) {
   return {
     profilesMetricData: state.commentsComparison.profilesMetricData,
     profileTotals: state.commentsComparison.profileTotals,
+    profiles: state.profiles.profiles,
     loading: state.commentsComparison.loading,
   };
 }

--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -1746,7 +1746,7 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1754,81 +1754,73 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Click
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      selected
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#fda3f3",
+                            "borderColor": "#df85d5",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Click
+                       over 
+                      <span>
+                        the 
+                        selected
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1836,80 +1828,90 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1918,7 +1920,7 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1926,81 +1928,73 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#9B9FA3",
-                          "borderColor": "#7d8185",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Click
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      previous
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#9B9FA3",
+                            "borderColor": "#7d8185",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Click
+                       over 
+                      <span>
+                        the 
+                        previous
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -2008,17 +2002,27 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        100
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </li>
@@ -2594,7 +2598,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -2602,81 +2606,73 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Posts
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      selected
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#fda3f3",
+                            "borderColor": "#df85d5",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Posts
+                       over 
+                      <span>
+                        the 
+                        selected
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -2684,80 +2680,90 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        39
+                        100
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          39
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -2766,7 +2772,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -2774,81 +2780,73 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#9B9FA3",
-                          "borderColor": "#7d8185",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Posts
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      previous
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#9B9FA3",
+                            "borderColor": "#7d8185",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Posts
+                       over 
+                      <span>
+                        the 
+                        previous
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -2856,17 +2854,27 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        100
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </li>
@@ -3442,7 +3450,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -3450,81 +3458,73 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Posts
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      selected
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#fda3f3",
+                            "borderColor": "#df85d5",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Posts
+                       over 
+                      <span>
+                        the 
+                        selected
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -3532,80 +3532,90 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        39
+                        100
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          39
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -3614,7 +3624,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -3622,81 +3632,73 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#9B9FA3",
-                          "borderColor": "#7d8185",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Posts
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      previous
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#9B9FA3",
+                            "borderColor": "#7d8185",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Posts
+                       over 
+                      <span>
+                        the 
+                        previous
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -3704,17 +3706,27 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        100
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </li>
@@ -4366,7 +4378,7 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -4374,81 +4386,73 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Click
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      selected
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#fda3f3",
+                            "borderColor": "#df85d5",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Click
+                       over 
+                      <span>
+                        the 
+                        selected
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -4456,80 +4460,90 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -4538,7 +4552,7 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -4546,81 +4560,73 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#9B9FA3",
-                          "borderColor": "#7d8185",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Click
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      previous
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#9B9FA3",
+                            "borderColor": "#7d8185",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Click
+                       over 
+                      <span>
+                        the 
+                        previous
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -4628,17 +4634,27 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        100
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </li>
@@ -5214,7 +5230,7 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -5222,81 +5238,73 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Click
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      selected
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#fda3f3",
+                            "borderColor": "#df85d5",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Click
+                       over 
+                      <span>
+                        the 
+                        selected
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -5304,80 +5312,90 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -5386,7 +5404,7 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -5394,81 +5412,73 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "background": "#9B9FA3",
-                          "borderColor": "#7d8185",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
                       }
-                    />
-                    Click
-                     over 
+                    }
+                  >
                     <span>
-                      the 
-                      previous
-                       
-                      7 days
+                      <span
+                        style={
+                          Object {
+                            "background": "#9B9FA3",
+                            "borderColor": "#7d8185",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      Click
+                       over 
+                      <span>
+                        the 
+                        previous
+                         
+                        7 days
+                      </span>
                     </span>
                   </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -5476,17 +5486,27 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      100
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        100
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </li>
@@ -5528,7 +5548,7 @@ exports[`Snapshots Footer should render the table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -5536,81 +5556,73 @@ exports[`Snapshots Footer should render the table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                <span>
-                  <span
-                    style={
-                      Object {
-                        "background": "#fda3f3",
-                        "borderColor": "#df85d5",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
                     }
-                  />
-                  Impression
-                   over 
+                  }
+                >
                   <span>
-                    the 
-                    selected
-                     
-                    7 days
+                    <span
+                      style={
+                        Object {
+                          "background": "#fda3f3",
+                          "borderColor": "#df85d5",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    Impression
+                     over 
+                    <span>
+                      the 
+                      selected
+                       
+                      7 days
+                    </span>
                   </span>
                 </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -5618,79 +5630,89 @@ exports[`Snapshots Footer should render the table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    150
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#2fd566",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shamrock"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#2FD566",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "shamrock",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      25
+                      150
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#2fd566",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shamrock"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#2FD566",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "shamrock",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -5699,7 +5721,7 @@ exports[`Snapshots Footer should render the table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -5707,81 +5729,73 @@ exports[`Snapshots Footer should render the table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                <span>
-                  <span
-                    style={
-                      Object {
-                        "background": "#9B9FA3",
-                        "borderColor": "#7d8185",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
                     }
-                  />
-                  Impression
-                   over 
+                  }
+                >
                   <span>
-                    the 
-                    previous
-                     
-                    7 days
+                    <span
+                      style={
+                        Object {
+                          "background": "#9B9FA3",
+                          "borderColor": "#7d8185",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    Impression
+                     over 
+                    <span>
+                      the 
+                      previous
+                       
+                      7 days
+                    </span>
                   </span>
                 </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -5789,17 +5803,27 @@ exports[`Snapshots Footer should render the table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    100
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      100
+                    </span>
                   </span>
                 </span>
-              </span>
+              </div>
             </div>
           </div>
         </li>

--- a/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
+++ b/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
@@ -54,12 +54,12 @@ exports[`Snapshots ContextualCompare [TESTED] Should render Posts metrics as col
         </h2>
       </header>
       <div
-        className="sc-iwsKbI ddWkic"
+        className="sc-gqjmRU kIuJuB"
       >
         <div>
           <div>
             <div
-              className="sc-dnqmqq iFsitv"
+              className="sc-gZMcBi koPbPx"
             >
               <div
                 className="dropdown dropdownContainer"
@@ -794,12 +794,12 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Custom mode 1`] =
         </h2>
       </header>
       <div
-        className="sc-iwsKbI ddWkic"
+        className="sc-gqjmRU kIuJuB"
       >
         <div>
           <div>
             <div
-              className="sc-dnqmqq iFsitv"
+              className="sc-gZMcBi koPbPx"
             >
               <div
                 className="dropdown dropdownContainer"
@@ -1534,12 +1534,12 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
         </h2>
       </header>
       <div
-        className="sc-iwsKbI ddWkic"
+        className="sc-gqjmRU kIuJuB"
       >
         <div>
           <div>
             <div
-              className="sc-dnqmqq iFsitv"
+              className="sc-gZMcBi koPbPx"
             >
               <div
                 style={
@@ -1689,7 +1689,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                  
                               </span>
                               <span
-                                className="sc-htoDjs djCszi"
+                                className="sc-iwsKbI gcczDF"
                                 data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
                               >
                                 ?
@@ -1770,7 +1770,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                   (no data) 
                               </span>
                               <span
-                                className="sc-htoDjs djCszi"
+                                className="sc-iwsKbI gcczDF"
                                 data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
                               >
                                 ?
@@ -1839,7 +1839,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                  
                               </span>
                               <span
-                                className="sc-htoDjs djCszi"
+                                className="sc-iwsKbI gcczDF"
                                 data-description="Discover how your posting frequency affects your fan count."
                               >
                                 ?
@@ -2081,12 +2081,12 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
         </h2>
       </header>
       <div
-        className="sc-iwsKbI ddWkic"
+        className="sc-gqjmRU kIuJuB"
       >
         <div>
           <div>
             <div
-              className="sc-dnqmqq iFsitv"
+              className="sc-gZMcBi koPbPx"
             >
               <div
                 style={
@@ -2236,7 +2236,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                  
                               </span>
                               <span
-                                className="sc-htoDjs djCszi"
+                                className="sc-iwsKbI gcczDF"
                                 data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
                               >
                                 ?
@@ -2317,7 +2317,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                   (no data) 
                               </span>
                               <span
-                                className="sc-htoDjs djCszi"
+                                className="sc-iwsKbI gcczDF"
                                 data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
                               >
                                 ?
@@ -2386,7 +2386,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                  
                               </span>
                               <span
-                                className="sc-htoDjs djCszi"
+                                className="sc-iwsKbI gcczDF"
                                 data-description="Discover how your posting frequency affects your fan count."
                               >
                                 ?
@@ -2664,7 +2664,7 @@ exports[`Snapshots ContextualCompare [TESTED] should render a "no data" state 1`
         </h2>
       </header>
       <div
-        className="sc-iwsKbI ddWkic"
+        className="sc-gqjmRU kIuJuB"
       >
         <div
           style={
@@ -2787,7 +2787,7 @@ exports[`Snapshots ContextualCompare [TESTED] should render a loading state 1`] 
         </h2>
       </header>
       <div
-        className="sc-iwsKbI ddWkic"
+        className="sc-gqjmRU kIuJuB"
       >
         <div
           style={
@@ -3043,7 +3043,7 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                      
                   </span>
                   <span
-                    className="sc-htoDjs djCszi"
+                    className="sc-iwsKbI gcczDF"
                     data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
                   >
                     ?
@@ -3124,7 +3124,7 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                       (no data) 
                   </span>
                   <span
-                    className="sc-htoDjs djCszi"
+                    className="sc-iwsKbI gcczDF"
                     data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
                   >
                     ?
@@ -3193,7 +3193,7 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                      
                   </span>
                   <span
-                    className="sc-htoDjs djCszi"
+                    className="sc-iwsKbI gcczDF"
                     data-description="Discover how your posting frequency affects your fan count."
                   >
                     ?

--- a/packages/engagement-comparison-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/engagement-comparison-chart/__snapshots__/snapshot.test.js.snap
@@ -32,7 +32,7 @@ exports[`Snapshots EngagementComparisonChart should render a "no data" state 1`]
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -50,7 +50,7 @@ exports[`Snapshots EngagementComparisonChart should render a "no data" state 1`]
         </h2>
       </header>
       <div
-        className="sc-gZMcBi cCickz"
+        className="sc-VigVT knyrTu"
       >
         <div
           style={
@@ -151,7 +151,7 @@ exports[`Snapshots EngagementComparisonChart should render a loading state 1`] =
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -169,7 +169,7 @@ exports[`Snapshots EngagementComparisonChart should render a loading state 1`] =
         </h2>
       </header>
       <div
-        className="sc-iwsKbI MLANU"
+        className="sc-gqjmRU fgNPjU"
       >
         <div
           style={
@@ -307,7 +307,7 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -325,21 +325,21 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
         </h2>
       </header>
       <div
-        className="sc-dnqmqq jhnxZF"
+        className="sc-gZMcBi cCickz"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -347,117 +347,45 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -465,9 +393,9 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -477,41 +405,167 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -520,7 +574,7 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -528,117 +582,45 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      700
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -646,9 +628,9 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
                     height="100%"
                     style={
                       Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -658,42 +640,168 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="torchRed"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Joel Gascoigne
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#FF1E1E",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        10
+                        700
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          10
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -737,7 +845,7 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -755,21 +863,21 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
         </h2>
       </header>
       <div
-        className="sc-htoDjs rfxNx"
+        className="sc-iwsKbI MLANU"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -777,117 +885,45 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -895,9 +931,9 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -907,41 +943,167 @@ exports[`Snapshots EngagementComparisonChart should render the engagement compar
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/engagement-comparison-chart/components/EngagementComparisonChart/index.jsx
+++ b/packages/engagement-comparison-chart/components/EngagementComparisonChart/index.jsx
@@ -7,12 +7,14 @@ const CHART_NAME = 'Engagement';
 const EngagementComparisonChart = ({
   profilesMetricData,
   profileTotals,
+  profiles,
   loading,
 }) =>
   (
     <ComparisonChartWrapper
       profilesMetricData={profilesMetricData}
       profileTotals={profileTotals}
+      profiles={profiles}
       loading={loading}
       chartName={CHART_NAME}
     />
@@ -49,6 +51,12 @@ EngagementComparisonChart.propTypes = {
     profileId: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     service: PropTypes.string,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
   })).isRequired,
 };
 

--- a/packages/engagement-comparison-chart/components/EngagementComparisonChart/story.jsx
+++ b/packages/engagement-comparison-chart/components/EngagementComparisonChart/story.jsx
@@ -4,12 +4,13 @@ import { checkA11y } from 'storybook-addon-a11y';
 
 import EngagementComparisonChart from './index';
 import mockDailyData from '../../mocks/dailyData';
+import profiles from '../../mocks/profiles';
 
 const profileTotals = [
   {
     currentPeriodTotal: 400,
     currentPeriodDiff: 20,
-    profileId: '1234abcd',
+    profileId: '1',
     username: 'Buffer',
     service: 'facebook',
     metric: {
@@ -20,7 +21,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: '5678abcd',
+    profileId: '2',
     username: 'buffer',
     service: 'twitter',
     metric: {
@@ -41,6 +42,7 @@ storiesOf('EngagementComparisonChart')
       <EngagementComparisonChart
         profilesMetricData={[mockDailyData[0]]}
         profileTotals={[profileTotals[0]]}
+        profiles={profiles}
       />
     </div>
   ))
@@ -53,6 +55,7 @@ storiesOf('EngagementComparisonChart')
       <EngagementComparisonChart
         profilesMetricData={mockDailyData}
         profileTotals={profileTotals}
+        profiles={profiles}
       />
     </div>
   ))
@@ -65,6 +68,7 @@ storiesOf('EngagementComparisonChart')
       <EngagementComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
         loading
       />
     </div>
@@ -78,6 +82,7 @@ storiesOf('EngagementComparisonChart')
       <EngagementComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
       />
     </div>
   ));

--- a/packages/engagement-comparison-chart/index.js
+++ b/packages/engagement-comparison-chart/index.js
@@ -5,6 +5,7 @@ function mapStateToProps (state) {
   return {
     profilesMetricData: state.engagementComparison.profilesMetricData,
     profileTotals: state.engagementComparison.profileTotals,
+    profiles: state.profiles.profiles,
     loading: state.engagementComparison.loading,
   };
 }

--- a/packages/likes-comparison-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/likes-comparison-chart/__snapshots__/snapshot.test.js.snap
@@ -32,7 +32,7 @@ exports[`Snapshots LikesComparisonChart should render a "no data" state 1`] = `
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -50,7 +50,7 @@ exports[`Snapshots LikesComparisonChart should render a "no data" state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-gZMcBi cCickz"
+        className="sc-VigVT knyrTu"
       >
         <div
           style={
@@ -151,7 +151,7 @@ exports[`Snapshots LikesComparisonChart should render a loading state 1`] = `
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -169,7 +169,7 @@ exports[`Snapshots LikesComparisonChart should render a loading state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-iwsKbI MLANU"
+        className="sc-gqjmRU fgNPjU"
       >
         <div
           style={
@@ -307,7 +307,7 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -325,21 +325,21 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
         </h2>
       </header>
       <div
-        className="sc-dnqmqq jhnxZF"
+        className="sc-gZMcBi cCickz"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -347,91 +347,135 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
+                  className="sc-bdVaJa bjwIvU"
+                >
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
+                    style={
+                      Object {
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
+                      }
+                    }
+                  />
+                </span>
+                <div
                   style={
                     Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="twitter"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
                   >
                     <div
-                      className="sc-bZQynM fqsBLH"
+                      className="sc-htoDjs jxuJsQ"
                     >
                       <span
                         style={
                           Object {
                             "color": "#59626a",
                             "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
                           }
                         }
                       >
                         Buffer
                       </span>
                     </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -439,79 +483,89 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      400
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -520,7 +574,7 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -528,117 +582,45 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      700
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -646,9 +628,9 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     height="100%"
                     style={
                       Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -658,42 +640,168 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="torchRed"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Joel Gascoigne
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#FF1E1E",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        10
+                        700
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          10
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -702,7 +810,7 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -710,117 +818,45 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        TestInstagram
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      2,000
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -828,9 +864,9 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#3b5998",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -840,41 +876,167 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="facebook"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        80
+                        2,000
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          80
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -918,7 +1080,7 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -936,21 +1098,21 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
         </h2>
       </header>
       <div
-        className="sc-htoDjs rfxNx"
+        className="sc-iwsKbI MLANU"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -958,117 +1120,45 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -1076,9 +1166,9 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -1088,41 +1178,167 @@ exports[`Snapshots LikesComparisonChart should render the likes comparison chart
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/likes-comparison-chart/components/LikesComparisonChart/index.jsx
+++ b/packages/likes-comparison-chart/components/LikesComparisonChart/index.jsx
@@ -7,12 +7,14 @@ const CHART_NAME = 'Likes';
 const LikesComparisonChart = ({
   profilesMetricData,
   profileTotals,
+  profiles,
   loading,
 }) =>
   (
     <ComparisonChartWrapper
       profilesMetricData={profilesMetricData}
       profileTotals={profileTotals}
+      profiles={profiles}
       loading={loading}
       chartName={CHART_NAME}
     />
@@ -49,6 +51,12 @@ LikesComparisonChart.propTypes = {
     profileId: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     service: PropTypes.string,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
   })).isRequired,
 };
 

--- a/packages/likes-comparison-chart/components/LikesComparisonChart/story.jsx
+++ b/packages/likes-comparison-chart/components/LikesComparisonChart/story.jsx
@@ -4,12 +4,13 @@ import { checkA11y } from 'storybook-addon-a11y';
 
 import LikesComparisonChart from './index';
 import mockDailyData from '../../mocks/dailyData';
+import profiles from '../../mocks/profiles';
 
 const profileTotals = [
   {
     currentPeriodTotal: 400,
     currentPeriodDiff: 20,
-    profileId: '1234abcd',
+    profileId: '1',
     username: 'Buffer',
     service: 'facebook',
     metric: {
@@ -20,7 +21,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: '5678abcd',
+    profileId: '2',
     username: 'buffer',
     service: 'twitter',
     metric: {
@@ -31,7 +32,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 2000,
     currentPeriodDiff: 80,
-    profileId: '5678abcd',
+    profileId: '3',
     username: 'TestInstagram',
     service: 'instagram',
     metric: {
@@ -52,6 +53,7 @@ storiesOf('LikesComparisonChart')
       <LikesComparisonChart
         profilesMetricData={[mockDailyData[0]]}
         profileTotals={[profileTotals[0]]}
+        profiles={profiles}
       />
     </div>
   ))
@@ -64,6 +66,7 @@ storiesOf('LikesComparisonChart')
       <LikesComparisonChart
         profilesMetricData={mockDailyData}
         profileTotals={profileTotals}
+        profiles={profiles}
       />
     </div>
   ))
@@ -76,6 +79,7 @@ storiesOf('LikesComparisonChart')
       <LikesComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
         loading
       />
     </div>
@@ -89,6 +93,7 @@ storiesOf('LikesComparisonChart')
       <LikesComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
       />
     </div>
   ));

--- a/packages/likes-comparison-chart/index.js
+++ b/packages/likes-comparison-chart/index.js
@@ -5,6 +5,7 @@ function mapStateToProps (state) {
   return {
     profilesMetricData: state.likesComparison.profilesMetricData,
     profileTotals: state.likesComparison.profileTotals,
+    profiles: state.profiles.profiles,
     loading: state.likesComparison.loading,
   };
 }

--- a/packages/multi-profile-selector/__snapshots__/snapshot.test.js.snap
+++ b/packages/multi-profile-selector/__snapshots__/snapshot.test.js.snap
@@ -71,6 +71,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -143,6 +144,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -215,6 +217,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -287,6 +290,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -374,6 +378,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -446,6 +451,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -644,6 +650,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -807,6 +814,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -970,6 +978,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1133,6 +1142,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1296,6 +1306,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1474,6 +1485,7 @@ exports[`Snapshots MultiProfileSelector Compare Profiles Button should be disabl
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1822,6 +1834,7 @@ exports[`Snapshots MultiProfileSelector should filter by profilesFilterString 1`
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2003,6 +2016,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -2075,6 +2089,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -2258,6 +2273,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2421,6 +2437,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2552,6 +2569,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2715,6 +2733,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2846,6 +2865,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2992,6 +3012,7 @@ exports[`Snapshots MultiProfileSelector should open the profile selector 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3307,6 +3328,7 @@ exports[`Snapshots MultiProfileSelector should render the initial empty state of
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3438,6 +3460,7 @@ exports[`Snapshots MultiProfileSelector should render the initial empty state of
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3569,6 +3592,7 @@ exports[`Snapshots MultiProfileSelector should render the initial empty state of
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3700,6 +3724,7 @@ exports[`Snapshots MultiProfileSelector should render the initial empty state of
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3831,6 +3856,7 @@ exports[`Snapshots MultiProfileSelector should render the initial empty state of
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3977,6 +4003,7 @@ exports[`Snapshots MultiProfileSelector should render the initial empty state of
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -4161,6 +4188,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -4233,6 +4261,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -4305,6 +4334,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -4377,6 +4407,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -4464,6 +4495,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -4536,6 +4568,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "11px",
                 "left": "11px",
@@ -4734,6 +4767,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -4897,6 +4931,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -5060,6 +5095,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -5223,6 +5259,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -5386,6 +5423,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -5564,6 +5602,7 @@ exports[`Snapshots MultiProfileSelector should render the selected profiles in t
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -5912,6 +5951,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6043,6 +6083,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6174,6 +6215,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6305,6 +6347,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6436,6 +6479,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6582,6 +6626,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6728,6 +6773,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6859,6 +6905,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -6990,6 +7037,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -7121,6 +7169,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -7252,6 +7301,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -7383,6 +7433,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -7514,6 +7565,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -7645,6 +7697,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -7776,6 +7829,7 @@ exports[`Snapshots MultiProfileSelector should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",

--- a/packages/pdf-export/__snapshots__/snapshot.test.js.snap
+++ b/packages/pdf-export/__snapshots__/snapshot.test.js.snap
@@ -3,10 +3,10 @@
 exports[`Snapshots PDFExportButton a story 1`] = `
 <span>
   <span
-    className="sc-htoDjs cqFtEe"
+    className="sc-iwsKbI eoVlhz"
   >
     <button
-      className="sc-bdVaJa eTEyQW"
+      className="sc-htpNat jElTWv"
       onClick={[Function]}
     >
       <span

--- a/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
@@ -374,7 +374,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -382,56 +382,48 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Posts
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Posts
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -439,79 +431,89 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      20
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        5
+                        20
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          5
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -520,7 +522,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -528,56 +530,48 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Post Impressions
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Post Impressions
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -585,80 +579,90 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      901
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        39
+                        901
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          39
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -667,7 +671,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -675,56 +679,48 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Post Reach
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Post Reach
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -732,79 +728,89 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -813,7 +819,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -821,56 +827,48 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Reactions
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Reactions
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -878,80 +876,90 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      568
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        26
+                        568
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          26
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -960,7 +968,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -968,56 +976,48 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Comments
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Comments
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1025,227 +1025,239 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#59626a",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shuttleGray"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#8D969E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "#8D969E",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
-                        }
-                      }
-                    >
-                      <span>
-                        0
-                      </span>
-                      %
-                    </span>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            style={
-              Object {
-                "boxSizing": "border-box",
-                "display": "inline-block",
-                "flexGrow": 1,
-                "listStyle": "none",
-                "paddingBottom": "15px",
-                "width": "33.33%",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
-              <span
-                data-tip={null}
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
-                >
-                  Shares
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    <span>
-                      12
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
-                    <span
-                      style={
-                        Object {
-                          "color": "torchRed",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
                         1
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#59626a",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shuttleGray"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#8D969E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#8D969E",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            style={
+              Object {
+                "boxSizing": "border-box",
+                "display": "flex",
+                "flexGrow": 1,
+                "listStyle": "none",
+                "paddingBottom": "15px",
+                "width": "33.33%",
+              }
+            }
+          >
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Shares
+                  </span>
+                </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "inline-block",
+                    }
+                  }
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        12
+                      </span>
+                    </span>
+                  </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          1
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/profile-header/__snapshots__/snapshot.test.js.snap
+++ b/packages/profile-header/__snapshots__/snapshot.test.js.snap
@@ -43,6 +43,7 @@ exports[`Snapshots ProfileHeader should render facebook fans 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "16px",
                 "left": "16px",
@@ -196,6 +197,7 @@ exports[`Snapshots ProfileHeader should render twitter followers 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "16px",
                 "left": "16px",

--- a/packages/profile-selector/__snapshots__/snapshot.test.js.snap
+++ b/packages/profile-selector/__snapshots__/snapshot.test.js.snap
@@ -77,6 +77,7 @@ exports[`Snapshots ProfileSelectorDropdown should filter by profilesFilterString
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "13px",
                 "left": "9px",
@@ -297,6 +298,7 @@ exports[`Snapshots ProfileSelectorDropdown should filter by profilesFilterString
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -446,6 +448,7 @@ exports[`Snapshots ProfileSelectorDropdown should open the dropdown 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "13px",
                 "left": "9px",
@@ -666,6 +669,7 @@ exports[`Snapshots ProfileSelectorDropdown should open the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -829,6 +833,7 @@ exports[`Snapshots ProfileSelectorDropdown should open the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -960,6 +965,7 @@ exports[`Snapshots ProfileSelectorDropdown should open the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1091,6 +1097,7 @@ exports[`Snapshots ProfileSelectorDropdown should open the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1243,6 +1250,7 @@ exports[`Snapshots ProfileSelectorDropdown should render the dropdown 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "13px",
                 "left": "9px",
@@ -1463,6 +1471,7 @@ exports[`Snapshots ProfileSelectorDropdown should render the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1626,6 +1635,7 @@ exports[`Snapshots ProfileSelectorDropdown should render the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1757,6 +1767,7 @@ exports[`Snapshots ProfileSelectorDropdown should render the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -1888,6 +1899,7 @@ exports[`Snapshots ProfileSelectorDropdown should render the dropdown 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2040,6 +2052,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "13px",
                 "left": "9px",
@@ -2262,6 +2275,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2425,6 +2439,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2556,6 +2571,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2687,6 +2703,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2833,6 +2850,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -2964,6 +2982,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3095,6 +3114,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3226,6 +3246,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3357,6 +3378,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3488,6 +3510,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3619,6 +3642,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3750,6 +3774,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -3881,6 +3906,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -4012,6 +4038,7 @@ exports[`Snapshots ProfileSelectorDropdown should scroll profiles if > 7 1`] = `
                     style={
                       Object {
                         "background": "#fff",
+                        "border": "#fff 0 solid",
                         "borderRadius": "50%",
                         "height": "11px",
                         "left": "13px",
@@ -4149,6 +4176,7 @@ exports[`Snapshots ProfileSelectorDropdown should show no match message 1`] = `
             style={
               Object {
                 "background": "#fff",
+                "border": "#fff 0 solid",
                 "borderRadius": "50%",
                 "height": "13px",
                 "left": "9px",

--- a/packages/reach-comparison-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/reach-comparison-chart/__snapshots__/snapshot.test.js.snap
@@ -32,7 +32,7 @@ exports[`Snapshots ReachComparisonChart should render a "no data" state 1`] = `
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -50,7 +50,7 @@ exports[`Snapshots ReachComparisonChart should render a "no data" state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-gZMcBi cCickz"
+        className="sc-VigVT knyrTu"
       >
         <div
           style={
@@ -151,7 +151,7 @@ exports[`Snapshots ReachComparisonChart should render a loading state 1`] = `
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -169,7 +169,7 @@ exports[`Snapshots ReachComparisonChart should render a loading state 1`] = `
         </h2>
       </header>
       <div
-        className="sc-iwsKbI MLANU"
+        className="sc-gqjmRU fgNPjU"
       >
         <div
           style={
@@ -307,7 +307,7 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -325,21 +325,21 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
         </h2>
       </header>
       <div
-        className="sc-dnqmqq jhnxZF"
+        className="sc-gZMcBi cCickz"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -347,91 +347,135 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
+                  className="sc-bdVaJa bjwIvU"
+                >
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
+                    style={
+                      Object {
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
+                      }
+                    }
+                  />
+                </span>
+                <div
                   style={
                     Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="twitter"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
                   >
                     <div
-                      className="sc-bZQynM fqsBLH"
+                      className="sc-htoDjs jxuJsQ"
                     >
                       <span
                         style={
                           Object {
                             "color": "#59626a",
                             "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
                           }
                         }
                       >
                         Buffer
                       </span>
                     </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -439,79 +483,89 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      400
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -520,7 +574,7 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -528,117 +582,45 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      700
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -646,9 +628,9 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     height="100%"
                     style={
                       Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -658,42 +640,168 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="torchRed"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Joel Gascoigne
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#FF1E1E",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        10
+                        700
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          10
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -702,7 +810,7 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -710,117 +818,45 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa hWwCRQ"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        TestInstagram
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda444",
-                          "borderColor": "#df8626",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      2,000
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -828,9 +864,9 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#3b5998",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -840,41 +876,167 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="facebook"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        80
+                        2,000
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          80
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -918,7 +1080,7 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
         }
       >
         <h2
-          className="sc-gzVnrw fhxDdR"
+          className="sc-dnqmqq CwTMq"
         >
           <span
             style={
@@ -936,21 +1098,21 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
         </h2>
       </header>
       <div
-        className="sc-htoDjs rfxNx"
+        className="sc-iwsKbI MLANU"
       >
         <div />
       </div>
       <section
-        className="sc-ifAKCX fEBlBl"
+        className="sc-bZQynM jQlKhY"
       >
         <ul
-          className="sc-bxivhb kLcPeY"
+          className="sc-EHOje gptsFE"
         >
           <li
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -958,117 +1120,45 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
+            <div
+              className="sc-gzVnrw azIqp"
             >
               <span
-                data-tip={null}
+                className="sc-bwzfXH ghuPdm"
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  className="sc-bdVaJa bjwIvU"
                 >
-                  <div
-                    className="sc-EHOje enMLlg"
-                  >
-                    <div
-                      className="sc-bZQynM fqsBLH"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.75rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        Buffer
-                      </span>
-                    </div>
-                    <span
-                      style={
-                        Object {
-                          "background": "#fda3f3",
-                          "borderColor": "#df85d5",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                  </div>
-                </span>
-              </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
-                    }
-                  }
-                >
-                  <span
+                  <img
+                    alt=""
+                    src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                     style={
                       Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "borderRadius": "50%",
+                        "height": "26px",
+                        "marginBottom": undefined,
+                        "marginTop": undefined,
+                        "maxHeight": undefined,
+                        "maxWidth": undefined,
+                        "minHeight": undefined,
+                        "minWidth": undefined,
+                        "objectFit": undefined,
+                        "width": "26px",
                       }
                     }
-                  >
-                    <span>
-                      400
-                    </span>
-                  </span>
+                  />
                 </span>
-              </div>
-              <div>
-                <span
+                <div
                   style={
                     Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
+                      "background": "#fff",
+                      "border": "#fff 1px solid",
+                      "borderRadius": "50%",
+                      "height": "14px",
+                      "left": "20px",
+                      "position": "absolute",
+                      "top": "20px",
+                      "width": "14px",
                     }
                   }
                 >
@@ -1076,9 +1166,9 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     height="100%"
                     style={
                       Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
                       }
                     }
                     version="1.1"
@@ -1088,41 +1178,167 @@ exports[`Snapshots ReachComparisonChart should render the reach comparison chart
                     xmlnsXlink="http://www.w3.org/1999/xlink"
                   >
                     <g
-                      className="shamrock"
+                      className="twitter"
                     >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
                     </g>
                   </svg>
+                </div>
+              </span>
+            </div>
+            <div>
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    <div
+                      className="sc-htoDjs jxuJsQ"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        Buffer
+                      </span>
+                    </div>
+                  </span>
                 </span>
+              </span>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
+                  }
+                }
+              >
                 <div
                   style={
                     Object {
-                      "color": "#2FD566",
                       "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
                     }
                   }
                 >
-                  <span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontSize": "2rem",
+                        "fontWeight": 600,
+                      }
+                    }
+                  >
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        20
+                        400
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          20
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/reach-comparison-chart/components/ReachComparisonChart/index.jsx
+++ b/packages/reach-comparison-chart/components/ReachComparisonChart/index.jsx
@@ -7,12 +7,14 @@ const CHART_NAME = 'Reach';
 const ReachComparisonChart = ({
   profilesMetricData,
   profileTotals,
+  profiles,
   loading,
 }) =>
   (
     <ComparisonChartWrapper
       profilesMetricData={profilesMetricData}
       profileTotals={profileTotals}
+      profiles={profiles}
       loading={loading}
       chartName={CHART_NAME}
     />
@@ -49,6 +51,12 @@ ReachComparisonChart.propTypes = {
     profileId: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     service: PropTypes.string,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
   })).isRequired,
 };
 

--- a/packages/reach-comparison-chart/components/ReachComparisonChart/story.jsx
+++ b/packages/reach-comparison-chart/components/ReachComparisonChart/story.jsx
@@ -4,12 +4,13 @@ import { checkA11y } from 'storybook-addon-a11y';
 
 import ReachComparisonChart from './index';
 import mockDailyData from '../../mocks/dailyData';
+import profiles from '../../mocks/profiles';
 
 const profileTotals = [
   {
     currentPeriodTotal: 400,
     currentPeriodDiff: 20,
-    profileId: '1234abcd',
+    profileId: '1',
     username: 'Buffer',
     service: 'facebook',
     metric: {
@@ -20,7 +21,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: '5678abcd',
+    profileId: '2',
     username: 'buffer',
     service: 'twitter',
     metric: {
@@ -31,7 +32,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 2000,
     currentPeriodDiff: 80,
-    profileId: '5678abcd',
+    profileId: '3',
     username: 'TestInstagram',
     service: 'instagram',
     metric: {
@@ -52,6 +53,7 @@ storiesOf('ReachComparisonChart')
       <ReachComparisonChart
         profilesMetricData={[mockDailyData[0]]}
         profileTotals={[profileTotals[0]]}
+        profiles={profiles}
       />
     </div>
   ))
@@ -64,6 +66,7 @@ storiesOf('ReachComparisonChart')
       <ReachComparisonChart
         profilesMetricData={mockDailyData}
         profileTotals={profileTotals}
+        profiles={profiles}
       />
     </div>
   ))
@@ -76,6 +79,7 @@ storiesOf('ReachComparisonChart')
       <ReachComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
         loading
       />
     </div>
@@ -89,6 +93,7 @@ storiesOf('ReachComparisonChart')
       <ReachComparisonChart
         profilesMetricData={[]}
         profileTotals={[]}
+        profiles={profiles}
       />
     </div>
   ));

--- a/packages/reach-comparison-chart/index.js
+++ b/packages/reach-comparison-chart/index.js
@@ -5,6 +5,7 @@ function mapStateToProps (state) {
   return {
     profilesMetricData: state.reachComparison.profilesMetricData,
     profileTotals: state.reachComparison.profileTotals,
+    profiles: state.profiles.profiles,
     loading: state.reachComparison.loading,
   };
 }

--- a/packages/report-list/__snapshots__/snapshot.test.js.snap
+++ b/packages/report-list/__snapshots__/snapshot.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Snapshots RemoveButton renders the remove button 1`] = `
 <span>
   <button
-    className="sc-htoDjs iTGyVB sc-bdVaJa eTEyQW"
+    className="sc-iwsKbI gzNeKR sc-htpNat jElTWv"
     onClick={[Function]}
   >
     <svg
@@ -66,7 +66,7 @@ exports[`Snapshots Report can display buttons for viewing and removing the repor
     }
   >
     <span
-      className="sc-gZMcBi gqiYya"
+      className="sc-VigVT imyKmg"
     >
       <span
         style={
@@ -79,16 +79,16 @@ exports[`Snapshots Report can display buttons for viewing and removing the repor
         }
       >
         <span
-          className="sc-dnqmqq fWAAQO"
+          className="sc-gZMcBi bMHQsL"
         >
           Weekly Sync Report
         </span>
       </span>
       <span
-        className="sc-gqjmRU ddIOsZ"
+        className="sc-jTzLTM imCabk"
       >
         <button
-          className="sc-htoDjs iTGyVB sc-bdVaJa eTEyQW"
+          className="sc-iwsKbI gzNeKR sc-htpNat jElTWv"
           onClick={[Function]}
         >
           <svg
@@ -125,7 +125,7 @@ exports[`Snapshots Report can display buttons for viewing and removing the repor
 exports[`Snapshots Report renders the report 1`] = `
 <span>
   <li
-    className="sc-VigVT iHSuUu"
+    className="sc-fjdhpX dihBVz"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -159,7 +159,7 @@ exports[`Snapshots Report renders the report 1`] = `
       }
     >
       <span
-        className="sc-gZMcBi gqiYya"
+        className="sc-VigVT imyKmg"
       >
         <span
           style={
@@ -172,7 +172,7 @@ exports[`Snapshots Report renders the report 1`] = `
           }
         >
           <span
-            className="sc-dnqmqq fWAAQO"
+            className="sc-gZMcBi bMHQsL"
           >
             Weekly Sync Report
           </span>
@@ -188,7 +188,7 @@ exports[`Snapshots Report renders the report 1`] = `
           }
         >
           <span
-            className="sc-iwsKbI dJPvHC"
+            className="sc-gqjmRU gYOUjR"
           >
             October 10, 2017
           </span>
@@ -305,10 +305,10 @@ exports[`Snapshots ReportList loading state 1`] = `
 exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
 <span>
   <ol
-    className="sc-jTzLTM jkPlha"
+    className="sc-jzJRlG fDXUjd"
   >
     <li
-      className="sc-VigVT iHSuUu"
+      className="sc-fjdhpX dihBVz"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
@@ -342,7 +342,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
         }
       >
         <span
-          className="sc-gZMcBi gqiYya"
+          className="sc-VigVT imyKmg"
         >
           <span
             style={
@@ -355,7 +355,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
             }
           >
             <span
-              className="sc-dnqmqq fWAAQO"
+              className="sc-gZMcBi bMHQsL"
             >
               Weekly Sync Report
             </span>
@@ -371,7 +371,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
             }
           >
             <span
-              className="sc-iwsKbI dJPvHC"
+              className="sc-gqjmRU gYOUjR"
             >
               November 7, 2017
             </span>
@@ -380,7 +380,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
       </button>
     </li>
     <li
-      className="sc-VigVT iHSuUu"
+      className="sc-fjdhpX dihBVz"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
@@ -414,7 +414,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
         }
       >
         <span
-          className="sc-gZMcBi gqiYya"
+          className="sc-VigVT imyKmg"
         >
           <span
             style={
@@ -427,7 +427,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
             }
           >
             <span
-              className="sc-dnqmqq fWAAQO"
+              className="sc-gZMcBi bMHQsL"
             >
               Client Social Media Campaign
             </span>
@@ -443,7 +443,7 @@ exports[`Snapshots ReportList renders the reports collection in a list 1`] = `
             }
           >
             <span
-              className="sc-iwsKbI dJPvHC"
+              className="sc-gqjmRU gYOUjR"
             >
               October 10, 2017
             </span>

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -556,7 +556,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
       }
     >
       <div
-        className="sc-cJSrbW ldkMSM"
+        className="sc-hmzhuo kHJSXr"
       >
         <button
           aria-label={null}
@@ -587,13 +587,13 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           }
         >
           <h1
-            className="sc-kgAjT eHVMBX"
+            className="sc-ksYbfQ jirdXB"
           >
             Weekly Sync Report
           </h1>
         </button>
         <div
-          className="sc-ksYbfQ gTHrCW"
+          className="sc-frDJqD fNpsqI"
         >
           <svg
             height="100%"
@@ -631,13 +631,13 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
         }
       >
         <span
-          className="sc-kjoXOD KIsXf"
+          className="sc-TOsTZ flIkJk"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-cHGsZl dInUbQ"
+          className="sc-kgAjT dweNln"
         >
           Invalid date
            to 
@@ -646,7 +646,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
       </span>
     </span>
     <section
-      className="sc-eqIVtm iPBqtY"
+      className="sc-caSCKo fpRkuH"
     >
       <h2
         style={
@@ -680,10 +680,10 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
         }
       >
         <span
-          className="sc-gisBJw fixKCf"
+          className="sc-cHGsZl hGuQbs"
         >
           <span
-            className="sc-fAjcbJ hosPcn"
+            className="sc-gisBJw jPLMAr"
           >
             Showing for accounts
           </span>
@@ -721,6 +721,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
               style={
                 Object {
                   "background": "#fff",
+                  "border": "#fff 0 solid",
                   "borderRadius": "50%",
                   "height": "13px",
                   "left": "9px",
@@ -760,7 +761,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             </div>
           </div>
           <span
-            className="sc-caSCKo sLzsC"
+            className="sc-kjoXOD iblUQU"
           >
             Buffer
           </span>
@@ -780,7 +781,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -788,56 +789,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Tweets
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -845,79 +838,89 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    150
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#2fd566",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shamrock"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#2FD566",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "shamrock",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      25
+                      150
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#2fd566",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shamrock"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#2FD566",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "shamrock",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -926,7 +929,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -934,56 +937,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Retweets
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -991,80 +986,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    901
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      39
+                      901
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        39
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1073,7 +1078,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1081,56 +1086,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Clicks
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -1138,80 +1135,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    1,010
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      55
+                      1,010
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        55
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1220,7 +1227,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1228,56 +1235,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Impressions
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -1285,80 +1284,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    963.4k
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      26
+                      963.4k
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        26
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1367,7 +1376,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1375,56 +1384,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                New Followers
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -1432,80 +1433,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    0
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#59626a",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shuttleGray"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#8D969E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "#8D969E",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
                       0
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#8D969E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#8D969E",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        0
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1514,7 +1525,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1522,56 +1533,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Engagements
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -1579,80 +1582,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    28.8k
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      33
+                      28.8k
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        33
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1661,7 +1674,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1669,56 +1682,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Likes
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -1726,80 +1731,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    2,313
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      28
+                      2,313
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        28
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1808,7 +1823,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1816,56 +1831,48 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Replies
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -1873,80 +1880,90 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    658
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      9
+                      658
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        9
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -2076,7 +2093,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
       }
     >
       <input
-        className="sc-TOsTZ cEFJKv"
+        className="sc-cJSrbW khsZLx"
         onBlur={[Function]}
         onChange={[Function]}
         value="Weekly Sync Report"
@@ -2092,13 +2109,13 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         }
       >
         <span
-          className="sc-kjoXOD KIsXf"
+          className="sc-TOsTZ flIkJk"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-cHGsZl dInUbQ"
+          className="sc-kgAjT dweNln"
         >
           Invalid date
            to 
@@ -2107,7 +2124,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
       </span>
     </span>
     <section
-      className="sc-eqIVtm iPBqtY"
+      className="sc-caSCKo fpRkuH"
     >
       <h2
         style={
@@ -2316,10 +2333,10 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         }
       >
         <span
-          className="sc-gisBJw fixKCf"
+          className="sc-cHGsZl hGuQbs"
         >
           <span
-            className="sc-fAjcbJ hosPcn"
+            className="sc-gisBJw jPLMAr"
           >
             Showing for accounts
           </span>
@@ -2357,6 +2374,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
               style={
                 Object {
                   "background": "#fff",
+                  "border": "#fff 0 solid",
                   "borderRadius": "50%",
                   "height": "13px",
                   "left": "9px",
@@ -2396,7 +2414,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             </div>
           </div>
           <span
-            className="sc-caSCKo sLzsC"
+            className="sc-kjoXOD iblUQU"
           >
             Buffer
           </span>
@@ -2416,7 +2434,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -2424,56 +2442,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Tweets
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -2481,79 +2491,89 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    150
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#2fd566",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shamrock"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#2FD566",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "shamrock",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      25
+                      150
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#2fd566",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shamrock"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#2FD566",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "shamrock",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -2562,7 +2582,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -2570,56 +2590,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Retweets
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -2627,80 +2639,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    901
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      39
+                      901
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        39
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -2709,7 +2731,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -2717,56 +2739,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Clicks
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -2774,80 +2788,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    1,010
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      55
+                      1,010
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        55
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -2856,7 +2880,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -2864,56 +2888,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Impressions
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -2921,80 +2937,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    963.4k
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      26
+                      963.4k
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        26
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -3003,7 +3029,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -3011,56 +3037,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                New Followers
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -3068,80 +3086,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    0
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#59626a",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shuttleGray"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#8D969E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "#8D969E",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
                       0
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#8D969E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#8D969E",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        0
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -3150,7 +3178,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -3158,56 +3186,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Engagements
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -3215,80 +3235,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    28.8k
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      33
+                      28.8k
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        33
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -3297,7 +3327,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -3305,56 +3335,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Likes
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -3362,80 +3384,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    2,313
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      28
+                      2,313
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        28
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -3444,7 +3476,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -3452,56 +3484,48 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Replies
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -3509,80 +3533,90 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    658
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      9
+                      658
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        9
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -3609,7 +3643,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       }
     >
       <div
-        className="sc-cJSrbW ldkMSM"
+        className="sc-hmzhuo kHJSXr"
       >
         <button
           aria-label={null}
@@ -3640,13 +3674,13 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           }
         >
           <h1
-            className="sc-kgAjT eHVMBX"
+            className="sc-ksYbfQ jirdXB"
           >
             Weekly Sync Report
           </h1>
         </button>
         <div
-          className="sc-ksYbfQ gTHrCW"
+          className="sc-frDJqD fNpsqI"
         >
           <svg
             height="100%"
@@ -3684,13 +3718,13 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-kjoXOD KIsXf"
+          className="sc-TOsTZ flIkJk"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-cHGsZl dInUbQ"
+          className="sc-kgAjT dweNln"
         >
           Invalid date
            to 
@@ -3699,7 +3733,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       </span>
     </span>
     <section
-      className="sc-eqIVtm iPBqtY"
+      className="sc-caSCKo fpRkuH"
     >
       <h2
         style={
@@ -3908,10 +3942,10 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-gisBJw fixKCf"
+          className="sc-cHGsZl hGuQbs"
         >
           <span
-            className="sc-fAjcbJ hosPcn"
+            className="sc-gisBJw jPLMAr"
           >
             Showing for accounts
           </span>
@@ -3949,6 +3983,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
               style={
                 Object {
                   "background": "#fff",
+                  "border": "#fff 0 solid",
                   "borderRadius": "50%",
                   "height": "13px",
                   "left": "9px",
@@ -3988,7 +4023,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             </div>
           </div>
           <span
-            className="sc-caSCKo sLzsC"
+            className="sc-kjoXOD iblUQU"
           >
             Buffer
           </span>
@@ -4008,7 +4043,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4016,56 +4051,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Tweets
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4073,79 +4100,89 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    150
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#2fd566",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shamrock"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#2FD566",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "shamrock",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      25
+                      150
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#2fd566",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shamrock"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#2FD566",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "shamrock",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -4154,7 +4191,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4162,56 +4199,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Retweets
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4219,80 +4248,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    901
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      39
+                      901
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        39
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -4301,7 +4340,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4309,56 +4348,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Clicks
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4366,80 +4397,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    1,010
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      55
+                      1,010
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        55
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -4448,7 +4489,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4456,56 +4497,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Impressions
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4513,80 +4546,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    963.4k
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      26
+                      963.4k
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        26
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -4595,7 +4638,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4603,56 +4646,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                New Followers
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4660,80 +4695,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    0
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#59626a",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shuttleGray"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#8D969E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "#8D969E",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
                       0
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#8D969E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#8D969E",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        0
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -4742,7 +4787,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4750,56 +4795,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Engagements
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4807,80 +4844,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    28.8k
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      33
+                      28.8k
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        33
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -4889,7 +4936,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -4897,56 +4944,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Likes
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -4954,80 +4993,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    2,313
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      28
+                      2,313
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        28
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -5036,7 +5085,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -5044,56 +5093,48 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
+          <div>
             <span
-              data-tip={null}
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                data-tip={null}
               >
-                Replies
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
               </span>
             </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
             <div
               style={
                 Object {
-                  "display": "inline-block",
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
                 }
               }
             >
-              <span
+              <div
                 style={
                   Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
+                    "display": "inline-block",
                   }
                 }
               >
@@ -5101,80 +5142,90 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
                   style={
                     Object {
                       "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
                       "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "fontWeight": 600,
                     }
                   }
                 >
-                  <span>
-                    658
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="torchRed"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#FF1E1E",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      9
+                      658
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        9
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/shared-components/ComparisonChartWrapper/index.jsx
+++ b/packages/shared-components/ComparisonChartWrapper/index.jsx
@@ -15,6 +15,7 @@ import {
 const ComparisonChartWrapper = ({
   profilesMetricData,
   profileTotals,
+  profiles,
   loading,
   chartName,
 }) => {
@@ -36,6 +37,7 @@ const ComparisonChartWrapper = ({
     footer = (
       <Footer
         profileTotals={profileTotals}
+        profiles={profiles}
       />
     );
   }
@@ -88,7 +90,12 @@ ComparisonChartWrapper.propTypes = {
     currentPeriodTotal: PropTypes.number.isRequired,
     currentPeriodDiff: PropTypes.number.isRequired,
     profileId: PropTypes.string.isRequired,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
   })).isRequired,
 };
 

--- a/packages/shared-components/ComparisonFooter/index.jsx
+++ b/packages/shared-components/ComparisonFooter/index.jsx
@@ -29,28 +29,59 @@ const ProfileUsernameWrapper = styled.div`
   margin-right: 10px;
 `;
 
-const ComparisonFooter = ({ profileTotals }) => (
+const ProfileCell = ({ profileTotal, profile }) => (
+  <GridItem
+    metric={{
+      label: profileTotal.metric.label,
+      value: profileTotal.currentPeriodTotal,
+      diff: profileTotal.currentPeriodDiff,
+    }}
+    customLabel={
+      <ProfileAvatarWrapper>
+        <ProfileUsernameWrapper>
+          <Text size="small">
+            {profile.username}
+          </Text>
+        </ProfileUsernameWrapper>
+        <MetricIcon key={profile.profileId} metric={profileTotal.metric} />
+      </ProfileAvatarWrapper>
+    }
+  />
+);
+
+ProfileCell.propTypes = {
+  profileTotal: PropTypes.shape({
+    metric: PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      color: PropTypes.string.isRequired,
+    }),
+    currentPeriodTotal: PropTypes.number.isRequired,
+    currentPeriodDiff: PropTypes.number.isRequired,
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    service: PropTypes.string,
+  }).isRequired,
+  profile: PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+function renderGridItem(profileTotal) {
+  const profile = this.profiles.find(p => p.id === profileTotal.profileId);
+  return (<ProfileCell
+    key={profileTotal.profileId}
+    profileTotal={profileTotal}
+    profile={profile}
+  />);
+}
+
+const ComparisonFooter = ({ profileTotals, profiles }) => (
   <Wrapper>
     <Grid>
-      {profileTotals.map(total =>
-        <GridItem
-          key={total.profileId}
-          metric={{
-            label: total.metric.label,
-            value: total.currentPeriodTotal,
-            diff: total.currentPeriodDiff,
-          }}
-          customLabel={
-            <ProfileAvatarWrapper>
-              <ProfileUsernameWrapper>
-                <Text size="small">
-                  {total.username}
-                </Text>
-              </ProfileUsernameWrapper>
-              <MetricIcon key={total.profileId} metric={total.metric} />
-            </ProfileAvatarWrapper>
-          }
-        />)}
+      {profileTotals.map(renderGridItem, { profiles })}
     </Grid>
   </Wrapper>
 );
@@ -70,6 +101,12 @@ ComparisonFooter.propTypes = {
     profileId: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     service: PropTypes.string,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    avatarUrl: PropTypes.string.isRequired,
+    service: PropTypes.string.isRequired,
   })).isRequired,
 };
 

--- a/packages/shared-components/ComparisonFooter/index.jsx
+++ b/packages/shared-components/ComparisonFooter/index.jsx
@@ -6,8 +6,12 @@ import Text from '@bufferapp/components/Text';
 
 import {
   GridItem,
-  MetricIcon,
+  ProfileIcon,
 } from '@bufferapp/analyze-shared-components';
+
+import {
+  shuttleGrey,
+} from '@bufferapp/components/style/color';
 
 const Grid = styled.ul`
   display: flex;
@@ -24,6 +28,7 @@ const Wrapper = styled.section`
 const ProfileAvatarWrapper = styled.div`
   display: inline-flex;
   align-items: center;
+  margin-right: 14px;
 `;
 const ProfileUsernameWrapper = styled.div`
   margin-right: 10px;
@@ -37,13 +42,15 @@ const ProfileCell = ({ profileTotal, profile }) => (
       diff: profileTotal.currentPeriodDiff,
     }}
     customLabel={
+      <ProfileUsernameWrapper>
+        <Text weight="bold" color={shuttleGrey}>
+          {profile.username}
+        </Text>
+      </ProfileUsernameWrapper>
+    }
+    prefix={
       <ProfileAvatarWrapper>
-        <ProfileUsernameWrapper>
-          <Text size="small">
-            {profile.username}
-          </Text>
-        </ProfileUsernameWrapper>
-        <MetricIcon key={profile.profileId} metric={profileTotal.metric} />
+        <ProfileIcon color={profileTotal.metric.color} profile={profile} />
       </ProfileAvatarWrapper>
     }
   />

--- a/packages/shared-components/ComparisonFooter/story.jsx
+++ b/packages/shared-components/ComparisonFooter/story.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import ComparisonFooter from './index';
+import profiles from '../mocks/profiles';
 
 const profileTotals = [
   {
     currentPeriodTotal: 400,
     currentPeriodDiff: 20,
-    profileId: '1234abcd',
-    username: 'Buffer',
+    profileId: '1',
     metric: {
       color: '#fda3f3',
       label: 'Fans',
@@ -17,8 +17,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: '5678abcd',
-    username: 'Buffer',
+    profileId: '2',
     metric: {
       color: '#fda444',
       label: 'Followers',
@@ -27,8 +26,7 @@ const profileTotals = [
   {
     currentPeriodTotal: 700,
     currentPeriodDiff: -10,
-    profileId: '5678ioio',
-    username: 'LifeIsAwesome',
+    profileId: '3',
     service: 'instagram',
     metric: {
       color: '#fda444',
@@ -47,17 +45,7 @@ storiesOf('ComparisonFooter')
     >
       <ComparisonFooter
         profileTotals={[profileTotals[2]]}
-      />
-    </div>
-  ))
-  .add('should render coming soon if the profile is instagram and metric is Impressions', () => (
-    <div
-      style={{
-        width: '750px',
-      }}
-    >
-      <ComparisonFooter
-        profileTotals={[profileTotals[0]]}
+        profiles={profiles}
       />
     </div>
   ))
@@ -69,6 +57,7 @@ storiesOf('ComparisonFooter')
     >
       <ComparisonFooter
         profileTotals={profileTotals}
+        profiles={profiles}
       />
     </div>
   ));

--- a/packages/shared-components/GridItem/components/Value/index.jsx
+++ b/packages/shared-components/GridItem/components/Value/index.jsx
@@ -7,7 +7,7 @@ import TruncatedNumber from '../../../TruncatedNumber';
 const headingColor = '#323b43';
 
 const gridSummaryItemValue = {
-  fontSize: '2.5rem',
+  fontSize: '2rem',
   fontWeight: 600,
   color: headingColor,
 };

--- a/packages/shared-components/GridItem/index.jsx
+++ b/packages/shared-components/GridItem/index.jsx
@@ -9,7 +9,7 @@ import GridItemChart from './components/GridItemChart';
 const baseMargin = 10;
 const borderColor = '#CED7DF';
 const gridSummaryItem = {
-  display: 'inline-block',
+  display: 'flex',
   listStyle: 'none',
   boxSizing: 'border-box',
   paddingBottom: `${1.5 * baseMargin}px`,
@@ -29,7 +29,16 @@ function filterDailyDataMetrics(dailyData, metricLabel) {
   }));
 }
 
-const GridItem = ({ metric, tooltip, gridWidth, dailyData, timezone, customLabel, hideDiff }) => {
+const GridItem = ({
+  metric,
+  tooltip,
+  gridWidth,
+  dailyData,
+  timezone,
+  customLabel,
+  prefix,
+  hideDiff,
+}) => {
   const style = {
     ...gridSummaryItem,
     width: gridWidth,
@@ -40,16 +49,19 @@ const GridItem = ({ metric, tooltip, gridWidth, dailyData, timezone, customLabel
       style={style}
       key={metric.label}
     >
-      {dailyData.length > 1 &&
-        <GridItemChart timezone={timezone} dailyData={dailyMetricData} />
-      }
-      <Label tooltip={tooltip} >
-        {!customLabel && metric.label}
-        {customLabel && customLabel}
-      </Label>
-      <div style={gridSummaryItemValueWrapper}>
-        <Value>{metric.value}</Value>
-        {!hideDiff && <Diff diff={metric.diff} />}
+      {prefix && prefix}
+      <div>
+        {dailyData.length > 1 &&
+          <GridItemChart timezone={timezone} dailyData={dailyMetricData} />
+        }
+        <Label tooltip={tooltip} >
+          {!customLabel && metric.label}
+          {customLabel && customLabel}
+        </Label>
+        <div style={gridSummaryItemValueWrapper}>
+          <Value>{metric.value}</Value>
+          {!hideDiff && <Diff diff={metric.diff} />}
+        </div>
       </div>
     </li>
   );
@@ -61,6 +73,7 @@ GridItem.defaultProps = {
   timezone: 'Etc/UTC',
   tooltip: null,
   customLabel: null,
+  prefix: null,
   hideDiff: false,
 };
 
@@ -71,6 +84,7 @@ GridItem.propTypes = {
     value: PropTypes.number,
   }).isRequired,
   customLabel: PropTypes.element,
+  prefix: PropTypes.element,
   dailyData: PropTypes.arrayOf(PropTypes.shape({
     day: PropTypes.string.isRequired,
     metrics: PropTypes.arrayOf(PropTypes.shape({

--- a/packages/shared-components/ProfileIcon/index.jsx
+++ b/packages/shared-components/ProfileIcon/index.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { Image } from '@bufferapp/components';
+
+import {
+  geyser,
+} from '@bufferapp/components/style/color';
+
+import SocialIcon from '../SocialIcon';
+
+const avatarSize = 26;
+const AvatarWithAuraSize = 34;
+const socialIconSize = 14;
+
+const IconAura = ({ color, children, className }) => (
+  <span className={className} >
+    { children }
+  </span>
+);
+
+IconAura.propTypes = {
+  children: PropTypes.element.isRequired,
+  className: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired,
+};
+
+const IconAuraStyled = styled(IconAura)`
+  width: 30px;
+  height: 30px;
+  border: 2px solid ${props => props.color};
+  display: flex;
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ProfileIcon = ({ className, profile, color }) => (
+  <span className={className} >
+    <IconAuraStyled color={color} >
+      <Image
+        border={'circle'}
+        src={profile.avatarUrl}
+        height={`${avatarSize}px`}
+        width={`${avatarSize}px`}
+      />
+    </IconAuraStyled>
+    <SocialIcon service={profile.service} socialIconSize={socialIconSize} avatarSize={AvatarWithAuraSize} withBorder />
+  </span>
+);
+
+ProfileIcon.propTypes = {
+  className: PropTypes.string.isRequired,
+  color: PropTypes.string,
+  profile: PropTypes.shape({
+    username: PropTypes.string,
+    service: PropTypes.string,
+  }).isRequired,
+};
+
+ProfileIcon.defaultProps = {
+  color: geyser,
+};
+
+const ProfileIconStyled = styled(ProfileIcon)`
+  position: relative;
+`;
+
+export default ProfileIconStyled;

--- a/packages/shared-components/ProfileIcon/story.jsx
+++ b/packages/shared-components/ProfileIcon/story.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+
+import ProfileIcon from './index';
+
+const avatarUrl = 'https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png';
+
+storiesOf('ProfileIcon')
+  .addDecorator(checkA11y)
+  .add('should render', () => (
+    <div style={{ width: '260px', display: 'flex' }}>
+      <ProfileIcon
+        profile={{
+          service: 'facebook',
+          avatarUrl,
+        }}
+      />
+    </div>
+  ));

--- a/packages/shared-components/SocialIcon/index.jsx
+++ b/packages/shared-components/SocialIcon/index.jsx
@@ -7,7 +7,7 @@ import {
   CircleTwitterIcon,
 } from '@bufferapp/components';
 
-const SocialIcon = ({ service, socialIconSize, avatarSize }) => {
+const SocialIcon = ({ service, socialIconSize, avatarSize, withBorder }) => {
   let icon;
   switch (service) {
     case 'twitter':
@@ -36,6 +36,7 @@ const SocialIcon = ({ service, socialIconSize, avatarSize }) => {
         top: `${avatarSize - socialIconSize}px`,
         left: `${avatarSize - socialIconSize}px`,
         borderRadius: '50%',
+        border: `#fff ${withBorder ? '1px' : '0'} solid`,
       }}
     >
       {icon}
@@ -47,6 +48,11 @@ SocialIcon.propTypes = {
   service: PropTypes.oneOf(['twitter', 'facebook', 'instagram']).isRequired,
   socialIconSize: PropTypes.number.isRequired,
   avatarSize: PropTypes.number.isRequired,
+  withBorder: PropTypes.bool,
+};
+
+SocialIcon.defaultProps = {
+  withBorder: false,
 };
 
 export default SocialIcon;

--- a/packages/shared-components/SocialIcon/story.jsx
+++ b/packages/shared-components/SocialIcon/story.jsx
@@ -11,5 +11,13 @@ storiesOf('SocialIcon')
       socialIconSize={16}
       avatarSize={32}
     />
+  ))
+  .add('should render with border', () => (
+    <SocialIcon
+      service={'facebook'}
+      socialIconSize={16}
+      avatarSize={32}
+      withBorder
+    />
   ));
 

--- a/packages/shared-components/__snapshots__/snapshot.test.js.snap
+++ b/packages/shared-components/__snapshots__/snapshot.test.js.snap
@@ -442,7 +442,7 @@ exports[`Snapshots ComparisonChartTooltip should render the tooltip 1`] = `
     }
   >
     <div
-      className="sc-htoDjs gbcpcz"
+      className="sc-iwsKbI gaXzVq"
     >
       <span>
         <span
@@ -513,208 +513,6 @@ exports[`Snapshots ComparisonChartTooltip should render the tooltip 1`] = `
 </span>
 `;
 
-exports[`Snapshots ComparisonFooter should render coming soon if the profile is instagram and metric is Impressions 1`] = `
-<span>
-  <div
-    style={
-      Object {
-        "width": "750px",
-      }
-    }
-  >
-    <section
-      className="sc-iwsKbI jRuIUA"
-    >
-      <ul
-        className="sc-dnqmqq cbpPJN"
-      >
-        <li
-          style={
-            Object {
-              "boxSizing": "border-box",
-              "display": "inline-block",
-              "flexGrow": 1,
-              "listStyle": "none",
-              "paddingBottom": "15px",
-              "width": "25%",
-            }
-          }
-        >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
-          >
-            <span
-              data-tip={null}
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
-              >
-                <div
-                  className="sc-gZMcBi bLpxnI"
-                >
-                  <div
-                    className="sc-gqjmRU jcagjt"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#59626a",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "0.75rem",
-                          "fontWeight": 400,
-                        }
-                      }
-                    >
-                      Buffer
-                    </span>
-                  </div>
-                  <span
-                    style={
-                      Object {
-                        "background": "#fda3f3",
-                        "borderColor": "#df85d5",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
-                    }
-                  />
-                </div>
-              </span>
-            </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "2rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    400
-                  </span>
-                </span>
-              </span>
-            </div>
-            <div>
-              <span
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#2fd566",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shamrock"
-                  >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                    />
-                  </g>
-                </svg>
-              </span>
-              <div
-                style={
-                  Object {
-                    "color": "#2FD566",
-                    "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
-                  }
-                }
-              >
-                <span>
-                  <span
-                    style={
-                      Object {
-                        "color": "shamrock",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
-                      }
-                    }
-                  >
-                    <span>
-                      20
-                    </span>
-                    %
-                  </span>
-                </span>
-              </div>
-            </div>
-          </div>
-        </li>
-      </ul>
-    </section>
-  </div>
-</span>
-`;
-
 exports[`Snapshots ComparisonFooter should render the footer for a single profile 1`] = `
 <span>
   <div
@@ -725,16 +523,16 @@ exports[`Snapshots ComparisonFooter should render the footer for a single profil
     }
   >
     <section
-      className="sc-iwsKbI jRuIUA"
+      className="sc-gqjmRU fAQVWU"
     >
       <ul
-        className="sc-dnqmqq cbpPJN"
+        className="sc-gZMcBi eWCLFi"
       >
         <li
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -742,117 +540,45 @@ exports[`Snapshots ComparisonFooter should render the footer for a single profil
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
+          <div
+            className="sc-VigVT fAjQiM"
           >
             <span
-              data-tip={null}
+              className="sc-bwzfXH ghuPdm"
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                className="sc-bdVaJa hWwCRQ"
               >
-                <div
-                  className="sc-gZMcBi bLpxnI"
-                >
-                  <div
-                    className="sc-gqjmRU jcagjt"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#59626a",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "0.75rem",
-                          "fontWeight": 400,
-                        }
-                      }
-                    >
-                      LifeIsAwesome
-                    </span>
-                  </div>
-                  <span
-                    style={
-                      Object {
-                        "background": "#fda444",
-                        "borderColor": "#df8626",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
-                    }
-                  />
-                </div>
-              </span>
-            </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
-                  }
-                }
-              >
-                <span
+                <img
+                  alt=""
+                  src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "borderRadius": "50%",
+                      "height": "26px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "26px",
                     }
                   }
-                >
-                  <span>
-                    700
-                  </span>
-                </span>
+                />
               </span>
-            </div>
-            <div>
-              <span
+              <div
                 style={
                   Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
+                    "background": "#fff",
+                    "border": "#fff 1px solid",
+                    "borderRadius": "50%",
+                    "height": "14px",
+                    "left": "20px",
+                    "position": "absolute",
+                    "top": "20px",
+                    "width": "14px",
                   }
                 }
               >
@@ -860,9 +586,9 @@ exports[`Snapshots ComparisonFooter should render the footer for a single profil
                   height="100%"
                   style={
                     Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
                     }
                   }
                   version="1.1"
@@ -872,42 +598,168 @@ exports[`Snapshots ComparisonFooter should render the footer for a single profil
                   xmlnsXlink="http://www.w3.org/1999/xlink"
                 >
                   <g
-                    className="torchRed"
+                    className="facebook"
                   >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
                   </g>
                 </svg>
+              </div>
+            </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  <div
+                    className="sc-jTzLTM ikcdJN"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#59626a",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      Buffer
+                    </span>
+                  </div>
+                </span>
               </span>
+            </span>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
               <div
                 style={
                   Object {
-                    "color": "#FF1E1E",
                     "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
                   }
                 }
               >
-                <span>
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontSize": "2rem",
+                      "fontWeight": 600,
+                    }
+                  }
+                >
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      10
+                      700
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        10
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -928,16 +780,16 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
     }
   >
     <section
-      className="sc-iwsKbI jRuIUA"
+      className="sc-gqjmRU fAQVWU"
     >
       <ul
-        className="sc-dnqmqq cbpPJN"
+        className="sc-gZMcBi eWCLFi"
       >
         <li
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -945,117 +797,45 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
+          <div
+            className="sc-VigVT fAjQiM"
           >
             <span
-              data-tip={null}
+              className="sc-bwzfXH ghuPdm"
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                className="sc-bdVaJa bjwIvU"
               >
-                <div
-                  className="sc-gZMcBi bLpxnI"
-                >
-                  <div
-                    className="sc-gqjmRU jcagjt"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#59626a",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "0.75rem",
-                          "fontWeight": 400,
-                        }
-                      }
-                    >
-                      Buffer
-                    </span>
-                  </div>
-                  <span
-                    style={
-                      Object {
-                        "background": "#fda3f3",
-                        "borderColor": "#df85d5",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
-                    }
-                  />
-                </div>
-              </span>
-            </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
-                  }
-                }
-              >
-                <span
+                <img
+                  alt=""
+                  src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "borderRadius": "50%",
+                      "height": "26px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "26px",
                     }
                   }
-                >
-                  <span>
-                    400
-                  </span>
-                </span>
+                />
               </span>
-            </div>
-            <div>
-              <span
+              <div
                 style={
                   Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
+                    "background": "#fff",
+                    "border": "#fff 1px solid",
+                    "borderRadius": "50%",
+                    "height": "14px",
+                    "left": "20px",
+                    "position": "absolute",
+                    "top": "20px",
+                    "width": "14px",
                   }
                 }
               >
@@ -1063,9 +843,9 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
                   height="100%"
                   style={
                     Object {
-                      "fill": "#2fd566",
-                      "height": "1rem",
-                      "width": "1rem",
+                      "fill": "#55acee",
+                      "height": "100%",
+                      "width": "100%",
                     }
                   }
                   version="1.1"
@@ -1075,41 +855,167 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
                   xmlnsXlink="http://www.w3.org/1999/xlink"
                 >
                   <g
-                    className="shamrock"
+                    className="twitter"
                   >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                    />
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                      />
+                    </g>
                   </g>
                 </svg>
+              </div>
+            </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  <div
+                    className="sc-jTzLTM ikcdJN"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#59626a",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      Buffer
+                    </span>
+                  </div>
+                </span>
               </span>
+            </span>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
               <div
                 style={
                   Object {
-                    "color": "#2FD566",
                     "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
                   }
                 }
               >
-                <span>
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontSize": "2rem",
+                      "fontWeight": 600,
+                    }
+                  }
+                >
                   <span
                     style={
                       Object {
-                        "color": "shamrock",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      20
+                      400
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#2fd566",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shamrock"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#2FD566",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "shamrock",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        20
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1118,7 +1024,7 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1126,117 +1032,45 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
+          <div
+            className="sc-VigVT fAjQiM"
           >
             <span
-              data-tip={null}
+              className="sc-bwzfXH ghuPdm"
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                className="sc-bdVaJa hWwCRQ"
               >
-                <div
-                  className="sc-gZMcBi bLpxnI"
-                >
-                  <div
-                    className="sc-gqjmRU jcagjt"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#59626a",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "0.75rem",
-                          "fontWeight": 400,
-                        }
-                      }
-                    >
-                      Buffer
-                    </span>
-                  </div>
-                  <span
-                    style={
-                      Object {
-                        "background": "#fda444",
-                        "borderColor": "#df8626",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
-                    }
-                  />
-                </div>
-              </span>
-            </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
-                  }
-                }
-              >
-                <span
+                <img
+                  alt=""
+                  src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "borderRadius": "50%",
+                      "height": "26px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "26px",
                     }
                   }
-                >
-                  <span>
-                    700
-                  </span>
-                </span>
+                />
               </span>
-            </div>
-            <div>
-              <span
+              <div
                 style={
                   Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
+                    "background": "#fff",
+                    "border": "#fff 1px solid",
+                    "borderRadius": "50%",
+                    "height": "14px",
+                    "left": "20px",
+                    "position": "absolute",
+                    "top": "20px",
+                    "width": "14px",
                   }
                 }
               >
@@ -1244,9 +1078,9 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
                   height="100%"
                   style={
                     Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
+                      "fill": "#55acee",
+                      "height": "100%",
+                      "width": "100%",
                     }
                   }
                   version="1.1"
@@ -1256,42 +1090,168 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
                   xmlnsXlink="http://www.w3.org/1999/xlink"
                 >
                   <g
-                    className="torchRed"
+                    className="twitter"
                   >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                      />
+                    </g>
                   </g>
                 </svg>
+              </div>
+            </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  <div
+                    className="sc-jTzLTM ikcdJN"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#59626a",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      Joel Gascoigne
+                    </span>
+                  </div>
+                </span>
               </span>
+            </span>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
               <div
                 style={
                   Object {
-                    "color": "#FF1E1E",
                     "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
                   }
                 }
               >
-                <span>
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontSize": "2rem",
+                      "fontWeight": 600,
+                    }
+                  }
+                >
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      10
+                      700
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        10
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1300,7 +1260,7 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
           style={
             Object {
               "boxSizing": "border-box",
-              "display": "inline-block",
+              "display": "flex",
               "flexGrow": 1,
               "listStyle": "none",
               "paddingBottom": "15px",
@@ -1308,117 +1268,45 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
             }
           }
         >
-          <span
-            style={
-              Object {
-                "display": "block",
-                "fontSize": "0.75rem",
-                "fontWeight": 600,
-                "marginTop": "15px",
-              }
-            }
+          <div
+            className="sc-VigVT fAjQiM"
           >
             <span
-              data-tip={null}
+              className="sc-bwzfXH ghuPdm"
             >
               <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
+                className="sc-bdVaJa hWwCRQ"
               >
-                <div
-                  className="sc-gZMcBi bLpxnI"
-                >
-                  <div
-                    className="sc-gqjmRU jcagjt"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#59626a",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "0.75rem",
-                          "fontWeight": 400,
-                        }
-                      }
-                    >
-                      LifeIsAwesome
-                    </span>
-                  </div>
-                  <span
-                    style={
-                      Object {
-                        "background": "#fda444",
-                        "borderColor": "#df8626",
-                        "borderRadius": "10px",
-                        "borderStyle": "solid",
-                        "borderWidth": "1px",
-                        "display": "inline-block",
-                        "height": "7px",
-                        "marginRight": "5px",
-                        "verticalAlign": "baseline",
-                        "width": "7px",
-                      }
-                    }
-                  />
-                </div>
-              </span>
-            </span>
-          </span>
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flex": 1,
-                "flexDirection": "row",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#323b43",
-                    "fontSize": "2.5rem",
-                    "fontWeight": 600,
-                  }
-                }
-              >
-                <span
+                <img
+                  alt=""
+                  src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "2rem",
-                      "fontWeight": 700,
+                      "borderRadius": "50%",
+                      "height": "26px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "26px",
                     }
                   }
-                >
-                  <span>
-                    700
-                  </span>
-                </span>
+                />
               </span>
-            </div>
-            <div>
-              <span
+              <div
                 style={
                   Object {
-                    "display": "inline-block",
-                    "height": "1rem",
-                    "marginLeft": "10px",
+                    "background": "#fff",
+                    "border": "#fff 1px solid",
+                    "borderRadius": "50%",
+                    "height": "14px",
+                    "left": "20px",
+                    "position": "absolute",
+                    "top": "20px",
+                    "width": "14px",
                   }
                 }
               >
@@ -1426,9 +1314,9 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
                   height="100%"
                   style={
                     Object {
-                      "fill": "#ff1e1e",
-                      "height": "1rem",
-                      "width": "1rem",
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
                     }
                   }
                   version="1.1"
@@ -1438,42 +1326,168 @@ exports[`Snapshots ComparisonFooter should render the footer for multiple profil
                   xmlnsXlink="http://www.w3.org/1999/xlink"
                 >
                   <g
-                    className="torchRed"
+                    className="facebook"
                   >
-                    <path
-                      d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                    />
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
                   </g>
                 </svg>
+              </div>
+            </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "block",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 600,
+                  "marginTop": "15px",
+                }
+              }
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.75rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  <div
+                    className="sc-jTzLTM ikcdJN"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#59626a",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      Buffer
+                    </span>
+                  </div>
+                </span>
               </span>
+            </span>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
               <div
                 style={
                   Object {
-                    "color": "#FF1E1E",
                     "display": "inline-block",
-                    "fontSize": "18px",
-                    "fontWeight": 600,
-                    "marginLeft": "5px",
                   }
                 }
               >
-                <span>
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontSize": "2rem",
+                      "fontWeight": 600,
+                    }
+                  }
+                >
                   <span
                     style={
                       Object {
-                        "color": "torchRed",
+                        "color": "#323b43",
                         "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.25rem",
+                        "fontSize": "2rem",
+                        "fontWeight": 700,
                       }
                     }
                   >
                     <span>
-                      10
+                      700
                     </span>
-                    %
                   </span>
                 </span>
+              </div>
+              <div>
+                <span
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "height": "1rem",
+                      "marginLeft": "10px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#ff1e1e",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="torchRed"
+                    >
+                      <path
+                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <div
+                  style={
+                    Object {
+                      "color": "#FF1E1E",
+                      "display": "inline-block",
+                      "fontSize": "18px",
+                      "fontWeight": 600,
+                      "marginLeft": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    <span
+                      style={
+                        Object {
+                          "color": "torchRed",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.25rem",
+                        }
+                      }
+                    >
+                      <span>
+                        10
+                      </span>
+                      %
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1572,6 +1586,7 @@ exports[`Snapshots Dropdown Item should render 1`] = `
               style={
                 Object {
                   "background": "#fff",
+                  "border": "#fff 0 solid",
                   "borderRadius": "50%",
                   "height": "11px",
                   "left": "13px",
@@ -1796,6 +1811,7 @@ exports[`Snapshots Dropdown Item should render properly with an empty avatarUrl 
               style={
                 Object {
                   "background": "#fff",
+                  "border": "#fff 0 solid",
                   "borderRadius": "50%",
                   "height": "11px",
                   "left": "13px",
@@ -2052,6 +2068,7 @@ exports[`Snapshots Dropdown Item should selected 1`] = `
               style={
                 Object {
                   "background": "#fff",
+                  "border": "#fff 0 solid",
                   "borderRadius": "50%",
                   "height": "11px",
                   "left": "13px",
@@ -2490,7 +2507,7 @@ exports[`Snapshots GridItem should not render the chart if we have only one day 
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -2498,56 +2515,48 @@ exports[`Snapshots GridItem should not render the chart if we have only one day 
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            Engagement average
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Engagement average
+            </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -2555,79 +2564,89 @@ exports[`Snapshots GridItem should not render the chart if we have only one day 
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                42
-              </span>
-            </span>
-          </span>
-        </div>
-        <div>
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "height": "1rem",
-                "marginLeft": "10px",
-              }
-            }
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#2fd566",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shamrock"
-              >
-                <path
-                  d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            style={
-              Object {
-                "color": "#2FD566",
-                "display": "inline-block",
-                "fontSize": "18px",
-                "fontWeight": 600,
-                "marginLeft": "5px",
-              }
-            }
-          >
-            <span>
               <span
                 style={
                   Object {
-                    "color": "shamrock",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
                   }
                 }
               >
                 <span>
-                  60
+                  42
                 </span>
-                %
               </span>
             </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "height": "1rem",
+                  "marginLeft": "10px",
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "fill": "#2fd566",
+                    "height": "1rem",
+                    "width": "1rem",
+                  }
+                }
+                version="1.1"
+                viewBox="0 0 16 16"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <g
+                  className="shamrock"
+                >
+                  <path
+                    d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              style={
+                Object {
+                  "color": "#2FD566",
+                  "display": "inline-block",
+                  "fontSize": "18px",
+                  "fontWeight": 600,
+                  "marginLeft": "5px",
+                }
+              }
+            >
+              <span>
+                <span
+                  style={
+                    Object {
+                      "color": "shamrock",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.25rem",
+                    }
+                  }
+                >
+                  <span>
+                    60
+                  </span>
+                  %
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -2655,7 +2674,7 @@ exports[`Snapshots GridItem should render a grid item with a Chart if dailyData 
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -2663,56 +2682,48 @@ exports[`Snapshots GridItem should render a grid item with a Chart if dailyData 
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            Engagement average
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Engagement average
+            </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -2720,79 +2731,89 @@ exports[`Snapshots GridItem should render a grid item with a Chart if dailyData 
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                42
-              </span>
-            </span>
-          </span>
-        </div>
-        <div>
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "height": "1rem",
-                "marginLeft": "10px",
-              }
-            }
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#2fd566",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shamrock"
-              >
-                <path
-                  d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            style={
-              Object {
-                "color": "#2FD566",
-                "display": "inline-block",
-                "fontSize": "18px",
-                "fontWeight": 600,
-                "marginLeft": "5px",
-              }
-            }
-          >
-            <span>
               <span
                 style={
                   Object {
-                    "color": "shamrock",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
                   }
                 }
               >
                 <span>
-                  60
+                  42
                 </span>
-                %
               </span>
             </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "height": "1rem",
+                  "marginLeft": "10px",
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "fill": "#2fd566",
+                    "height": "1rem",
+                    "width": "1rem",
+                  }
+                }
+                version="1.1"
+                viewBox="0 0 16 16"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <g
+                  className="shamrock"
+                >
+                  <path
+                    d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              style={
+                Object {
+                  "color": "#2FD566",
+                  "display": "inline-block",
+                  "fontSize": "18px",
+                  "fontWeight": 600,
+                  "marginLeft": "5px",
+                }
+              }
+            >
+              <span>
+                <span
+                  style={
+                    Object {
+                      "color": "shamrock",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.25rem",
+                    }
+                  }
+                >
+                  <span>
+                    60
+                  </span>
+                  %
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -2820,7 +2841,7 @@ exports[`Snapshots GridItem should render a grid item with a custom Label 1`] = 
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -2828,58 +2849,50 @@ exports[`Snapshots GridItem should render a grid item with a custom Label 1`] = 
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            <span>
-              This is a custom label
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <span>
+                This is a custom label
+              </span>
             </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -2887,80 +2900,90 @@ exports[`Snapshots GridItem should render a grid item with a custom Label 1`] = 
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                10
-              </span>
-            </span>
-          </span>
-        </div>
-        <div>
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "height": "1rem",
-                "marginLeft": "10px",
-              }
-            }
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#ff1e1e",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="torchRed"
-              >
-                <path
-                  d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                  transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            style={
-              Object {
-                "color": "#FF1E1E",
-                "display": "inline-block",
-                "fontSize": "18px",
-                "fontWeight": 600,
-                "marginLeft": "5px",
-              }
-            }
-          >
-            <span>
               <span
                 style={
                   Object {
-                    "color": "torchRed",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
                   }
                 }
               >
                 <span>
-                  60
+                  10
                 </span>
-                %
               </span>
             </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "height": "1rem",
+                  "marginLeft": "10px",
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "fill": "#ff1e1e",
+                    "height": "1rem",
+                    "width": "1rem",
+                  }
+                }
+                version="1.1"
+                viewBox="0 0 16 16"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <g
+                  className="torchRed"
+                >
+                  <path
+                    d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                    transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              style={
+                Object {
+                  "color": "#FF1E1E",
+                  "display": "inline-block",
+                  "fontSize": "18px",
+                  "fontWeight": 600,
+                  "marginLeft": "5px",
+                }
+              }
+            >
+              <span>
+                <span
+                  style={
+                    Object {
+                      "color": "torchRed",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.25rem",
+                    }
+                  }
+                >
+                  <span>
+                    60
+                  </span>
+                  %
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -3014,7 +3037,7 @@ exports[`Snapshots GridItem should render a summary grid item with a neutral dif
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -3022,56 +3045,48 @@ exports[`Snapshots GridItem should render a summary grid item with a neutral dif
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            Tweets
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Tweets
+            </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -3079,80 +3094,90 @@ exports[`Snapshots GridItem should render a summary grid item with a neutral dif
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                0
-              </span>
-            </span>
-          </span>
-        </div>
-        <div>
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "height": "1rem",
-                "marginLeft": "10px",
-              }
-            }
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#59626a",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shuttleGray"
-              >
-                <path
-                  d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                  transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            style={
-              Object {
-                "color": "#8D969E",
-                "display": "inline-block",
-                "fontSize": "18px",
-                "fontWeight": 600,
-                "marginLeft": "5px",
-              }
-            }
-          >
-            <span>
               <span
                 style={
                   Object {
-                    "color": "#8D969E",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
                   }
                 }
               >
                 <span>
                   0
                 </span>
-                %
               </span>
             </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "height": "1rem",
+                  "marginLeft": "10px",
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "fill": "#59626a",
+                    "height": "1rem",
+                    "width": "1rem",
+                  }
+                }
+                version="1.1"
+                viewBox="0 0 16 16"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <g
+                  className="shuttleGray"
+                >
+                  <path
+                    d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                    transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              style={
+                Object {
+                  "color": "#8D969E",
+                  "display": "inline-block",
+                  "fontSize": "18px",
+                  "fontWeight": 600,
+                  "marginLeft": "5px",
+                }
+              }
+            >
+              <span>
+                <span
+                  style={
+                    Object {
+                      "color": "#8D969E",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.25rem",
+                    }
+                  }
+                >
+                  <span>
+                    0
+                  </span>
+                  %
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -3180,7 +3205,7 @@ exports[`Snapshots GridItem should render a summary grid item with negative diff
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -3188,56 +3213,48 @@ exports[`Snapshots GridItem should render a summary grid item with negative diff
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            Tweets
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Tweets
+            </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -3245,80 +3262,90 @@ exports[`Snapshots GridItem should render a summary grid item with negative diff
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                10
-              </span>
-            </span>
-          </span>
-        </div>
-        <div>
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "height": "1rem",
-                "marginLeft": "10px",
-              }
-            }
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#ff1e1e",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="torchRed"
-              >
-                <path
-                  d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                  transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            style={
-              Object {
-                "color": "#FF1E1E",
-                "display": "inline-block",
-                "fontSize": "18px",
-                "fontWeight": 600,
-                "marginLeft": "5px",
-              }
-            }
-          >
-            <span>
               <span
                 style={
                   Object {
-                    "color": "torchRed",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
                   }
                 }
               >
                 <span>
-                  60
+                  10
                 </span>
-                %
               </span>
             </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "height": "1rem",
+                  "marginLeft": "10px",
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "fill": "#ff1e1e",
+                    "height": "1rem",
+                    "width": "1rem",
+                  }
+                }
+                version="1.1"
+                viewBox="0 0 16 16"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <g
+                  className="torchRed"
+                >
+                  <path
+                    d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                    transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              style={
+                Object {
+                  "color": "#FF1E1E",
+                  "display": "inline-block",
+                  "fontSize": "18px",
+                  "fontWeight": 600,
+                  "marginLeft": "5px",
+                }
+              }
+            >
+              <span>
+                <span
+                  style={
+                    Object {
+                      "color": "torchRed",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.25rem",
+                    }
+                  }
+                >
+                  <span>
+                    60
+                  </span>
+                  %
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -3346,7 +3373,7 @@ exports[`Snapshots GridItem should render a summary grid item with no diff 1`] =
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -3354,56 +3381,48 @@ exports[`Snapshots GridItem should render a summary grid item with no diff 1`] =
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            Tweets
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Tweets
+            </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -3411,17 +3430,27 @@ exports[`Snapshots GridItem should render a summary grid item with no diff 1`] =
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                10
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  10
+                </span>
               </span>
             </span>
-          </span>
+          </div>
         </div>
       </div>
     </li>
@@ -3448,7 +3477,7 @@ exports[`Snapshots GridItem should render a summary grid item with positive diff
       style={
         Object {
           "boxSizing": "border-box",
-          "display": "inline-block",
+          "display": "flex",
           "flexGrow": 1,
           "listStyle": "none",
           "paddingBottom": "15px",
@@ -3456,56 +3485,48 @@ exports[`Snapshots GridItem should render a summary grid item with positive diff
         }
       }
     >
-      <span
-        style={
-          Object {
-            "display": "block",
-            "fontSize": "0.75rem",
-            "fontWeight": 600,
-            "marginTop": "15px",
-          }
-        }
-      >
+      <div>
         <span
-          data-tip={null}
+          style={
+            Object {
+              "display": "block",
+              "fontSize": "0.75rem",
+              "fontWeight": 600,
+              "marginTop": "15px",
+            }
+          }
         >
           <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
-                "fontWeight": 400,
-              }
-            }
+            data-tip={null}
           >
-            Tweets
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Tweets
+            </span>
           </span>
         </span>
-      </span>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
         <div
           style={
             Object {
-              "display": "inline-block",
+              "alignItems": "center",
+              "display": "flex",
+              "flex": 1,
+              "flexDirection": "row",
             }
           }
         >
-          <span
+          <div
             style={
               Object {
-                "color": "#323b43",
-                "fontSize": "2.5rem",
-                "fontWeight": 600,
+                "display": "inline-block",
               }
             }
           >
@@ -3513,79 +3534,89 @@ exports[`Snapshots GridItem should render a summary grid item with positive diff
               style={
                 Object {
                   "color": "#323b43",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "2rem",
-                  "fontWeight": 700,
+                  "fontWeight": 600,
                 }
               }
             >
-              <span>
-                150
-              </span>
-            </span>
-          </span>
-        </div>
-        <div>
-          <span
-            style={
-              Object {
-                "display": "inline-block",
-                "height": "1rem",
-                "marginLeft": "10px",
-              }
-            }
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#2fd566",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shamrock"
-              >
-                <path
-                  d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            style={
-              Object {
-                "color": "#2FD566",
-                "display": "inline-block",
-                "fontSize": "18px",
-                "fontWeight": 600,
-                "marginLeft": "5px",
-              }
-            }
-          >
-            <span>
               <span
                 style={
                   Object {
-                    "color": "shamrock",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.25rem",
+                    "fontSize": "2rem",
+                    "fontWeight": 700,
                   }
                 }
               >
                 <span>
-                  50
+                  150
                 </span>
-                %
               </span>
             </span>
+          </div>
+          <div>
+            <span
+              style={
+                Object {
+                  "display": "inline-block",
+                  "height": "1rem",
+                  "marginLeft": "10px",
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "fill": "#2fd566",
+                    "height": "1rem",
+                    "width": "1rem",
+                  }
+                }
+                version="1.1"
+                viewBox="0 0 16 16"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <g
+                  className="shamrock"
+                >
+                  <path
+                    d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              style={
+                Object {
+                  "color": "#2FD566",
+                  "display": "inline-block",
+                  "fontSize": "18px",
+                  "fontWeight": 600,
+                  "marginLeft": "5px",
+                }
+              }
+            >
+              <span>
+                <span
+                  style={
+                    Object {
+                      "color": "shamrock",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.25rem",
+                    }
+                  }
+                >
+                  <span>
+                    50
+                  </span>
+                  %
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -12057,6 +12088,7 @@ exports[`Snapshots ProfileBadge should render 1`] = `
       style={
         Object {
           "background": "#fff",
+          "border": "#fff 0 solid",
           "borderRadius": "50%",
           "height": "16px",
           "left": "16px",
@@ -12098,12 +12130,142 @@ exports[`Snapshots ProfileBadge should render 1`] = `
 </span>
 `;
 
+exports[`Snapshots ProfileIcon should render 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "width": "260px",
+      }
+    }
+  >
+    <span
+      className="sc-cSHVUG hDUXUW"
+    >
+      <span
+        className="sc-jzJRlG iFhvqW"
+      >
+        <img
+          alt=""
+          src="https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png"
+          style={
+            Object {
+              "borderRadius": "50%",
+              "height": "26px",
+              "marginBottom": undefined,
+              "marginTop": undefined,
+              "maxHeight": undefined,
+              "maxWidth": undefined,
+              "minHeight": undefined,
+              "minWidth": undefined,
+              "objectFit": undefined,
+              "width": "26px",
+            }
+          }
+        />
+      </span>
+      <div
+        style={
+          Object {
+            "background": "#fff",
+            "border": "#fff 1px solid",
+            "borderRadius": "50%",
+            "height": "14px",
+            "left": "20px",
+            "position": "absolute",
+            "top": "20px",
+            "width": "14px",
+          }
+        }
+      >
+        <svg
+          height="100%"
+          style={
+            Object {
+              "fill": "#3b5998",
+              "height": "100%",
+              "width": "100%",
+            }
+          }
+          version="1.1"
+          viewBox="0 0 16 16"
+          width="100%"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        >
+          <g
+            className="facebook"
+          >
+            <g
+              fillRule="evenodd"
+            >
+              <path
+                d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </span>
+  </div>
+</span>
+`;
+
 exports[`Snapshots SocialIcon should render 1`] = `
 <span>
   <div
     style={
       Object {
         "background": "#fff",
+        "border": "#fff 0 solid",
+        "borderRadius": "50%",
+        "height": "16px",
+        "left": "16px",
+        "position": "absolute",
+        "top": "16px",
+        "width": "16px",
+      }
+    }
+  >
+    <svg
+      height="100%"
+      style={
+        Object {
+          "fill": "#3b5998",
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+      version="1.1"
+      viewBox="0 0 16 16"
+      width="100%"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
+      <g
+        className="facebook"
+      >
+        <g
+          fillRule="evenodd"
+        >
+          <path
+            d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+          />
+        </g>
+      </g>
+    </svg>
+  </div>
+</span>
+`;
+
+exports[`Snapshots SocialIcon should render with border 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "background": "#fff",
+        "border": "#fff 1px solid",
         "borderRadius": "50%",
         "height": "16px",
         "left": "16px",
@@ -12154,7 +12316,7 @@ exports[`Snapshots Title should render the title for the comparison audience cha
     }
   >
     <h2
-      className="sc-VigVT koZmyN"
+      className="sc-fjdhpX emYWof"
     >
       <span
         style={
@@ -12184,7 +12346,7 @@ exports[`Snapshots Title should render the title for the comparison reach chart 
     }
   >
     <h2
-      className="sc-VigVT koZmyN"
+      className="sc-fjdhpX emYWof"
     >
       <span
         style={

--- a/packages/shared-components/index.js
+++ b/packages/shared-components/index.js
@@ -4,6 +4,7 @@ export GridItem from './GridItem';
 export Dropdown from './Dropdown';
 export style from './style';
 export MetricIcon from './MetricIcon';
+export ProfileIcon from './ProfileIcon';
 export PeriodPhrase from './PeriodPhrase';
 export PostsTable from './PostsTable';
 export ProfileBadge from './ProfileBadge';

--- a/packages/shared-components/mocks/profiles.js
+++ b/packages/shared-components/mocks/profiles.js
@@ -1,0 +1,36 @@
+const avatarUrl = 'https://buffer-uploads.s3.amazonaws.com/503a5c8ffc99f72a7f00002e/f49c2ff693f1c307af5e1b3d84e581ca.png';
+
+const twitterProfiles = [
+  {
+    avatarUrl,
+    username: 'Buffer',
+    id: '1',
+    service: 'twitter',
+  },
+  {
+    avatarUrl,
+    username: 'Joel Gascoigne',
+    id: '2',
+    service: 'twitter',
+  },
+];
+
+const facebookProfiles = [
+  {
+    avatarUrl,
+    username: 'Buffer',
+    id: '3',
+    service: 'facebook',
+  },
+];
+
+const instagramProfiles = [
+  {
+    avatarUrl,
+    username: 'Buffer',
+    id: '4',
+    service: 'instagram',
+  },
+];
+
+export default [...twitterProfiles, ...facebookProfiles, ...instagramProfiles];

--- a/packages/summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/summary-table/__snapshots__/snapshot.test.js.snap
@@ -371,7 +371,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -379,56 +379,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Tweets
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Tweets
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -436,79 +428,89 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      150
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        25
+                        150
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          25
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -517,7 +519,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -525,56 +527,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Retweets
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Retweets
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -582,80 +576,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      901
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        39
+                        901
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          39
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -664,7 +668,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -672,56 +676,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Clicks
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Clicks
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -729,80 +725,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -811,7 +817,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -819,56 +825,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Impressions
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Impressions
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -876,80 +874,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      963.4k
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        26
+                        963.4k
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          26
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -958,7 +966,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -966,56 +974,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  New Followers
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    New Followers
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1023,80 +1023,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      0
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#59626a",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shuttleGray"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#8D969E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "#8D969E",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
                         0
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#59626a",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shuttleGray"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#8D969E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#8D969E",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1105,7 +1115,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1113,56 +1123,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Engagements
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Engagements
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1170,80 +1172,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      28.8k
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        33
+                        28.8k
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          33
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1252,7 +1264,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1260,56 +1272,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Likes
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Likes
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1317,80 +1321,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      2,313
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        28
+                        2,313
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          28
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1399,7 +1413,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1407,56 +1421,48 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Replies
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Replies
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1464,80 +1470,90 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      658
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        9
+                        658
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          9
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1625,7 +1641,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1633,56 +1649,48 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Tweets
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Tweets
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1690,79 +1698,89 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      150
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#2fd566",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shamrock"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#2FD566",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "shamrock",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        25
+                        150
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#2fd566",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shamrock"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#2FD566",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "shamrock",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          25
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1771,7 +1789,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1779,56 +1797,48 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Retweets
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Retweets
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1836,80 +1846,90 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      901
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        39
+                        901
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          39
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1918,7 +1938,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -1926,56 +1946,48 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Clicks
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Clicks
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -1983,80 +1995,90 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      1,010
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        55
+                        1,010
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          55
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -2065,7 +2087,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -2073,56 +2095,48 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  Impressions
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Impressions
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -2130,80 +2144,90 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      963.4k
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#ff1e1e",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="torchRed"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#FF1E1E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "torchRed",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
-                        26
+                        963.4k
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#ff1e1e",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="torchRed"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#FF1E1E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "torchRed",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          26
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -2212,7 +2236,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             style={
               Object {
                 "boxSizing": "border-box",
-                "display": "inline-block",
+                "display": "flex",
                 "flexGrow": 1,
                 "listStyle": "none",
                 "paddingBottom": "15px",
@@ -2220,56 +2244,48 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "block",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 600,
-                  "marginTop": "15px",
-                }
-              }
-            >
+            <div>
               <span
-                data-tip={null}
+                style={
+                  Object {
+                    "display": "block",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 600,
+                    "marginTop": "15px",
+                  }
+                }
               >
                 <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 400,
-                    }
-                  }
+                  data-tip={null}
                 >
-                  New Followers
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    New Followers
+                  </span>
                 </span>
               </span>
-            </span>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
               <div
                 style={
                   Object {
-                    "display": "inline-block",
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flex": 1,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <span
+                <div
                   style={
                     Object {
-                      "color": "#323b43",
-                      "fontSize": "2.5rem",
-                      "fontWeight": 600,
+                      "display": "inline-block",
                     }
                   }
                 >
@@ -2277,80 +2293,90 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
                     style={
                       Object {
                         "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
                         "fontSize": "2rem",
-                        "fontWeight": 700,
+                        "fontWeight": 600,
                       }
                     }
                   >
-                    <span>
-                      0
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <div>
-                <span
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "height": "1rem",
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#59626a",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shuttleGray"
-                    >
-                      <path
-                        d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
-                        transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  style={
-                    Object {
-                      "color": "#8D969E",
-                      "display": "inline-block",
-                      "fontSize": "18px",
-                      "fontWeight": 600,
-                      "marginLeft": "5px",
-                    }
-                  }
-                >
-                  <span>
                     <span
                       style={
                         Object {
-                          "color": "#8D969E",
+                          "color": "#323b43",
                           "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.25rem",
+                          "fontSize": "2rem",
+                          "fontWeight": 700,
                         }
                       }
                     >
                       <span>
                         0
                       </span>
-                      %
                     </span>
                   </span>
+                </div>
+                <div>
+                  <span
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "height": "1rem",
+                        "marginLeft": "10px",
+                      }
+                    }
+                  >
+                    <svg
+                      height="100%"
+                      style={
+                        Object {
+                          "fill": "#59626a",
+                          "height": "1rem",
+                          "width": "1rem",
+                        }
+                      }
+                      version="1.1"
+                      viewBox="0 0 16 16"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
+                    >
+                      <g
+                        className="shuttleGray"
+                      >
+                        <path
+                          d="M9.14049638,4.2860102 L12.0353395,6.89310549 C12.4537988,7.26996987 13.0967448,7.23809282 13.4772842,6.81536904 C13.855189,6.39557201 13.8172589,5.74519856 13.4038537,5.37288597 L8.83967284,1.26238536 C8.63426816,1.07739793 8.37477499,0.990893877 8.11877778,1.0007568 C7.86278056,0.990893877 7.60328739,1.07739793 7.3978827,1.26238536 L2.83370181,5.37288597 C2.42029668,5.74519856 2.38236657,6.39557201 2.76027134,6.81536904 C3.14081078,7.23809282 3.78375672,7.26996987 4.20221602,6.89310549 L7.09528397,4.28760894 L7.09528397,13.9628717 C7.09528397,14.5341657 7.55312036,14.9879169 8.11789018,14.9879169 C8.68659746,14.9879169 9.14049638,14.5289885 9.14049638,13.9628717 L9.14049638,4.2860102 Z"
+                          transform="translate(8.118778, 7.993958) scale(1, -1) rotate(90.000000) translate(-8.118778, -7.993958) "
+                        />
+                      </g>
+                    </svg>
+                  </span>
+                  <div
+                    style={
+                      Object {
+                        "color": "#8D969E",
+                        "display": "inline-block",
+                        "fontSize": "18px",
+                        "fontWeight": 600,
+                        "marginLeft": "5px",
+                      }
+                    }
+                  >
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#8D969E",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "1.25rem",
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                        %
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1762,7 +1762,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-jnlKLf hyYdYy"
+    className="sc-tilXH ldznYL"
   >
     <div
       style={
@@ -1945,13 +1945,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
       </a>
     </div>
     <div
-      className="sc-fYxtnH fOnNfm"
+      className="sc-hEsumM iujgNo"
     >
       <header
-        className="sc-hEsumM dDdjEf"
+        className="sc-cIShpX xRUNA"
       >
         <button
-          className="sc-bdVaJa eTEyQW"
+          className="sc-htpNat jElTWv"
           onClick={[Function]}
         >
           <span
@@ -1968,13 +1968,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           </span>
         </button>
         <section
-          className="sc-cIShpX iWIiAw"
+          className="sc-feJyhm ehvwQP"
         >
           <div
-            className="sc-Rmtcm kWSdXa"
+            className="sc-hzDkRC dBAlrs"
           >
             <button
-              className="sc-kgoBCf bCHNEj"
+              className="sc-kpOJdX ccRmgv"
               disabled={false}
               onClick={[Function]}
             >
@@ -1991,7 +1991,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                 From: 10/29/17 - To: 11/04/17
               </span>
               <span
-                className="sc-kGXeez QhbPc"
+                className="sc-dxgOiQ lbVagd"
               >
                 <svg
                   height="100%"
@@ -2020,17 +2020,17 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               </span>
             </button>
             <div
-              className="sc-kpOJdX dYDxNw"
+              className="sc-ckVGcZ iuFYmf"
             >
               <div>
                 <header
-                  className="sc-jWBwVP hHfNoH"
+                  className="sc-cMljjf hlNNhZ"
                 >
                   <ul
-                    className="sc-brqgnP hNHNEh"
+                    className="sc-jAaTju eTssnX"
                   >
                     <li
-                      className="sc-cMljjf fLBuZh"
+                      className="sc-jDwBTQ ffztvn"
                       data-tip={null}
                       disabled={false}
                     >
@@ -2077,7 +2077,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                       </button>
                     </li>
                     <li
-                      className="sc-cMljjf fLBuZh"
+                      className="sc-jDwBTQ ffztvn"
                       data-tip={null}
                       disabled={false}
                     >
@@ -2124,7 +2124,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                       </button>
                     </li>
                     <li
-                      className="sc-cMljjf fLBuZh"
+                      className="sc-jDwBTQ ffztvn"
                       data-tip={null}
                       disabled={false}
                     >
@@ -2172,10 +2172,10 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                     </li>
                   </ul>
                   <ul
-                    className="sc-brqgnP hNHNEh"
+                    className="sc-jAaTju eTssnX"
                   >
                     <li
-                      className="sc-cMljjf fLBuZh"
+                      className="sc-jDwBTQ ffztvn"
                       data-tip={null}
                       disabled={false}
                     >
@@ -2222,7 +2222,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                       </button>
                     </li>
                     <li
-                      className="sc-cMljjf fLBuZh"
+                      className="sc-jDwBTQ ffztvn"
                       data-tip={null}
                       disabled={false}
                     >
@@ -2269,7 +2269,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                       </button>
                     </li>
                     <li
-                      className="sc-cMljjf kVpdba"
+                      className="sc-jDwBTQ kkbslg"
                       data-tip={null}
                       disabled={false}
                     >
@@ -2318,22 +2318,22 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
                   </ul>
                 </header>
                 <div
-                  className="sc-gipzik bvAyXF"
+                  className="sc-Rmtcm jJadEW"
                 />
               </div>
             </div>
             <div
-              className="sc-bRBYWo eETGfz"
+              className="sc-jhAzac locqjF"
               onClick={[Function]}
               role="button"
               tabIndex="0"
             />
           </div>
           <span
-            className="sc-gGBfsJ iOISQQ"
+            className="sc-fYxtnH jbzfyO"
           >
             <button
-              className="sc-bdVaJa eTEyQW"
+              className="sc-htpNat jElTWv"
               onClick={[Function]}
             >
               <span
@@ -2353,10 +2353,10 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </section>
       </header>
       <div
-        className="sc-tilXH llDiCM"
+        className="sc-ktHwxA kBfdSc"
       >
         <section
-          className="sc-ktHwxA igrPvZ"
+          className="sc-kafWEX eWqpeC"
         >
           <div
             style={


### PR DESCRIPTION
### Purpose
show profiles avatar in Comparison charts footer

### Notes
We are now passing the entire profiles collection to the Comparison Chart, to get avatarsUrl, and username. Reason for this is that we already have all the information in the `profiles` store, and we can avoid passing it down from the comparison API.

more info in https://app.getflow.com/organizations/369191/teams/339227/tasks/28535436

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
