### PR TITLE
Fix instagram audience chart report

### DIFF
--- a/packages/audience-chart/components/AudienceChart/index.jsx
+++ b/packages/audience-chart/components/AudienceChart/index.jsx
@@ -25,7 +25,7 @@ const AudienceChart = ({
     <ChartHeader>
       <Title dailyData={data} />
       <AddReport
-        chart="audience-compare"
+        chart="audience"
         state={{
           mode: props.mode,
           selectedMetrics: props.selectedMetrics,

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -556,7 +556,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
       }
     >
       <div
-        className="sc-jnlKLf eggVnr"
+        className="sc-tilXH bkBwWr"
       >
         <button
           aria-label={null}
@@ -587,13 +587,13 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           }
         >
           <h1
-            className="sc-gGBfsJ fHiXdl"
+            className="sc-fYxtnH HuPID"
           >
             Weekly Sync Report
           </h1>
         </button>
         <div
-          className="sc-fYxtnH hcgiEu"
+          className="sc-hEsumM ClmrB"
         >
           <svg
             height="100%"
@@ -631,13 +631,13 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
         }
       >
         <span
-          className="sc-jqCOkK VkehX"
+          className="sc-bbmXgH bPNoAj"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-uJMKN hvlSKg"
+          className="sc-gGBfsJ cwcERw"
         >
           Invalid date
            to 
@@ -646,7 +646,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
       </span>
     </span>
     <section
-      className="sc-kvZOFW hTJQjW"
+      className="sc-jbKcbu dnDUoT"
     >
       <h2
         style={
@@ -680,10 +680,10 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
         }
       >
         <span
-          className="sc-dNLxif gQUAVc"
+          className="sc-uJMKN gdNjKI"
         >
           <span
-            className="sc-hqyNC dRNKrH"
+            className="sc-dNLxif fLSJyM"
           >
             Showing for accounts
           </span>
@@ -761,7 +761,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
             </div>
           </div>
           <span
-            className="sc-jbKcbu iuRTvb"
+            className="sc-jqCOkK laZUyd"
           >
             Buffer
           </span>
@@ -2093,7 +2093,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
       }
     >
       <input
-        className="sc-bbmXgH kyqikf"
+        className="sc-jnlKLf fuVnqU"
         onBlur={[Function]}
         onChange={[Function]}
         value="Weekly Sync Report"
@@ -2109,13 +2109,13 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         }
       >
         <span
-          className="sc-jqCOkK VkehX"
+          className="sc-bbmXgH bPNoAj"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-uJMKN hvlSKg"
+          className="sc-gGBfsJ cwcERw"
         >
           Invalid date
            to 
@@ -2124,7 +2124,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
       </span>
     </span>
     <section
-      className="sc-kvZOFW hTJQjW"
+      className="sc-jbKcbu dnDUoT"
     >
       <h2
         style={
@@ -2333,10 +2333,10 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         }
       >
         <span
-          className="sc-dNLxif gQUAVc"
+          className="sc-uJMKN gdNjKI"
         >
           <span
-            className="sc-hqyNC dRNKrH"
+            className="sc-dNLxif fLSJyM"
           >
             Showing for accounts
           </span>
@@ -2414,7 +2414,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
             </div>
           </div>
           <span
-            className="sc-jbKcbu iuRTvb"
+            className="sc-jqCOkK laZUyd"
           >
             Buffer
           </span>
@@ -3643,7 +3643,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       }
     >
       <div
-        className="sc-jnlKLf eggVnr"
+        className="sc-tilXH bkBwWr"
       >
         <button
           aria-label={null}
@@ -3674,13 +3674,13 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           }
         >
           <h1
-            className="sc-gGBfsJ fHiXdl"
+            className="sc-fYxtnH HuPID"
           >
             Weekly Sync Report
           </h1>
         </button>
         <div
-          className="sc-fYxtnH hcgiEu"
+          className="sc-hEsumM ClmrB"
         >
           <svg
             height="100%"
@@ -3718,13 +3718,13 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-jqCOkK VkehX"
+          className="sc-bbmXgH bPNoAj"
         >
           Showing for dates
         </span>
          
         <span
-          className="sc-uJMKN hvlSKg"
+          className="sc-gGBfsJ cwcERw"
         >
           Invalid date
            to 
