### PR TITLE
Comparisons Charts multi profiles tool-tip 

### DIFF
--- a/packages/audience-comparison-chart/mocks/dailyData.js
+++ b/packages/audience-comparison-chart/mocks/dailyData.js
@@ -4,7 +4,7 @@ export default [
       {
         day: 1504137600000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 50,
           color: '#fda3f3',
         },
@@ -12,7 +12,7 @@ export default [
       {
         day: 1504224000000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 100,
           color: '#fda3f3',
         },
@@ -20,7 +20,7 @@ export default [
       {
         day: 1504310400000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 150,
           color: '#fda3f3',
         },
@@ -28,7 +28,7 @@ export default [
       {
         day: 1504396800000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 200,
           color: '#fda3f3',
         },
@@ -36,7 +36,7 @@ export default [
       {
         day: 1504483200000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 300,
           color: '#fda3f3',
         },
@@ -44,7 +44,7 @@ export default [
       {
         day: 1504569600000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 400,
           color: '#fda3f3',
         },
@@ -52,7 +52,7 @@ export default [
       {
         day: 1504656000000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 450,
           color: '#fda3f3',
         },
@@ -62,13 +62,14 @@ export default [
     currentPeriodDiff: 23,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
   {
     dailyData: [
       {
         day: 1504137600000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 200,
           color: '#A3C6FD',
         },
@@ -76,7 +77,7 @@ export default [
       {
         day: 1504224000000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 100,
           color: '#A3C6FD',
         },
@@ -84,7 +85,7 @@ export default [
       {
         day: 1504310400000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 500,
           color: '#A3C6FD',
         },
@@ -92,7 +93,7 @@ export default [
       {
         day: 1504396800000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 400,
           color: '#A3C6FD',
         },
@@ -100,7 +101,7 @@ export default [
       {
         day: 1504483200000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 800,
           color: '#A3C6FD',
         },
@@ -108,7 +109,7 @@ export default [
       {
         day: 1504569600000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 900,
           color: '#A3C6FD',
         },
@@ -116,7 +117,7 @@ export default [
       {
         day: 1504656000000,
         metric: {
-          label: 'Fans',
+          label: 'Likes',
           value: 600,
           color: '#A3C6FD',
         },
@@ -126,5 +127,6 @@ export default [
     currentPeriodDiff: 50,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
 ];

--- a/packages/comments-comparison-chart/mocks/dailyData.js
+++ b/packages/comments-comparison-chart/mocks/dailyData.js
@@ -62,6 +62,7 @@ export default [
     currentPeriodDiff: 23,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
   {
     dailyData: [
@@ -126,5 +127,6 @@ export default [
     currentPeriodDiff: 50,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
 ];

--- a/packages/engagement-comparison-chart/mocks/dailyData.js
+++ b/packages/engagement-comparison-chart/mocks/dailyData.js
@@ -4,7 +4,7 @@ export default [
       {
         day: 1504137600000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 50,
           color: '#fda3f3',
         },
@@ -12,7 +12,7 @@ export default [
       {
         day: 1504224000000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 100,
           color: '#fda3f3',
         },
@@ -20,7 +20,7 @@ export default [
       {
         day: 1504310400000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 150,
           color: '#fda3f3',
         },
@@ -28,7 +28,7 @@ export default [
       {
         day: 1504396800000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 200,
           color: '#fda3f3',
         },
@@ -36,7 +36,7 @@ export default [
       {
         day: 1504483200000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 300,
           color: '#fda3f3',
         },
@@ -44,7 +44,7 @@ export default [
       {
         day: 1504569600000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 400,
           color: '#fda3f3',
         },
@@ -52,7 +52,7 @@ export default [
       {
         day: 1504656000000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 450,
           color: '#fda3f3',
         },
@@ -62,13 +62,14 @@ export default [
     currentPeriodDiff: 23,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
   {
     dailyData: [
       {
         day: 1504137600000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 200,
           color: '#A3C6FD',
         },
@@ -76,7 +77,7 @@ export default [
       {
         day: 1504224000000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 100,
           color: '#A3C6FD',
         },
@@ -84,7 +85,7 @@ export default [
       {
         day: 1504310400000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 500,
           color: '#A3C6FD',
         },
@@ -92,7 +93,7 @@ export default [
       {
         day: 1504396800000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 400,
           color: '#A3C6FD',
         },
@@ -100,7 +101,7 @@ export default [
       {
         day: 1504483200000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 800,
           color: '#A3C6FD',
         },
@@ -108,7 +109,7 @@ export default [
       {
         day: 1504569600000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 900,
           color: '#A3C6FD',
         },
@@ -116,7 +117,7 @@ export default [
       {
         day: 1504656000000,
         metric: {
-          label: 'Engagement',
+          label: 'Likes',
           value: 600,
           color: '#A3C6FD',
         },
@@ -126,5 +127,6 @@ export default [
     currentPeriodDiff: 50,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
 ];

--- a/packages/likes-comparison-chart/mocks/dailyData.js
+++ b/packages/likes-comparison-chart/mocks/dailyData.js
@@ -62,6 +62,7 @@ export default [
     currentPeriodDiff: 23,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
   {
     dailyData: [
@@ -126,5 +127,6 @@ export default [
     currentPeriodDiff: 50,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
 ];

--- a/packages/reach-comparison-chart/mocks/dailyData.js
+++ b/packages/reach-comparison-chart/mocks/dailyData.js
@@ -4,7 +4,7 @@ export default [
       {
         day: 1504137600000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 50,
           color: '#fda3f3',
         },
@@ -12,7 +12,7 @@ export default [
       {
         day: 1504224000000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 100,
           color: '#fda3f3',
         },
@@ -20,7 +20,7 @@ export default [
       {
         day: 1504310400000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 150,
           color: '#fda3f3',
         },
@@ -28,7 +28,7 @@ export default [
       {
         day: 1504396800000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 200,
           color: '#fda3f3',
         },
@@ -36,7 +36,7 @@ export default [
       {
         day: 1504483200000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 300,
           color: '#fda3f3',
         },
@@ -44,7 +44,7 @@ export default [
       {
         day: 1504569600000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 400,
           color: '#fda3f3',
         },
@@ -52,7 +52,7 @@ export default [
       {
         day: 1504656000000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 450,
           color: '#fda3f3',
         },
@@ -62,13 +62,14 @@ export default [
     currentPeriodDiff: 23,
     service: 'facebook',
     timezone: 'America/New_York',
+    profileId: '1',
   },
   {
     dailyData: [
       {
         day: 1504137600000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 200,
           color: '#A3C6FD',
         },
@@ -76,7 +77,7 @@ export default [
       {
         day: 1504224000000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 100,
           color: '#A3C6FD',
         },
@@ -84,7 +85,7 @@ export default [
       {
         day: 1504310400000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 500,
           color: '#A3C6FD',
         },
@@ -92,7 +93,7 @@ export default [
       {
         day: 1504396800000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 400,
           color: '#A3C6FD',
         },
@@ -100,7 +101,7 @@ export default [
       {
         day: 1504483200000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 800,
           color: '#A3C6FD',
         },
@@ -108,7 +109,7 @@ export default [
       {
         day: 1504569600000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 900,
           color: '#A3C6FD',
         },
@@ -116,7 +117,7 @@ export default [
       {
         day: 1504656000000,
         metric: {
-          label: 'Impressions',
+          label: 'Likes',
           value: 600,
           color: '#A3C6FD',
         },
@@ -124,71 +125,8 @@ export default [
     ],
     currentPeriodTotal: 4000,
     currentPeriodDiff: 50,
-    service: 'twitter',
+    service: 'facebook',
     timezone: 'America/New_York',
-  },
-  {
-    dailyData: [
-      {
-        day: 1504137600000,
-        metric: {
-          label: 'Impressions',
-          value: 500,
-          color: '#A3C6FD',
-        },
-      },
-      {
-        day: 1504224000000,
-        metric: {
-          label: 'Impressions',
-          value: 1000,
-          color: '#A3C6FD',
-        },
-      },
-      {
-        day: 1504310400000,
-        metric: {
-          label: 'Impressions',
-          value: 2000,
-          color: '#A3C6FD',
-        },
-      },
-      {
-        day: 1504396800000,
-        metric: {
-          label: 'Impressions',
-          value: 2500,
-          color: '#A3C6FD',
-        },
-      },
-      {
-        day: 1504483200000,
-        metric: {
-          label: 'Impressions',
-          value: 2700,
-          color: '#A3C6FD',
-        },
-      },
-      {
-        day: 1504569600000,
-        metric: {
-          label: 'Impressions',
-          value: 2600,
-          color: '#A3C6FD',
-        },
-      },
-      {
-        day: 1504656000000,
-        metric: {
-          label: 'Impressions',
-          value: 3000,
-          color: '#A3C6FD',
-        },
-      },
-    ],
-    currentPeriodTotal: 2000,
-    currentPeriodDiff: 50,
-    service: 'instagram',
-    timezone: 'America/New_York',
+    profileId: '1',
   },
 ];

--- a/packages/server/rpc/comparison/index.js
+++ b/packages/server/rpc/comparison/index.js
@@ -87,7 +87,7 @@ function formatData(result, metricKey) {
   const profileIds = Object.keys(result);
   const profilesMetricData = Array.from(profileIds, (id) => {
     const data = result[id];
-    return data.profilesMetricData;
+    return Object.assign({ profileId: id }, data.profilesMetricData);
   });
 
   const profileTotals = Array.from(profileIds, (id) => {
@@ -107,8 +107,7 @@ function formatData(result, metricKey) {
           index,
         ),
       ),
-      service: data.service,
-      timezone,
+      profileId: data.profileId,
     };
   });
 

--- a/packages/server/rpc/comparison/mockResponse.js
+++ b/packages/server/rpc/comparison/mockResponse.js
@@ -120,8 +120,7 @@ export const rpcFinalResponse = {
           },
         },
       ],
-      service: 'facebook',
-      timezone: 'America/New_York',
+      profileId: 'profile1234',
     },
   ],
 };

--- a/packages/shared-components/ComparisonChart/chartConfig.jsx
+++ b/packages/shared-components/ComparisonChart/chartConfig.jsx
@@ -145,7 +145,7 @@ export default () => ({
     formatter() {
       const point = this.points[0].point;
       return reactDOM.renderToStaticMarkup(
-        <ChartTooltip {...point.metricData} day={point.x} />,
+        <ChartTooltip metrics={this.points.map(p => p.point.metricData)} day={point.x} />,
       );
     },
     backgroundColor: '#343E46',

--- a/packages/shared-components/ComparisonChart/index.jsx
+++ b/packages/shared-components/ComparisonChart/index.jsx
@@ -54,6 +54,7 @@ function prepareSeries(
   dailyMetric,
   timezone,
   profileService,
+  username,
 ) {
   let color = '#9B9FA3';
   const seriesData = Array.from(dailyMetric, (day) => {
@@ -71,6 +72,7 @@ function prepareSeries(
       metricData: Object.assign({}, day.metric, {
         profileService,
         timezone,
+        username,
       }),
       pointPlacement: getMinorTickInterval(dailyMetric),
       // set profile specific timezone
@@ -97,19 +99,25 @@ function prepareSeries(
   return seriesConfig;
 }
 
-function prepareChartOptions(profilesMetricData) {
+function prepareChartOptions(profilesMetricData, profiles) {
   const config = getChartConfig();
-  const seriesData = profilesMetricData.map(profileData =>
-    prepareSeries(profileData.dailyData, profileData.timezone, profileData.service),
-  );
+  const seriesData = profilesMetricData.map((profileData) => {
+    const profile = profiles.find(p => p.id === profileData.profileId);
+    return prepareSeries(
+      profileData.dailyData,
+      profile.timezone,
+      profile.service,
+      profile.username,
+    );
+  }, { profiles });
   config.series = seriesData.filter(e => e !== null);
   setChartLimits(config);
   return config;
 }
 
 const CHART_HEIGHT = '400px';
-const ComparisonChart = ({ profilesMetricData }) => {
-  const charOptions = prepareChartOptions(profilesMetricData);
+const ComparisonChart = ({ profilesMetricData, profiles }) => {
+  const charOptions = prepareChartOptions(profilesMetricData, profiles);
   return (<div style={{ minHeight: CHART_HEIGHT }}>
     <ReactHighcharts config={charOptions} />
   </div>);
@@ -125,6 +133,10 @@ ComparisonChart.propTypes = {
         value: PropTypes.number.isRequired,
       }),
     })),
+    profileId: PropTypes.string.isRequired,
+  })).isRequired,
+  profiles: PropTypes.arrayOf(PropTypes.shape({
+    profileId: PropTypes.string.isRequired,
     service: PropTypes.string.isRequired,
     timezone: PropTypes.string.isRequired,
   })).isRequired,

--- a/packages/shared-components/ComparisonChart/story.jsx
+++ b/packages/shared-components/ComparisonChart/story.jsx
@@ -5,6 +5,7 @@ import { ReportsStore } from '@bufferapp/analyze-decorators';
 
 import ComparisonChart from './index';
 import mockDailyData from '../mocks/compareDayData';
+import profiles from '../mocks/profiles';
 
 storiesOf('ComparisonChart')
   .addDecorator(checkA11y)
@@ -16,11 +17,17 @@ storiesOf('ComparisonChart')
       }}
     >
       <ComparisonChart
-        profilesMetricData={[{
-          service: 'twitter',
-          timezone: 'America/Los_Angeles',
-          dailyData: mockDailyData,
-        }]}
+        profilesMetricData={[
+          {
+            dailyData: mockDailyData,
+            profileId: '1',
+          },
+          {
+            dailyData: mockDailyData,
+            profileId: '2',
+          },
+        ]}
+        profiles={profiles}
       />
     </div>
   ));

--- a/packages/shared-components/ComparisonChartTooltip/index.jsx
+++ b/packages/shared-components/ComparisonChartTooltip/index.jsx
@@ -6,7 +6,7 @@ import { TruncatedNumber, MetricIcon } from '@bufferapp/analyze-shared-component
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  width: 185px;
+  width: 240px;
   padding: 10px;
   color: #fff;
   cursor: default;
@@ -14,35 +14,46 @@ const Wrapper = styled.div`
   font-family: Open Sans, Helvetica Neue, Helvetica, Arial, sans serif;
   pointer-events: none;
   white-space: normal;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 function transformLabelForTooltip(label) {
   return `${label.toLowerCase()}`;
 }
 
-const StandardTooltip = ({
-  label,
-  value,
-  color,
+const MetricEntry = ({
+  metric,
 }) => (
-  <span>
-    <Text color="white" size="small" weight="bold">
-      <MetricIcon metric={{ color }} /> <TruncatedNumber>{value}</TruncatedNumber>
+  <span
+    style={{
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      display: 'inline-box',
+    }}
+  >
+    <br />
+    <Text color="white" size="small" weight="bold" >
+      <MetricIcon metric={{ color: metric.color }} /> <TruncatedNumber>
+        {metric.value}
+      </TruncatedNumber>
     </Text>
-    <Text color="white" size="small" > {transformLabelForTooltip(label)}</Text>
+    <Text color="white" size="small" > {transformLabelForTooltip(metric.label)}</Text>
+    <Text color="white" size="small" > for </Text>
+    <Text color="white" size="small" weight="bold" > {metric.username} </Text>
   </span>
 );
 
-StandardTooltip.propTypes = {
-  label: PropTypes.string,
-  value: PropTypes.number,
-  color: PropTypes.string,
-};
-
-StandardTooltip.defaultProps = {
-  color: null,
-  label: null,
-  value: null,
+MetricEntry.propTypes = {
+  metric: PropTypes.shape({
+    color: PropTypes.string,
+    label: PropTypes.string,
+    username: PropTypes.string,
+    value: PropTypes.number,
+  }).isRequired,
 };
 
 const Header = ({
@@ -61,25 +72,24 @@ Header.propTypes = {
 
 const ComparisonChartTooltip = ({
   day,
-  label,
-  ...extraProps
+  metrics,
 }) => (
   <Wrapper>
-    <Header day={day} {...extraProps} />
-    {label &&
-      <span>
-        <StandardTooltip label={label} {...extraProps} />
-      </span>}
+    <Header day={day} />
+    <span>
+      {metrics.map(m => <MetricEntry key={m.username} metric={m} />)}
+    </span>
   </Wrapper>
 );
 
 ComparisonChartTooltip.propTypes = {
   day: PropTypes.number.isRequired,
-  label: PropTypes.string,
-};
-
-ComparisonChartTooltip.defaultProps = {
-  label: null,
+  metrics: PropTypes.arrayOf(PropTypes.shape({
+    color: PropTypes.string,
+    label: PropTypes.string,
+    username: PropTypes.string,
+    value: PropTypes.string,
+  })).isRequired,
 };
 
 export default ComparisonChartTooltip;

--- a/packages/shared-components/ComparisonChartTooltip/story.jsx
+++ b/packages/shared-components/ComparisonChartTooltip/story.jsx
@@ -12,14 +12,25 @@ storiesOf('ComparisonChartTooltip')
     <div
       style={{
         backgroundColor: '#343E46',
+        width: '185px',
       }}
     >
       <ComparisonChartTooltip
-        color="#fda3f3"
         day={dayTimestamp}
-        label="Fans"
-        value={143}
-        timezone="America/New_York"
+        metrics={[
+          {
+            color: '#fda3f3',
+            label: 'clicks',
+            username: 'foo',
+            value: 42,
+          },
+          {
+            color: '#fda3f3',
+            label: 'clicks',
+            username: 'Buffer very long name',
+            value: 42,
+          },
+        ]}
       />
     </div>
   ));

--- a/packages/shared-components/ComparisonChartWrapper/index.jsx
+++ b/packages/shared-components/ComparisonChartWrapper/index.jsx
@@ -31,6 +31,7 @@ const ComparisonChartWrapper = ({
       <div>
         <Chart
           profilesMetricData={profilesMetricData}
+          profiles={profiles}
         />
       </div>
     );

--- a/packages/shared-components/__snapshots__/snapshot.test.js.snap
+++ b/packages/shared-components/__snapshots__/snapshot.test.js.snap
@@ -926,11 +926,12 @@ exports[`Snapshots ComparisonChartTooltip should render the tooltip 1`] = `
     style={
       Object {
         "backgroundColor": "#343E46",
+        "width": "185px",
       }
     }
   >
     <div
-      className="sc-kAzzGY dcHRuz"
+      className="sc-kAzzGY bNdPJH"
     >
       <span>
         <span
@@ -949,7 +950,17 @@ exports[`Snapshots ComparisonChartTooltip should render the tooltip 1`] = `
         <br />
       </span>
       <span>
-        <span>
+        <span
+          style={
+            Object {
+              "display": "inline-box",
+              "overflow": "hidden",
+              "textOverflow": "ellipsis",
+              "whiteSpace": "nowrap",
+            }
+          }
+        >
+          <br />
           <span
             style={
               Object {
@@ -978,7 +989,7 @@ exports[`Snapshots ComparisonChartTooltip should render the tooltip 1`] = `
             />
              
             <span>
-              143
+              42
             </span>
           </span>
           <span
@@ -992,7 +1003,115 @@ exports[`Snapshots ComparisonChartTooltip should render the tooltip 1`] = `
             }
           >
              
-            fans
+            clicks
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             for 
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+             
+            foo
+             
+          </span>
+        </span>
+        <span
+          style={
+            Object {
+              "display": "inline-box",
+              "overflow": "hidden",
+              "textOverflow": "ellipsis",
+              "whiteSpace": "nowrap",
+            }
+          }
+        >
+          <br />
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "background": "#fda3f3",
+                  "borderColor": "#df85d5",
+                  "borderRadius": "10px",
+                  "borderStyle": "solid",
+                  "borderWidth": "1px",
+                  "display": "inline-block",
+                  "height": "7px",
+                  "marginRight": "5px",
+                  "verticalAlign": "baseline",
+                  "width": "7px",
+                }
+              }
+            />
+             
+            <span>
+              42
+            </span>
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             
+            clicks
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             for 
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+             
+            Buffer very long name
+             
           </span>
         </span>
       </span>


### PR DESCRIPTION
### Purpose
To show the data for all the selected profiles in the Comparison Chart tooltip.
BAN-68

![20180205_185805-screenshot](https://user-images.githubusercontent.com/992920/35839678-8c3c0722-0aa6-11e8-9d57-db83de526ef3.png)

### Notes
Similar to what we are doing in the footer, we are now using the `profiles` collection to extrapolate the profiles data.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
