### PR TITLE
Rebuild grpc after installing everything so that it has the linux binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "start": "cd ./packages/server/ && yarn start",
     "watch": "webpack-dev-server --config ./packages/server/webpack.config.dev.js --colors",
     "publish": "echo \"will eventually run: lerna publish\"",
-    "build": "webpack  --config ./packages/server/webpack.config.js --output-path=`pwd`"
+    "build": "webpack  --config ./packages/server/webpack.config.js --output-path=`pwd`",
+
+    "postinstall": "npm rebuild grpc --target_arch=x64 --target_platform=linux --target_libc=glibc"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
### Purpose

To fix `Error: Failed to load gRPC binary module because it was not installed for the current system` when running Analyze on a non-linux environment.