### PR TITLE
Fix contextual tooltip hover on Firefox

### DIFF
--- a/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
+++ b/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
@@ -1631,7 +1631,11 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                         <li
                           style={
                             Object {
+                              "display": "flex",
+                              "justifyContent": "space-between",
                               "listStyle": "none",
+                              "padding": "5px 10px",
+                              "position": "relative",
                             }
                           }
                         >
@@ -1669,7 +1673,6 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 Object {
                                   "boxSizing": "border-box",
                                   "display": "inline-flex",
-                                  "padding": "5px 10px",
                                   "textAlign": "left",
                                   "width": "100%",
                                 }
@@ -1688,19 +1691,23 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 How does post frequency affect my fan count?
                                  
                               </span>
-                              <span
-                                className="sc-kAzzGY jLLAkG"
-                                data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
-                              >
-                                ?
-                              </span>
                             </span>
                           </button>
+                          <span
+                            className="sc-kAzzGY dweAdK"
+                            data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
+                          >
+                            ?
+                          </span>
                         </li>
                         <li
                           style={
                             Object {
+                              "display": "flex",
+                              "justifyContent": "space-between",
                               "listStyle": "none",
+                              "padding": "5px 10px",
+                              "position": "relative",
                             }
                           }
                         >
@@ -1738,7 +1745,6 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 Object {
                                   "boxSizing": "border-box",
                                   "display": "inline-flex",
-                                  "padding": "5px 10px",
                                   "textAlign": "left",
                                   "width": "100%",
                                 }
@@ -1769,19 +1775,23 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                               >
                                   (no data) 
                               </span>
-                              <span
-                                className="sc-kAzzGY jLLAkG"
-                                data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
-                              >
-                                ?
-                              </span>
                             </span>
                           </button>
+                          <span
+                            className="sc-kAzzGY dweAdK"
+                            data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
+                          >
+                            ?
+                          </span>
                         </li>
                         <li
                           style={
                             Object {
+                              "display": "flex",
+                              "justifyContent": "space-between",
                               "listStyle": "none",
+                              "padding": "5px 10px",
+                              "position": "relative",
                             }
                           }
                         >
@@ -1819,7 +1829,6 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 Object {
                                   "boxSizing": "border-box",
                                   "display": "inline-flex",
-                                  "padding": "5px 10px",
                                   "textAlign": "left",
                                   "width": "100%",
                                 }
@@ -1838,14 +1847,14 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 How does post  affect te reach per post?
                                  
                               </span>
-                              <span
-                                className="sc-kAzzGY jLLAkG"
-                                data-description="Discover how your posting frequency affects your fan count."
-                              >
-                                ?
-                              </span>
                             </span>
                           </button>
+                          <span
+                            className="sc-kAzzGY dweAdK"
+                            data-description="Discover how your posting frequency affects your fan count."
+                          >
+                            ?
+                          </span>
                         </li>
                       </ol>
                     </div>
@@ -2178,7 +2187,11 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                         <li
                           style={
                             Object {
+                              "display": "flex",
+                              "justifyContent": "space-between",
                               "listStyle": "none",
+                              "padding": "5px 10px",
+                              "position": "relative",
                             }
                           }
                         >
@@ -2216,7 +2229,6 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 Object {
                                   "boxSizing": "border-box",
                                   "display": "inline-flex",
-                                  "padding": "5px 10px",
                                   "textAlign": "left",
                                   "width": "100%",
                                 }
@@ -2235,19 +2247,23 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 How does post frequency affect my fan count?
                                  
                               </span>
-                              <span
-                                className="sc-kAzzGY jLLAkG"
-                                data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
-                              >
-                                ?
-                              </span>
                             </span>
                           </button>
+                          <span
+                            className="sc-kAzzGY dweAdK"
+                            data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
+                          >
+                            ?
+                          </span>
                         </li>
                         <li
                           style={
                             Object {
+                              "display": "flex",
+                              "justifyContent": "space-between",
                               "listStyle": "none",
+                              "padding": "5px 10px",
+                              "position": "relative",
                             }
                           }
                         >
@@ -2285,7 +2301,6 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 Object {
                                   "boxSizing": "border-box",
                                   "display": "inline-flex",
-                                  "padding": "5px 10px",
                                   "textAlign": "left",
                                   "width": "100%",
                                 }
@@ -2316,19 +2331,23 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                               >
                                   (no data) 
                               </span>
-                              <span
-                                className="sc-kAzzGY jLLAkG"
-                                data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
-                              >
-                                ?
-                              </span>
                             </span>
                           </button>
+                          <span
+                            className="sc-kAzzGY dweAdK"
+                            data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
+                          >
+                            ?
+                          </span>
                         </li>
                         <li
                           style={
                             Object {
+                              "display": "flex",
+                              "justifyContent": "space-between",
                               "listStyle": "none",
+                              "padding": "5px 10px",
+                              "position": "relative",
                             }
                           }
                         >
@@ -2366,7 +2385,6 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 Object {
                                   "boxSizing": "border-box",
                                   "display": "inline-flex",
-                                  "padding": "5px 10px",
                                   "textAlign": "left",
                                   "width": "100%",
                                 }
