### PR TITLE
Batch performance tracker RPC requests

### DIFF
--- a/packages/performance-tracking/middleware.js
+++ b/packages/performance-tracking/middleware.js
@@ -6,11 +6,20 @@ import {
 
 import { actionTypes, actions } from './reducer';
 
-export const storeMeasure = dispatch => (data) => {
+const pendingMeasures = [];
+let rpcCallTimeout;
+
+function sendMeasuresToRPC (dispatch) {
   dispatch(fetchActions.fetch({
     name: 'performance',
-    args: { data },
+    args: { measures: pendingMeasures.splice(0, pendingMeasures.length) },
   }));
+}
+
+export const storeMeasure = dispatch => (measure) => {
+  pendingMeasures.push(measure);
+  if (rpcCallTimeout) clearTimeout(rpcCallTimeout);
+  rpcCallTimeout = setTimeout(sendMeasuresToRPC, 10000, dispatch);
 };
 
 function actionTypeRegExp(actionType) {

--- a/packages/server/rpc/performanceTracking/index.js
+++ b/packages/server/rpc/performanceTracking/index.js
@@ -6,18 +6,21 @@ const dogstatsd = new StatsD('dd-agent.default');
 module.exports = method(
   'performance',
   'track performance',
-  ({ data }) => {
-    if (!data.tags) data.tags = [];
-    if (!data.name) throw createError({ message: 'can\'t save a measure without a valid data.name' });
-    if (!data.duration) throw createError({ message: 'can\'t save a measure without a valid data.duration' });
-    data.tags.push('app:analyze');
-    data.name = `buffer.perf.${data.name}`;
+  ({ measures }) => {
+    const processedMeasures = measures.map((data) => {
+      if (!data.tags) data.tags = [];
+      if (!data.name) throw createError({ message: 'can\'t save a measure without a valid data.name' });
+      if (!data.duration) throw createError({ message: 'can\'t save a measure without a valid data.duration' });
+      data.tags.push('app:analyze');
+      data.name = `buffer.perf.${data.name}`;
 
-    dogstatsd.histogram(
-      data.name,
-      data.duration,
-      1,
-      data.tags,
-    );
-    return data;
+      dogstatsd.histogram(
+        data.name,
+        data.duration,
+        1,
+        data.tags,
+      );
+      return data;
+    });
+    return processedMeasures;
   });

--- a/packages/server/rpc/performanceTracking/index.js
+++ b/packages/server/rpc/performanceTracking/index.js
@@ -1,4 +1,4 @@
-const { method } = require('@bufferapp/micro-rpc');
+const { method, createError } = require('@bufferapp/micro-rpc');
 const StatsD = require('node-dogstatsd').StatsD;
 
 const dogstatsd = new StatsD('dd-agent.default');
@@ -8,6 +8,8 @@ module.exports = method(
   'track performance',
   ({ data }) => {
     if (!data.tags) data.tags = [];
+    if (!data.name) throw createError({ message: 'can\'t save a measure without a valid data.name' });
+    if (!data.duration) throw createError({ message: 'can\'t save a measure without a valid data.duration' });
     data.tags.push('app:analyze');
     data.name = `buffer.perf.${data.name}`;
 


### PR DESCRIPTION
### Purpose
To make sure performance tracking is not interfering with network performances.

### Notes
**This sends out all the measures every 10 seconds**. I think this is a good balance between getting the data and making sure we are not interfering with the main RPC requests.

Given this interval, there is a chance we might lose some measures toward the end of the navigation, but for the cases, we are using the tracking at the moment I doubt this will be a concern, and we can always revisit the interval if needed :smile: .

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
