### PR TITLE
get_report returns profile information for each chart

### DIFF
--- a/packages/report/middleware.js
+++ b/packages/report/middleware.js
@@ -1,5 +1,5 @@
 import { LOCATION_CHANGE } from 'react-router-redux';
-import { actions, actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
+import { actions } from '@bufferapp/async-data-fetch';
 import { actionTypes as dateActionTypes } from '@bufferapp/analyze-date-picker';
 import { actionTypes as listActionTypes } from '@bufferapp/report-list';
 import { actionTypes } from './reducer';
@@ -18,27 +18,11 @@ const isExportRoute = pathname => pathname.match(/export\/reports/) !== null;
 const getReport = (reportId, reports) =>
   reports.find(report => report._id === reportId);
 
-const addProfileInformationToCharts = (charts, state) =>
-  charts.map(chart => ({
-    ...chart,
-    profile: state.profiles.profiles.find(profile =>
-      profile.id === chart.profile_id),
-  }));
-
 export default store => next => (action) => { // eslint-disable-line no-unused-vars
   const state = store.getState();
   let formatter;
   let report;
   switch (action.type) {
-    case `get_report_${asyncDataFetchActionTypes.FETCH_SUCCESS}`:
-      action = {
-        ...action,
-        result: {
-          ...action.result,
-          charts: addProfileInformationToCharts(action.result.charts, state),
-        },
-      };
-      break;
     case dateActionTypes.SET_DATE_RANGE:
       if (!isExportRoute(state.router.location.pathname)) {
         store.dispatch(actions.fetch({

--- a/packages/report/middleware.test.js
+++ b/packages/report/middleware.test.js
@@ -1,5 +1,5 @@
 import { actionTypes as dateActionTypes } from '@bufferapp/analyze-date-picker';
-import { actions, actionTypes as asyncDataFetchActions } from '@bufferapp/async-data-fetch';
+import { actions } from '@bufferapp/async-data-fetch';
 import { actionTypes as listActionTypes } from '@bufferapp/report-list';
 import { LOCATION_CHANGE } from 'react-router-redux';
 import { actionTypes } from './reducer';
@@ -118,35 +118,6 @@ describe('middleware', () => {
         endDate: state.date.endDate,
       },
     }));
-  });
-
-  it('fills profile information for each retrieved chart', () => {
-    const action = {
-      type: `get_report_${asyncDataFetchActions.FETCH_SUCCESS}`,
-      result: {
-        charts: [{
-          chart_id: 'summary-table',
-          profile_id: 'profile1',
-          metrics: [],
-        }],
-      },
-    };
-    middleware(store)(next)(action);
-    expect(next).toHaveBeenCalledWith({
-      type: action.type,
-      result: {
-        charts: [{
-          chart_id: 'summary-table',
-          profile_id: 'profile1',
-          profile: {
-            id: 'profile1',
-            username: 'profile_username_1',
-            service: 'foo',
-          },
-          metrics: [],
-        }],
-      },
-    });
   });
 
   it('SAVE_CHANGES dispatches a update report request', () => {

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -1,5 +1,6 @@
 const rp = require('request-promise');
 const { method } = require('@bufferapp/micro-rpc');
+const profileParser = require('../utils/profileParser');
 
 const RPC_ENDPOINTS = {
   'summary-table': require('../summary'), // eslint-disable-line global-require
@@ -40,6 +41,7 @@ module.exports = method(
           Object.assign(report, {
             charts: report.charts
               .map((chart, index) => {
+                chart.profile = profileParser(chart.profile);
                 if (!Array.isArray(chartMetrics[index])) {
                   return Object.assign(chart, chart.state, chartMetrics[index]);
                 }

--- a/packages/server/rpc/getReport/index.test.js
+++ b/packages/server/rpc/getReport/index.test.js
@@ -25,16 +25,34 @@ describe('rpc/get_report', () => {
         chart_id: 'summary-table',
         profile_id: '12351wa',
         service: 'facebook',
+        profile: {
+          _id: '12351wa',
+          service: 'facebook',
+          avatar_url: 'https://avatar.url',
+          service_username: 'Buffer',
+        },
       },
       {
         chart_id: 'deprecated-chart',
         profile_id: '12351wa',
         service: 'facebook',
+        profile: {
+          _id: '12351wa',
+          service: 'facebook',
+          avatar_url: 'https://avatar.url',
+          service_username: 'Buffer',
+        },
       },
       {
         chart_id: 'summary-table',
         profile_id: '12351xa',
         service: 'facebook',
+        profile: {
+          _id: '12351wa',
+          service: 'facebook',
+          avatar_url: 'https://avatar.url',
+          service_username: 'Buffer',
+        },
       },
     ],
   };


### PR DESCRIPTION
### Purpose

To reuse profile information fetched directly from the backend. This removes our need to reconcile information between the charts and local profile state.