@@ -2385,14 +2403,14 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                                 How does post  affect te reach per post?
                                  
                               </span>
-                              <span
-                                className="sc-kAzzGY jLLAkG"
-                                data-description="Discover how your posting frequency affects your fan count."
-                              >
-                                ?
-                              </span>
                             </span>
                           </button>
+                          <span
+                            className="sc-kAzzGY dweAdK"
+                            data-description="Discover how your posting frequency affects your fan count."
+                          >
+                            ?
+                          </span>
                         </li>
                       </ol>
                     </div>
@@ -2951,7 +2969,11 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
             <li
               style={
                 Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
                   "listStyle": "none",
+                  "padding": "5px 10px",
+                  "position": "relative",
                 }
               }
             >
@@ -2989,7 +3011,6 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                     Object {
                       "boxSizing": "border-box",
                       "display": "inline-flex",
-                      "padding": "5px 10px",
                       "textAlign": "left",
                       "width": "100%",
                     }
@@ -3008,19 +3029,23 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                     How does post frequency affect my fan count?
                      
                   </span>
-                  <span
-                    className="sc-kAzzGY jLLAkG"
-                    data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
-                  >
-                    ?
-                  </span>
                 </span>
               </button>
+              <span
+                className="sc-kAzzGY dweAdK"
+                data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
+              >
+                ?
+              </span>
             </li>
             <li
               style={
                 Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
                   "listStyle": "none",
+                  "padding": "5px 10px",
+                  "position": "relative",
                 }
               }
             >
@@ -3058,7 +3083,6 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                     Object {
                       "boxSizing": "border-box",
                       "display": "inline-flex",
-                      "padding": "5px 10px",
                       "textAlign": "left",
                       "width": "100%",
                     }
@@ -3089,19 +3113,23 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                   >
                       (no data) 
                   </span>
-                  <span
-                    className="sc-kAzzGY jLLAkG"
-                    data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
-                  >
-                    ?
-                  </span>
                 </span>
               </button>
+              <span
+                className="sc-kAzzGY dweAdK"
+                data-description="Already it was conjectured that this might be the well-known interplan industrialist Palmer Eldritch, who had gone to the Prox system a decade ago at the invitation of the Prox Council of humanoid types; they had wanted him to modernize their autofacs along Terran lines. Nothing had been heard from Eldritch since. Now this."
+              >
+                ?
+              </span>
             </li>
             <li
               style={
                 Object {
+                  "display": "flex",
+                  "justifyContent": "space-between",
                   "listStyle": "none",
+                  "padding": "5px 10px",
+                  "position": "relative",
                 }
               }
             >
@@ -3139,7 +3167,6 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                     Object {
                       "boxSizing": "border-box",
                       "display": "inline-flex",
-                      "padding": "5px 10px",
                       "textAlign": "left",
                       "width": "100%",
                     }
@@ -3158,14 +3185,14 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
                     How does post  affect te reach per post?
                      
                   </span>
-                  <span
-                    className="sc-kAzzGY jLLAkG"
-                    data-description="Discover how your posting frequency affects your fan count."
-                  >
-                    ?
-                  </span>
                 </span>
               </button>
+              <span
+                className="sc-kAzzGY dweAdK"
+                data-description="Discover how your posting frequency affects your fan count."
+              >
+                ?
+              </span>
             </li>
           </ol>
         </div>

--- a/packages/contextual-compare/components/PresetsDropdown/List.jsx
+++ b/packages/contextual-compare/components/PresetsDropdown/List.jsx
@@ -21,12 +21,13 @@ const HelpButton = styled.span`
   text-align: center;
   border-radius: 8px;
   cursor: pointer;
+  // position: relative;
 
   &::before {
     transition: opacity 250ms ease-out;
     content: " ";
     position: absolute;
-    margin-left: 14px;
+    right: 0;
     width: 0;
     height: 0;
     border-style: solid;
@@ -39,8 +40,8 @@ const HelpButton = styled.span`
     transition: opacity 250ms ease-out;
     content: attr(data-description);
     position: absolute;
-    margin-left: 14px;
-    margin-top: -10px;
+    top: -2px;
+    left: calc(100% - 2px);
     background: #343E46;
     border-radius: 4px;
     width: 175px;
@@ -62,13 +63,16 @@ const HelpButton = styled.span`
 
 const dropdownItem = {
   listStyle: 'none',
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '5px 10px',
+  position: 'relative',
 };
 
 const dropdownItemContent = {
   width: '100%',
   display: 'inline-flex',
   textAlign: 'left',
-  padding: '5px 10px',
   boxSizing: 'border-box',
 };
 
@@ -85,9 +89,9 @@ const DropdownItem = ({ preset, handleClick, selectedPresetLabel }) => (
           size="small"
         > &nbsp;(no data) </Text>}
 
-        <HelpButton data-description={preset.description}>?</HelpButton>
       </span>
     </Button>
+    <HelpButton data-description={preset.description}>?</HelpButton>
   </li>
 );
 


### PR DESCRIPTION
### Purpose

To ensure tooltips appear, I've moved the whole HelpButton to be a sibling of the preset button, since some browsers don't play nicely with different hover events inside a Button :)