### PR TITLE
hide Comparison tools from sidebar

### DIFF
--- a/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
+++ b/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
@@ -223,48 +223,6 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
           </span>
         </span>
         <a
-          href="/comparisons"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          style={
-            Object {
-              "color": "#168eea",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "outline": "none",
-              "padding": "0",
-              "textDecoration": "none",
-            }
-          }
-          target="_self"
-        >
-          <span
-            style={
-              Object {
-                "borderRadius": "4px",
-                "display": "block",
-                "margin": "0 0.5rem",
-                "padding": "0.75rem 0.5rem",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
-                }
-              }
-            >
-              Comparisons
-            </span>
-          </span>
-        </a>
-        <a
           href="/reports"
           onBlur={[Function]}
           onClick={[Function]}
@@ -621,48 +579,6 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
           </span>
         </span>
         <a
-          href="/comparisons"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          style={
-            Object {
-              "color": "#168eea",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "outline": "none",
-              "padding": "0",
-              "textDecoration": "none",
-            }
-          }
-          target="_self"
-        >
-          <span
-            style={
-              Object {
-                "borderRadius": "4px",
-                "display": "block",
-                "margin": "0 0.5rem",
-                "padding": "0.75rem 0.5rem",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
-                }
-              }
-            >
-              Comparisons
-            </span>
-          </span>
-        </a>
-        <a
           href="/reports"
           onBlur={[Function]}
           onClick={[Function]}
@@ -975,48 +891,6 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
             Tools
           </span>
         </span>
-        <a
-          href="/comparisons"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          style={
-            Object {
-              "color": "#168eea",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "outline": "none",
-              "padding": "0",
-              "textDecoration": "none",
-            }
-          }
-          target="_self"
-        >
-          <span
-            style={
-              Object {
-                "borderRadius": "4px",
-                "display": "block",
-                "margin": "0 0.5rem",
-                "padding": "0.75rem 0.5rem",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
-                }
-              }
-            >
-              Comparisons
-            </span>
-          </span>
-        </a>
         <a
           href="/reports"
           onBlur={[Function]}

--- a/packages/nav-sidebar/components/NavSidebar.jsx
+++ b/packages/nav-sidebar/components/NavSidebar.jsx
@@ -38,7 +38,6 @@ const NavSidebar = props => (
     <Insights {...props} />
     <div>
       <Label>Tools</Label>
-      <Item href="/comparisons" {...props}>Comparisons</Item>
       <Item href="/reports" {...props}>Reports</Item>
     </div>
     <div style={bottomSectionStyle}>

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -941,48 +941,6 @@ exports[`Snapshots App should render application 1`] = `
               </span>
             </span>
             <a
-              href="/comparisons"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              style={
-                Object {
-                  "color": "#168eea",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "outline": "none",
-                  "padding": "0",
-                  "textDecoration": "none",
-                }
-              }
-              target="_self"
-            >
-              <span
-                style={
-                  Object {
-                    "borderRadius": "4px",
-                    "display": "block",
-                    "margin": "0 0.5rem",
-                    "padding": "0.75rem 0.5rem",
-                  }
-                }
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1rem",
-                      "fontWeight": 400,
-                    }
-                  }
-                >
-                  Comparisons
-                </span>
-              </span>
-            </a>
-            <a
               href="/reports"
               onBlur={[Function]}
               onClick={[Function]}
@@ -1348,48 +1306,6 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           </span>
         </span>
         <a
-          href="/comparisons"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          style={
-            Object {
-              "color": "#168eea",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "outline": "none",
-              "padding": "0",
-              "textDecoration": "none",
-            }
-          }
-          target="_self"
-        >
-          <span
-            style={
-              Object {
-                "borderRadius": "4px",
-                "display": "block",
-                "margin": "0 0.5rem",
-                "padding": "0.75rem 0.5rem",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
-                }
-              }
-            >
-              Comparisons
-            </span>
-          </span>
-        </a>
-        <a
           href="/reports"
           onBlur={[Function]}
           onClick={[Function]}
@@ -1663,48 +1579,6 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           </span>
         </span>
         <a
-          href="/comparisons"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          style={
-            Object {
-              "color": "#168eea",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "outline": "none",
-              "padding": "0",
-              "textDecoration": "none",
-            }
-          }
-          target="_self"
-        >
-          <span
-            style={
-              Object {
-                "borderRadius": "4px",
-                "display": "block",
-                "margin": "0 0.5rem",
-                "padding": "0.75rem 0.5rem",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
-                }
-              }
-            >
-              Comparisons
-            </span>
-          </span>
-        </a>
-        <a
           href="/reports"
           onBlur={[Function]}
           onClick={[Function]}
@@ -1973,48 +1847,6 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
             Tools
           </span>
         </span>
-        <a
-          href="/comparisons"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          style={
-            Object {
-              "color": "#168eea",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "outline": "none",
-              "padding": "0",
-              "textDecoration": "none",
-            }
-          }
-          target="_self"
-        >
-          <span
-            style={
-              Object {
-                "borderRadius": "4px",
-                "display": "block",
-                "margin": "0 0.5rem",
-                "padding": "0.75rem 0.5rem",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
-                }
-              }
-            >
-              Comparisons
-            </span>
-          </span>
-        </a>
         <a
           href="/reports"
           onBlur={[Function]}


### PR DESCRIPTION
### Purpose
To temporarily hide the Comparison tool from the sidebar.

### Notes
Hey, @tomredman just want to confirm that we only want to remove the button and have the tool accessible via URL.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
