### PR TITLE
Fix small metrics table bugs BAN-146 BAN-147

### DIFF
--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -1796,7 +1796,7 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
               }
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -1957,7 +1957,7 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
                 </div>
               </li>
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -2624,7 +2624,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
               }
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -2785,7 +2785,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                 </div>
               </li>
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -3452,7 +3452,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
               }
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -3613,7 +3613,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                 </div>
               </li>
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -4356,7 +4356,7 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
               }
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -4517,7 +4517,7 @@ exports[`Snapshots CompareChart should render the compare chart with mode toggle
                 </div>
               </li>
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -5184,7 +5184,7 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
               }
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -5345,7 +5345,7 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
                 </div>
               </li>
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -5478,7 +5478,7 @@ exports[`Snapshots Footer should render the table 1`] = `
         }
       >
         <li
-          className="sc-ifAKCX hjaDfC"
+          className="sc-ifAKCX dYwfOF"
           width="25%"
         >
           <div
@@ -5638,7 +5638,7 @@ exports[`Snapshots Footer should render the table 1`] = `
           </div>
         </li>
         <li
-          className="sc-ifAKCX hjaDfC"
+          className="sc-ifAKCX dYwfOF"
           width="25%"
         >
           <div

--- a/packages/comparison_chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/comparison_chart/__snapshots__/snapshot.test.js.snap
@@ -67,7 +67,7 @@ exports[`Snapshots ComparisonChart [TESTED] should hide Instagram in the reach c
               className="sc-cSHVUG fGjpOO"
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -682,7 +682,7 @@ exports[`Snapshots ComparisonChart [TESTED] should render the audience compariso
               className="sc-cSHVUG fGjpOO"
             >
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div
@@ -906,7 +906,7 @@ exports[`Snapshots ComparisonChart [TESTED] should render the audience compariso
                 </div>
               </li>
               <li
-                className="sc-ifAKCX hjaDfC"
+                className="sc-ifAKCX dYwfOF"
                 width="25%"
               >
                 <div

--- a/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
@@ -337,7 +337,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
           }
         >
           <li
-            className="sc-ifAKCX bkOZJO"
+            className="sc-ifAKCX ldPJxk"
             width="33.33%"
           >
             <div
@@ -472,7 +472,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             </div>
           </li>
           <li
-            className="sc-ifAKCX bkOZJO"
+            className="sc-ifAKCX ldPJxk"
             width="33.33%"
           >
             <div
@@ -608,7 +608,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             </div>
           </li>
           <li
-            className="sc-ifAKCX bkOZJO"
+            className="sc-ifAKCX ldPJxk"
             width="33.33%"
           >
             <div
@@ -743,7 +743,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             </div>
           </li>
           <li
-            className="sc-ifAKCX bkOZJO"
+            className="sc-ifAKCX ldPJxk"
             width="33.33%"
           >
             <div
@@ -879,7 +879,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             </div>
           </li>
           <li
-            className="sc-ifAKCX bkOZJO"
+            className="sc-ifAKCX ldPJxk"
             width="33.33%"
           >
             <div
@@ -1015,7 +1015,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
             </div>
           </li>
           <li
