### PR TITLE
Get Analyze-only social accounts

### DIFF
--- a/packages/profile-loader/middleware.js
+++ b/packages/profile-loader/middleware.js
@@ -1,10 +1,13 @@
-import { actions as asyncDataFetchActions } from '@bufferapp/async-data-fetch';
+import { actions, actionTypes } from '@bufferapp/async-data-fetch';
 
 export default ({ dispatch }) => next => (action) => {
   switch (action.type) {
-    case 'APP_INIT':
-      dispatch(asyncDataFetchActions.fetch({
+    case `user_${actionTypes.FETCH_SUCCESS}`:
+      dispatch(actions.fetch({
         name: 'profiles',
+        args: {
+          id: action.result.id,
+        },
       }));
       break;
     default:

--- a/packages/profile-loader/middleware.test.js
+++ b/packages/profile-loader/middleware.test.js
@@ -1,4 +1,4 @@
-import { actions } from '@bufferapp/async-data-fetch';
+import { actions, actionTypes } from '@bufferapp/async-data-fetch';
 import middleware from './middleware';
 
 describe('middleware', () => {
@@ -20,11 +20,17 @@ describe('middleware', () => {
 
   it('should dispatch the data fetch action for fetching the profiles once app has been initialized', () => {
     const action = {
-      type: 'APP_INIT',
+      type: `user_${actionTypes.FETCH_SUCCESS}`,
+      result: {
+        id: 'user_id-1234',
+      },
     };
     middleware(store)(next)(action);
     expect(store.dispatch).toHaveBeenCalledWith(actions.fetch({
       name: 'profiles',
+      args: {
+        id: 'user_id-1234',
+      },
     }));
     expect(next).toHaveBeenCalledWith(action);
   });

--- a/packages/profile-loader/package.json
+++ b/packages/profile-loader/package.json
@@ -7,7 +7,8 @@
     "start": "start-storybook -p 9001",
     "lint": "eslint . --ignore-pattern coverage node_modules",
     "test": "yarn run lint && sh ../../package_test.sh",
-    "test-update": "jest -u"
+    "test-update": "jest -u",
+    "test-watch": "jest --watch"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/server/rpc/profiles/index.js
+++ b/packages/server/rpc/profiles/index.js
@@ -5,17 +5,15 @@ const profileParser = require('../utils/profileParser');
 module.exports = method(
   'profiles',
   'fetch profiles',
-  (_, { session }) =>
+  ({ id }, { session }) =>
     rp({
-      uri: `${process.env.API_ADDR}/1/profiles.json`,
+      uri: `${process.env.API_ADDR}/1/analyze/users/${id}/get_social_accounts.json`,
       method: 'GET',
       strictSSL: !(process.env.NODE_ENV === 'development'),
       qs: {
         access_token: session.analyze.accessToken,
-        subprofiles: true,
-        locked: true,
       },
     })
       .then(result => JSON.parse(result))
-      .then(profiles => profiles.map(profileParser)),
+      .then(({ profiles }) => profiles.map(profileParser)),
 );

--- a/packages/server/rpc/utils/profileParser.js
+++ b/packages/server/rpc/utils/profileParser.js
@@ -1,6 +1,6 @@
 module.exports = profile => ({
-  id: profile.id,
-  avatarUrl: profile.avatar,
+  id: profile._id,
+  avatarUrl: profile.avatar_url,
   service: profile.service,
   timezone: profile.timezone,
   username: profile.service_username,


### PR DESCRIPTION
### Purpose

To display only social accounts enabled for Analyze.

### Notes

Hey @tiggreen - ended up making a direct request to `get_social_accounts.json` to simplify the process for now. I feel that when this is more mature we'll just be able to move that endpoint from `web` to our API :)