@@ -3733,7 +3733,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
       </span>
     </span>
     <section
-      className="sc-kvZOFW hTJQjW"
+      className="sc-jbKcbu dnDUoT"
     >
       <h2
         style={
@@ -3942,10 +3942,10 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <span
-          className="sc-dNLxif gQUAVc"
+          className="sc-uJMKN gdNjKI"
         >
           <span
-            className="sc-hqyNC dRNKrH"
+            className="sc-dNLxif fLSJyM"
           >
             Showing for accounts
           </span>
@@ -4023,7 +4023,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
             </div>
           </div>
           <span
-            className="sc-jbKcbu iuRTvb"
+            className="sc-jqCOkK laZUyd"
           >
             Buffer
           </span>

--- a/packages/report/components/ChartFactory/index.jsx
+++ b/packages/report/components/ChartFactory/index.jsx
@@ -9,6 +9,7 @@ import { Table as AverageTable, Title as AverageTitle } from '@bufferapp/average
 import { Title as ContextualTitle } from '@bufferapp/contextual-compare';
 import { Table as PostsTable, Title as PostsTitle } from '@bufferapp/posts-table';
 import { Chart as CompareChart, Title as CompareTitle } from '@bufferapp/compare-chart';
+import { Title as AudienceTitle } from '@bufferapp/audience-chart';
 import {
   CommonChart,
   ProfileBadge,
@@ -41,6 +42,10 @@ const CHARTS = {
   compare: {
     chart: CompareChart,
     title: CompareTitle,
+  },
+  audience: {
+    chart: CommonChart,
+    title: AudienceTitle,
   },
 };
 

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -25,6 +25,7 @@
     "@bufferapp/analyze-shared-components": "^0.40.4",
     "@bufferapp/average-table": "^0.41.0",
     "@bufferapp/compare-chart": "^0.41.0",
+    "@bufferapp/audience-chart": "^0.41.0",
     "@bufferapp/components": "2.1.1",
     "@bufferapp/contextual-compare": "^0.41.0",
     "@bufferapp/posts-summary-table": "^0.41.0",

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -11,13 +11,15 @@ const RPC_ENDPOINTS = {
   audience: require('../audience'), // eslint-disable-line global-require
 };
 
-const requestChartData = (chart, startDate, endDate, session) =>
-  RPC_ENDPOINTS[chart.chart_id].fn(Object.assign({
+function requestChartData (chart, startDate, endDate, session) {
+  if (RPC_ENDPOINTS[chart.chart_id] === undefined) return;
+  return RPC_ENDPOINTS[chart.chart_id].fn(Object.assign({
     profileId: chart.profile_id,
     profileService: chart.service,
     startDate,
     endDate,
   }, chart.state), { session });
+}
 
 module.exports = method(
   'get_report',
@@ -36,16 +38,17 @@ module.exports = method(
         .all(report.charts.map(chart => requestChartData(chart, startDate, endDate, session)))
         .then(chartMetrics =>
           Object.assign(report, {
-            charts: report.charts.map((chart, index) => {
-              if (!Array.isArray(chartMetrics[index])) {
-                return Object.assign(chart, chart.state, chartMetrics[index]);
-              }
-              return Object.assign(chart, {
-                metrics: chartMetrics[index],
-              });
-            }),
+            charts: report.charts
+              .map((chart, index) => {
+                if (!Array.isArray(chartMetrics[index])) {
+                  return Object.assign(chart, chart.state, chartMetrics[index]);
+                }
+                return Object.assign(chart, {
+                  metrics: chartMetrics[index],
+                });
+              })
+              .filter(chart => RPC_ENDPOINTS[chart.chart_id] !== undefined),
           })),
-    )
-  ,
+    ),
 );
 

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -8,6 +8,7 @@ const RPC_ENDPOINTS = {
   posts: require('../posts'), // eslint-disable-line global-require
   'contextual-compare': require('../contextual'), // eslint-disable-line global-require
   compare: require('../compare'), // eslint-disable-line global-require
+  audience: require('../audience'), // eslint-disable-line global-require
 };
 
 const requestChartData = (chart, startDate, endDate, session) =>


### PR DESCRIPTION
### Purpose
To fix Instagram _Engagement and audience_ chart in reports, and prevent missing charts from breaking the reports.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