-            className="sc-ifAKCX bkOZJO"
+            className="sc-ifAKCX ldPJxk"
             width="33.33%"
           >
             <div

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -784,7 +784,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
         }
       >
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -919,7 +919,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -1055,7 +1055,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -1191,7 +1191,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -1327,7 +1327,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -1463,7 +1463,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -1599,7 +1599,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -1735,7 +1735,7 @@ exports[`Snapshots Report adds page breaks where needed if exporting 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -2339,7 +2339,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         }
       >
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -2474,7 +2474,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -2610,7 +2610,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -2746,7 +2746,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -2882,7 +2882,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -3018,7 +3018,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -3154,7 +3154,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -3290,7 +3290,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -3850,7 +3850,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         }
       >
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -3985,7 +3985,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -4121,7 +4121,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -4257,7 +4257,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -4393,7 +4393,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -4529,7 +4529,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -4665,7 +4665,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div
@@ -4801,7 +4801,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           </div>
         </li>
         <li
-          className="sc-bZQynM hDiwGY"
+          className="sc-bZQynM ciUnRY"
           width="25%"
         >
           <div

--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -16,9 +16,9 @@ const LABELS = {
     posts_count: 'Posts',
     retweets: 'Retweets',
     impressions: 'Impressions',
-    favorites: 'Likes',
     replies: 'Replies',
     url_clicks: 'Clicks',
+    favorites: 'Likes',
   },
   instagram: {
     posts_count: 'Posts',
@@ -52,6 +52,11 @@ const requestPostsSummary = (profileId, profileService, dateRange, accessToken) 
   });
 
 const filterMetrics = metrics => metrics.filter(metric => metric.label !== undefined);
+
+const sortMetrics = (metrics, profileService) => Object.values(LABELS[profileService]).map(
+  label => metrics.find(metric => metric.label === label),
+);
+
 
 const percentageDifference = (value, pastValue) => {
   const difference = value - pastValue;
@@ -96,9 +101,9 @@ module.exports = method(
         const currentPeriodResult = response[0].response;
         const pastPeriodResult = response[1].response;
         const metrics = Object.keys(currentPeriodResult);
-        return filterMetrics(metrics.map(metric =>
+        return sortMetrics(filterMetrics(metrics.map(metric =>
           summarize(metric, currentPeriodResult, pastPeriodResult, profileService),
-        ));
+        )), profileService);
       })
       .catch(() => []);
   },

--- a/packages/server/rpc/postsSummary/index.test.js
+++ b/packages/server/rpc/postsSummary/index.test.js
@@ -136,31 +136,37 @@ describe('rpc/posts_summary', () => {
       },
     });
 
-    expect(postsSummaryData).toEqual([{
-      label: 'Post Impressions',
-      value: 56755,
-      diff: 25,
-    }, {
-      label: 'Post Reach',
-      value: 1181030,
-      diff: -0,
-    }, {
-      label: 'Reactions',
-      value: 9391,
-      diff: 0,
-    }, {
-      label: 'Shares',
-      value: 5,
-      diff: 150,
-    }, {
-      label: 'Posts',
-      value: 3,
-      diff: -40,
-    }, {
-      label: 'Comments',
-      value: 100,
-      diff: 25,
-    },
+    expect(postsSummaryData).toEqual([
+      {
+        label: 'Posts',
+        value: 3,
+        diff: -40,
+      },
+      {
+        label: 'Post Impressions',
+        value: 56755,
+        diff: 25,
+      },
+      {
+        label: 'Post Reach',
+        value: 1181030,
+        diff: -0,
+      },
+      {
+        label: 'Reactions',
+        value: 9391,
+        diff: 0,
+      },
+      {
+        label: 'Comments',
+        value: 100,
+        diff: 25,
+      },
+      {
+        label: 'Shares',
+        value: 5,
+        diff: 150,
+      },
     ]);
   });
 });

--- a/packages/server/rpc/postsSummary/mockResponses.js
+++ b/packages/server/rpc/postsSummary/mockResponses.js
@@ -1,22 +1,22 @@
 export const CURRENT_PERIOD_RESPONSE = {
   response: {
+    comments: 100,
     post_impressions: 56755,
     post_reach: 1181030,
+    posts_count: 3,
     reactions: 9391,
     shares: 5,
-    posts_count: 3,
-    comments: 100,
   },
   success: true,
 };
 export const PAST_PERIOD_RESPONSE = {
   response: {
+    comments: 80,
     post_impressions: 45555,
     post_reach: 1181090,
+    posts_count: 5,
     reactions: 9391,
     shares: 2,
-    posts_count: 5,
-    comments: 80,
   },
   success: true,
 };

--- a/packages/shared-components/GridItem/index.jsx
+++ b/packages/shared-components/GridItem/index.jsx
@@ -18,13 +18,13 @@ const Item = styled.li`
   padding-right: 0.5rem;
 
   &:first-child > div {
-    padding-left: 0;
-    padding-right: 1rem;
+    padding-left: ${props => (props.withChart ? '0' : '')};
+    padding-right: ${props => (props.withChart ? '1rem' : '')};
   }
 
   &:last-child > div {
-    padding-left: 1rem;
-    padding-right: 0;
+    padding-left: ${props => (props.withChart ? '1rem' : '')};
+    padding-right: ${props => (props.withChart ? '0' : '')};
   }
 `;
 
@@ -62,7 +62,7 @@ const GridItem = ({
 }) => {
   const dailyMetricData = filterDailyDataMetrics(dailyData, metric.label);
   return (
-    <Item key={metric.label} width={gridWidth}>
+    <Item key={metric.label} width={gridWidth} withChart={dailyData.length > 0}>
       {prefix && prefix}
       <Container>
         {dailyData.length > 1 &&

--- a/packages/shared-components/__snapshots__/snapshot.test.js.snap
+++ b/packages/shared-components/__snapshots__/snapshot.test.js.snap
@@ -2630,7 +2630,7 @@ exports[`Snapshots GridItem should render a grid item with a custom Label 1`] = 
     }
   >
     <li
-      className="sc-ckVGcZ csnjIz"
+      className="sc-ckVGcZ hqKgoT"
       width="25%"
     >
       <div
@@ -2807,7 +2807,7 @@ exports[`Snapshots GridItem should render a summary grid item with a neutral dif
     }
   >
     <li
