### PR TITLE
remove compare link from Dashboar welcome

### DIFF
--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -1147,28 +1147,9 @@ exports[`Snapshots App should render application 1`] = `
                   >
                     Instagram Profiles
                   </a>
-                  . You can also 
-                  <a
-                    href="/comparisons"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    style={
-                      Object {
-                        "color": "#168eea",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "outline": "none",
-                        "padding": "0",
-                        "textDecoration": "none",
-                      }
-                    }
-                    target="_self"
-                  >
-                    compare profiles
-                  </a>
-                   or view 
+                  .
+                  <br />
+                  You can also view 
                   <a
                     href="/reports"
                     onBlur={[Function]}

--- a/packages/web/components/DefaultPage/index.jsx
+++ b/packages/web/components/DefaultPage/index.jsx
@@ -76,7 +76,8 @@ const DefaultPage = ({ location, dispatch, facebookProfile, twitterProfile, inst
   const welcomeText = (
     <span>
       Get started by viewing Insights for {facebookLink}, {twitterLink} or {instagramLink}.
-      You can also {comparisonsLink} or view {reportsLink}.
+      <br />
+      You can also view {reportsLink}.
     </span>
   );
 


### PR DESCRIPTION
### Purpose
To hide the Comparison link from users till we polished it

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
