### PR TITLE
Fix date picker loading endlessly when loading comparisons

### DIFF
--- a/packages/date-picker/index.js
+++ b/packages/date-picker/index.js
@@ -5,8 +5,7 @@ import { actions } from './reducer';
 // default export = container
 export default connect(
   (state, ownProps) => ({
-    loading: state.date.loading, // NOTE: Want to see if loading is really required for date picker
-    // loading: ownProps.staticData ? false : state.date.loading,
+    loading: ownProps.staticData ? false : state.date.loading,
     startDate: state.date.startDate,
     endDate: state.date.endDate,
     isOpen: state.date.open,

--- a/packages/web/components/ReportsPage/index.jsx
+++ b/packages/web/components/ReportsPage/index.jsx
@@ -66,7 +66,7 @@ const ReportsPage = ({ location, dispatch }) => (
       <Header>
         <Button onClick={() => dispatch(push('/reports'))}><Text weight="bold" size="small">Back to Reports</Text></Button>
         <Section>
-          <DatePicker staticData />
+          <DatePicker/>
           <PDFExportButton />
         </Section>
       </Header>


### PR DESCRIPTION
### Purpose

Date picker is waiting for an "analytics_start_date" call to finish, when comparisons does not need that. Comparisons can use `staticData` and reports does not need it anymore as reports have date ranges associated now.