### PR TITLE
Fix report export not selecting current date ranges

### DIFF
--- a/packages/report/middleware.js
+++ b/packages/report/middleware.js
@@ -19,19 +19,17 @@ export default store => next => (action) => { // eslint-disable-line no-unused-v
   let formatter;
   switch (action.type) {
     case dateActionTypes.SET_DATE_RANGE:
-      if (!isExportRoute(state.router.location.pathname)) {
-        store.dispatch(actions.fetch({
-          name: 'get_report',
-          args: {
-            _id: getReportId(state.router.location.pathname),
-            startDate: action.startDate,
-            endDate: action.endDate,
-          },
-        }));
-      }
+      store.dispatch(actions.fetch({
+        name: 'get_report',
+        args: {
+          _id: getReportId(state.router.location.pathname),
+          startDate: action.startDate,
+          endDate: action.endDate,
+        },
+      }));
       break;
     case LOCATION_CHANGE:
-      if (isReportDetailRoute(action.payload.pathname)) {
+      if (isReportDetailRoute(action.payload.pathname) && !isExportRoute(action.payload.pathname)) {
         store.dispatch(actions.fetch({
           name: 'get_report',
           args: {

--- a/packages/report/middleware.test.js
+++ b/packages/report/middleware.test.js
@@ -86,21 +86,6 @@ describe('middleware', () => {
       }));
       expect(next).toHaveBeenCalledWith(action);
     });
-
-    it('should not dispatch the data fetch if the view is an export view', () => {
-      state.router = {
-        location: {
-          pathname: '/export/reports/1234',
-        },
-      };
-      const action = {
-        type: dateActionTypes.SET_DATE_RANGE,
-        startDate: '10/10/2016',
-        endDate: '20/10/2016',
-      };
-      middleware(store)(next)(action);
-      expect(store.dispatch).not.toHaveBeenCalled();
-    });
   });
 
   it('SAVE_CHANGES dispatches a update report request', () => {
@@ -194,6 +179,17 @@ describe('middleware', () => {
           endDate: state.date.endDate,
         },
       }));
+    });
+
+    it('should not dispatch the data fetch if the view is an export view', () => {
+      const action = {
+        type: LOCATION_CHANGE,
+        payload: {
+          pathname: '/export/reports/1234',
+        },
+      };
+      middleware(store)(next)(action);
+      expect(store.dispatch).not.toHaveBeenCalled();
     });
 
     it('LOCATION_CHANGE to another route does not trigger get_report', () => {


### PR DESCRIPTION
### Purpose

Always trigger a report fetch on `SET_DATE_RANGE`, do not trigger it on `LOCATION_CHANGE` when loading the export view

### Notes

Fixes BAN-132