### PR TITLE
Task/comparisons tooltip BAN-140

### DIFF
--- a/packages/comparison_chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/comparison_chart/__snapshots__/snapshot.test.js.snap
@@ -1314,9 +1314,9 @@ exports[`Snapshots ComparisonChartTooltip [TESTED] should render the tooltip 1`]
               }
             }
           >
-             no 
+             No 
             post
-             published for
+             were published for
           </span>
           <span
             style={
@@ -1381,9 +1381,9 @@ exports[`Snapshots ComparisonChartTooltip [TESTED] should render the tooltip 1`]
               }
             }
           >
-             no 
+             No 
             tweet
-             published for
+             were published for
           </span>
           <span
             style={

--- a/packages/comparison_chart/components/ChartTooltip/index.jsx
+++ b/packages/comparison_chart/components/ChartTooltip/index.jsx
@@ -84,7 +84,7 @@ const NoDataEntry = ({
     <Text color="white" size="small" weight="bold" >
       <MetricIcon metric={{ color: metric.color }} />
     </Text>
-    <Text color="white" size="small" > no {postsWording(metric.profileService)} published for</Text>
+    <Text color="white" size="small" > No {postsWording(metric.profileService)} were published for</Text>
     <Text color="white" size="small" weight="bold" > {metric.username} </Text>
   </span>
 );
@@ -120,10 +120,10 @@ const ComparisonChartTooltip = ({
   <Wrapper>
     <Header day={day} />
     <span>
-      {metrics.map(m => m.value === null ?
+      {metrics.map(m => (m.value === null ?
         (<NoDataEntry key={m.username} metric={m} />) :
         (<MetricEntry key={m.username} metric={m} />)
-      )}
+      ))}
     </span>
   </Wrapper>
 );

--- a/packages/server/rpc/comparison/index.js
+++ b/packages/server/rpc/comparison/index.js
@@ -56,13 +56,13 @@ const METRIC_CONFIGS_BY_KEY = {
   },
   engagement: {
     facebook: {
-      label: 'Engagement',
+      label: 'Engagements',
     },
     instagram: {
-      label: 'Engagement',
+      label: 'Engagements',
     },
     twitter: {
-      label: 'Engagement',
+      label: 'Engagements',
     },
   },
   comments: {


### PR DESCRIPTION
### Purpose
On all charts where there were no posts published, let's change the copy from "no post published for buffer" to "No posts were published for buffer"

On the engagement chart, let's pluralize "engagement": Update from "123 engagement for buffer" to "123 engagements for buffer"

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
