### PR TITLE
Facebook Insights: Change Post Clicks to Link Clicks

### DIFF
--- a/packages/server/rpc/compare/metricsConfig.js
+++ b/packages/server/rpc/compare/metricsConfig.js
@@ -66,7 +66,7 @@ const facebookConfig = {
   },
 
   post_clicks: {
-    label: 'Post Clicks',
+    label: 'Link Clicks',
     color: '#98E8B2',
   },
 

--- a/packages/server/rpc/summary/index.js
+++ b/packages/server/rpc/summary/index.js
@@ -21,7 +21,7 @@ const LABELS = {
     reactions: 'Reactions',
     post_reach: 'Post Reach',
     page_engagements: 'Page & Post Engagements',
-    post_clicks: 'Post Clicks',
+    post_clicks: 'Link Clicks',
     new_followers: 'New Fans',
     posts_count: 'Posts',
   },

--- a/packages/server/rpc/summary/index.js
+++ b/packages/server/rpc/summary/index.js
@@ -27,6 +27,8 @@ const LABELS = {
   },
   instagram: {
     posts_count: 'Posts',
+
+
     likes: 'Likes',
     comments: 'Comments',
     followers: 'Total Followers',

--- a/packages/server/rpc/summary/index.js
+++ b/packages/server/rpc/summary/index.js
@@ -27,8 +27,6 @@ const LABELS = {
   },
   instagram: {
     posts_count: 'Posts',
-
-
     likes: 'Likes',
     comments: 'Comments',
     followers: 'Total Followers',

--- a/packages/server/rpc/summary/index.test.js
+++ b/packages/server/rpc/summary/index.test.js
@@ -155,7 +155,7 @@ describe('rpc/summary', () => {
       value: 12831,
       diff: 149,
     }, {
-      label: 'Post Clicks',
+      label: 'Link Clicks',
       value: 59989,
       diff: 173,
     }, {


### PR DESCRIPTION
### Purpose
The goal of this PR is to change Post Clicks label to Link Clicks in FB summary and compare charts. We have been pulling the actual link clicks metrics from backend and we just needed to adjust the label. 

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