-      className="sc-ckVGcZ csnjIz"
+      className="sc-ckVGcZ hqKgoT"
       width="25%"
     >
       <div
@@ -2962,7 +2962,7 @@ exports[`Snapshots GridItem should render a summary grid item with negative diff
     }
   >
     <li
-      className="sc-ckVGcZ csnjIz"
+      className="sc-ckVGcZ hqKgoT"
       width="25%"
     >
       <div
@@ -3117,7 +3117,7 @@ exports[`Snapshots GridItem should render a summary grid item with no diff 1`] =
     }
   >
     <li
-      className="sc-ckVGcZ csnjIz"
+      className="sc-ckVGcZ hqKgoT"
       width="25%"
     >
       <div
@@ -3208,7 +3208,7 @@ exports[`Snapshots GridItem should render a summary grid item with positive diff
     }
   >
     <li
-      className="sc-ckVGcZ csnjIz"
+      className="sc-ckVGcZ hqKgoT"
       width="25%"
     >
       <div

--- a/packages/summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/summary-table/__snapshots__/snapshot.test.js.snap
@@ -334,7 +334,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
           }
         >
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -469,7 +469,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -605,7 +605,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -741,7 +741,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -877,7 +877,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -1013,7 +1013,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -1149,7 +1149,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -1285,7 +1285,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
             </div>
           </li>
           <li
-            className="sc-ifAKCX hjaDfC"
+            className="sc-ifAKCX dYwfOF"
             width="25%"
           >
             <div
@@ -1500,7 +1500,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
           }
         >
           <li
-            className="sc-ifAKCX hxVBmD"
+            className="sc-ifAKCX ezERtX"
             width="20%"
           >
             <div
@@ -1635,7 +1635,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             </div>
           </li>
           <li
-            className="sc-ifAKCX hxVBmD"
+            className="sc-ifAKCX ezERtX"
             width="20%"
           >
             <div
@@ -1771,7 +1771,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             </div>
           </li>
           <li
-            className="sc-ifAKCX hxVBmD"
+            className="sc-ifAKCX ezERtX"
             width="20%"
           >
             <div
@@ -1907,7 +1907,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             </div>
           </li>
           <li
-            className="sc-ifAKCX hxVBmD"
+            className="sc-ifAKCX ezERtX"
             width="20%"
           >
             <div
@@ -2043,7 +2043,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
             </div>
           </li>
           <li
-            className="sc-ifAKCX hxVBmD"
+            className="sc-ifAKCX ezERtX"
             width="20%"
           >
             <div


### PR DESCRIPTION
### Purpose
- Bottom right metric of Performance Table and Posts table is misaligned/offset to the right
- Order of metrics in Performance table and Posts table should be the same



### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
