### PR TITLE
Fix comparison state inconsistencies in loading states and navigating back and forth to the comparison tool

### DIFF
--- a/packages/audience-comparison-chart/reducer.js
+++ b/packages/audience-comparison-chart/reducer.js
@@ -26,7 +26,6 @@ export default (state = initialState, action) => {
       }
       return {
         ...state,
-        loading: false,
       };
     default:
       return state;

--- a/packages/audience-comparison-chart/reducer.test.js
+++ b/packages/audience-comparison-chart/reducer.test.js
@@ -82,7 +82,6 @@ describe('reducer', () => {
       .toEqual(Object.assign({}, {
         profilesMetricData: [1, 2, 3],
         profileTotals: [5, 6, 7],
-        loading: false,
       }));
   });
 });

--- a/packages/comments-comparison-chart/reducer.js
+++ b/packages/comments-comparison-chart/reducer.js
@@ -26,7 +26,6 @@ export default (state = initialState, action) => {
       }
       return {
         ...state,
-        loading: false,
       };
     default:
       return state;

--- a/packages/comments-comparison-chart/reducer.test.js
+++ b/packages/comments-comparison-chart/reducer.test.js
@@ -86,7 +86,6 @@ describe('reducer', () => {
         {
           profilesMetricData: [1, 2, 3],
           profileTotals: [5, 6, 7],
-          loading: false,
         },
       ),
     );

--- a/packages/engagement-comparison-chart/reducer.js
+++ b/packages/engagement-comparison-chart/reducer.js
@@ -26,7 +26,6 @@ export default (state = initialState, action) => {
       }
       return {
         ...state,
-        loading: false,
       };
     default:
       return state;

--- a/packages/engagement-comparison-chart/reducer.test.js
+++ b/packages/engagement-comparison-chart/reducer.test.js
@@ -82,7 +82,6 @@ describe('reducer', () => {
       .toEqual(Object.assign({}, {
         profilesMetricData: [1, 2, 3],
         profileTotals: [5, 6, 7],
-        loading: false,
       }));
   });
 });

--- a/packages/likes-comparison-chart/reducer.js
+++ b/packages/likes-comparison-chart/reducer.js
@@ -26,7 +26,6 @@ export default (state = initialState, action) => {
       }
       return {
         ...state,
-        loading: false,
       };
     default:
       return state;

--- a/packages/likes-comparison-chart/reducer.test.js
+++ b/packages/likes-comparison-chart/reducer.test.js
@@ -82,7 +82,6 @@ describe('reducer', () => {
       .toEqual(Object.assign({}, {
         profilesMetricData: [1, 2, 3],
         profileTotals: [5, 6, 7],
-        loading: false,
       }));
   });
 });

--- a/packages/reach-comparison-chart/reducer.js
+++ b/packages/reach-comparison-chart/reducer.js
@@ -26,7 +26,6 @@ export default (state = initialState, action) => {
       }
       return {
         ...state,
-        loading: false,
       };
     default:
       return state;

--- a/packages/reach-comparison-chart/reducer.test.js
+++ b/packages/reach-comparison-chart/reducer.test.js
@@ -82,7 +82,6 @@ describe('reducer', () => {
       .toEqual(Object.assign({}, {
         profilesMetricData: [1, 2, 3],
         profileTotals: [5, 6, 7],
-        loading: false,
       }));
   });
 });

--- a/packages/shared-components/ComparisonChart/chartConfig.jsx
+++ b/packages/shared-components/ComparisonChart/chartConfig.jsx
@@ -23,7 +23,7 @@ export function truncateNumber() {
   return number;
 }
 
-export const highChartsConfigXAxis = {
+export const getXAxis = () => ({
   gridLineColor: '#F3F5F7',
   gridLineWidth: 1,
   lineColor: '#E6EBEF',
@@ -43,9 +43,9 @@ export const highChartsConfigXAxis = {
       'font-weight': 'lighter',
     },
   },
-};
+});
 
-export const highChartsConfigYAxis = [
+export const getYAxis = () => ([
   {
     title: { text: null },
     gridLineWidth: 1,
@@ -98,7 +98,7 @@ export const highChartsConfigYAxis = [
     },
     opposite: true,
   },
-];
+]);
 
 export const highChartsSeriesPrimaryConfig = {
   type: 'areaspline',
@@ -111,10 +111,10 @@ export const highChartsSeriesPrimaryConfig = {
   data: null,
 };
 
-export default {
+export default () => ({
   title: null,
-  xAxis: highChartsConfigXAxis,
-  yAxis: highChartsConfigYAxis,
+  xAxis: getXAxis(),
+  yAxis: getYAxis(),
   chart: {
     marginLeft: 20,
     marginRight: 20,
@@ -156,4 +156,4 @@ export default {
     useHTML: true,
   },
   series: [],
-};
+});

--- a/packages/shared-components/ComparisonChart/index.jsx
+++ b/packages/shared-components/ComparisonChart/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactHighcharts from 'react-highcharts';
 import moment from 'moment-timezone';
 
-import chartConfig, { highChartsSeriesPrimaryConfig } from './chartConfig';
+import getChartConfig, { highChartsSeriesPrimaryConfig } from './chartConfig';
 
 function getMarkerFillColor(color) {
   const highchartColor = ReactHighcharts.Highcharts.Color(color);
@@ -98,7 +98,7 @@ function prepareSeries(
 }
 
 function prepareChartOptions(profilesMetricData) {
-  const config = Object.assign({}, chartConfig);
+  const config = getChartConfig();
   const seriesData = profilesMetricData.map(profileData =>
     prepareSeries(profileData.dailyData, profileData.timezone, profileData.service),
   );


### PR DESCRIPTION
### Purpose

Comparison charts should only stop loading when their metric has been fetched. This also tweaks the way we generate the `highchartsConfig` for these charts to prevent race conditions and state overwriting between charts.