### PR TITLE
Fix day offset with positive UTC offset (BAN-144)

### DIFF
--- a/packages/date-picker/index.js
+++ b/packages/date-picker/index.js
@@ -1,13 +1,20 @@
+import moment from 'moment';
 import { connect } from 'react-redux';
 import DatePicker from './components/DatePicker';
 import { actions } from './reducer';
+
+export function convertDateToTimestamp(date) {
+  return date ?
+    moment(date, 'MM/DD/YYYY').unix() :
+    null;
+}
 
 // default export = container
 export default connect(
   (state, ownProps) => ({
     loading: ownProps.staticData ? false : state.date.loading,
-    startDate: state.date.startDate,
-    endDate: state.date.endDate,
+    startDate: convertDateToTimestamp(state.date.startDate),
+    endDate: convertDateToTimestamp(state.date.endDate),
     isOpen: state.date.open,
     calendarOpen: state.date.calendarOpen,
     minDate: ownProps.staticData ? null : state.date.minDate,

--- a/packages/date-picker/index.test.jsx
+++ b/packages/date-picker/index.test.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React from 'react';
 import { configure, mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -8,6 +9,7 @@ import DatePickerContainer, {
   actions,
   actionTypes,
   middleware,
+  convertDateToTimestamp,
 } from './index';
 import DatePicker from './components/DatePicker';
 import { presets } from './reducer';
@@ -70,8 +72,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .open()).toEqual(actions.open());
+      .props()
+      .open()).toEqual(actions.open());
   });
 
   it('should dispatch close', () => {
@@ -79,8 +81,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .close()).toEqual(actions.close());
+      .props()
+      .close()).toEqual(actions.close());
   });
 
   it('should dispatch clearStartDate', () => {
@@ -88,8 +90,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .clearStartDate()).toEqual(actions.clearStartDate());
+      .props()
+      .clearStartDate()).toEqual(actions.clearStartDate());
   });
 
   it('should dispatch setDateRange', () => {
@@ -97,8 +99,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .setDateRange(111, 222)).toEqual(actions.setDateRange(111, 222));
+      .props()
+      .setDateRange(111, 222)).toEqual(actions.setDateRange(111, 222));
   });
 
   it('should dispatch setMonth', () => {
@@ -113,8 +115,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .setStartDate(123)).toEqual(actions.setStartDate(123));
+      .props()
+      .setStartDate(123)).toEqual(actions.setStartDate(123));
   });
 
   it('should dispatch setEndDate', () => {
@@ -122,8 +124,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .setEndDate()).toEqual(actions.setEndDate());
+      .props()
+      .setEndDate()).toEqual(actions.setEndDate());
   });
 
   it('should dispatch clearEndDate', () => {
@@ -131,8 +133,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .clearEndDate()).toEqual(actions.clearEndDate());
+      .props()
+      .clearEndDate()).toEqual(actions.clearEndDate());
   });
 
   it('should dispatch selectPreset when value is defined', () => {
@@ -140,8 +142,8 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component
-        .props()
-        .selectPreset(1)).toEqual(undefined);
+      .props()
+      .selectPreset(1)).toEqual(undefined);
   });
 
   it('should dispatch selectPreset when value is Infinity', () => {
@@ -149,5 +151,16 @@ describe('DatePicker', () => {
     const store = mockStore(state);
     const component = shallow(<DatePickerContainer store={store} />);
     expect(component.props().selectPreset(Infinity)).toEqual(undefined);
+  });
+});
+
+describe('Convert Date To Timestamp', () => {
+  it('should convert date string to timestamp', () => {
+    const date = moment().startOf('day');
+    expect(convertDateToTimestamp(date.format('MM/DD/YYYY'))).toEqual(date.unix());
+  });
+
+  it('should return null if date is missing', () => {
+    expect(convertDateToTimestamp(null)).toEqual(null);
   });
 });

--- a/packages/date-picker/reducer.js
+++ b/packages/date-picker/reducer.js
@@ -16,11 +16,23 @@ export const actionTypes = keyWrapper('DATE_PICKER', {
   CLOSE_CALENDAR: 'CLOSE_CALENDAR',
 });
 
+function getDayFromTimestamp(timestamp) {
+  return moment.unix(timestamp).startOf('day');
+}
+
+function formatDay(momentDay) {
+  return momentDay.format('MM/DD/YYYY');
+}
+
+function formatTimestamp(timestamp) {
+  return formatDay(getDayFromTimestamp(timestamp));
+}
+
 function calculateDateRange(range) {
   // We need to enfoce the start of the day to make sure
   // that the range is not effected by the time of the day
-  const startDate = moment().startOf('day').subtract(range, 'days').unix();
-  const endDate = moment().startOf('day').subtract(1, 'days').unix();
+  const startDate = formatDay(moment().startOf('day').subtract(range, 'days'));
+  const endDate = formatDay(moment().startOf('day').subtract(1, 'days'));
   return { startDate, endDate };
 }
 
@@ -189,22 +201,22 @@ export const actions = {
   }),
   setStartDate: date => ({
     type: actionTypes.SET_START_DATE,
-    date,
+    date: formatTimestamp(date),
   }),
   clearStartDate: () => ({
     type: actionTypes.CLEAR_START_DATE,
   }),
   setEndDate: date => ({
     type: actionTypes.SET_END_DATE,
-    date,
+    date: formatTimestamp(date),
   }),
   clearEndDate: () => ({
     type: actionTypes.CLEAR_END_DATE,
   }),
   setDateRange: (startDate, endDate) => ({
     type: actionTypes.SET_DATE_RANGE,
-    startDate,
-    endDate,
+    startDate: formatTimestamp(startDate),
+    endDate: formatTimestamp(endDate),
   }),
   setDatePreset: preset => ({
     type: actionTypes.SET_DATE_RANGE,

--- a/packages/date-picker/reducer.test.js
+++ b/packages/date-picker/reducer.test.js
@@ -19,8 +19,8 @@ describe('reducer', () => {
     it('has the past seven days date range selected', () => {
       const yesterday = moment().subtract(1, 'day').format('MM/DD/YYYY');
       const sevenDaysAgo = moment().subtract(7, 'day').format('MM/DD/YYYY');
-      expect(moment.unix(state.startDate).format('MM/DD/YYYY')).toBe(sevenDaysAgo);
-      expect(moment.unix(state.endDate).format('MM/DD/YYYY')).toBe(yesterday);
+      expect(state.startDate).toBe(sevenDaysAgo);
+      expect(state.endDate).toBe(yesterday);
     });
 
     it('is closed', () => {
@@ -226,17 +226,17 @@ describe('actions', () => {
 
   describe('set dates', () => {
     it(`setStartDate triggers ${actionTypes.SET_START_DATE}`, () => {
-      const start = moment().subtract(30, 'days').unix();
-      expect(actions.setStartDate(start)).toEqual({
+      const start = moment().subtract(30, 'days');
+      expect(actions.setStartDate(start.unix())).toEqual({
         type: actionTypes.SET_START_DATE,
-        date: start,
+        date: start.format('MM/DD/YYYY'),
       });
     });
     it(`setEndDate triggers ${actionTypes.SET_END_DATE}`, () => {
-      const end = moment().subtract(1, 'days').unix();
-      expect(actions.setEndDate(end)).toEqual({
+      const end = moment().subtract(1, 'days');
+      expect(actions.setEndDate(end.unix())).toEqual({
         type: actionTypes.SET_END_DATE,
-        date: end,
+        date: end.format('MM/DD/YYYY'),
       });
     });
   });
@@ -261,12 +261,12 @@ describe('actions', () => {
   });
 
   it(`setDateRange triggers ${actionTypes.SET_DATE_RANGE}`, () => {
-    const start = moment().subtract(30, 'days').unix();
-    const end = moment().subtract(1, 'days').unix();
-    expect(actions.setDateRange(start, end)).toEqual({
+    const start = moment().subtract(30, 'days');
+    const end = moment().subtract(1, 'days');
+    expect(actions.setDateRange(start.unix(), end.unix())).toEqual({
       type: actionTypes.SET_DATE_RANGE,
-      startDate: start,
-      endDate: end,
+      startDate: start.format('MM/DD/YYYY'),
+      endDate: end.format('MM/DD/YYYY'),
     });
   });
 

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -555,9 +555,9 @@ exports[`Snapshots DateRange renders the date range 1`] = `
     <span
       className="sc-htpNat byAsPi"
     >
-      December 31, 2017
+      February 20, 2018
        to 
-      January 30, 2018
+      February 25, 2018
     </span>
   </span>
 </span>
@@ -1208,9 +1208,9 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
           <span
             className="sc-htpNat byAsPi"
           >
-            October 29, 2017
+            February 20, 2018
              to 
-            October 31, 2017
+            February 25, 2018
           </span>
         </span>
       </span>
@@ -5047,9 +5047,9 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
           <span
             className="sc-htpNat byAsPi"
           >
-            October 29, 2017
+            February 20, 2018
              to 
-            October 31, 2017
+            February 25, 2018
           </span>
         </span>
       </span>

--- a/packages/report/components/DateRange/index.jsx
+++ b/packages/report/components/DateRange/index.jsx
@@ -10,7 +10,7 @@ const Range = styled.span`
   color: #343E47;
 `;
 
-const Date = ({ children }) => moment.unix(children).format('MMMM D, YYYY');
+const Date = ({ children }) => moment(children, 'MM/DD/YYYY').format('MMMM D, YYYY');
 
 const DateRange = ({ startDate, endDate }) =>
   <Text weight="bold">

--- a/packages/report/components/DateRange/story.jsx
+++ b/packages/report/components/DateRange/story.jsx
@@ -7,5 +7,5 @@ import DateRange from './index';
 storiesOf('DateRange')
   .addDecorator(checkA11y)
   .add('renders the date range', () => (
-    <DateRange startDate="1514764800" endDate="1517356800" />
+    <DateRange startDate="02/20/2018" endDate="02/25/2018" />
   ));

--- a/packages/report/components/Report/story.jsx
+++ b/packages/report/components/Report/story.jsx
@@ -177,8 +177,8 @@ const report = {
 };
 
 const dateRange = {
-  startDate: '1509321600',
-  endDate: '1509494400',
+  startDate: '02/20/2018',
+  endDate: '02/25/2018',
 };
 
 storiesOf('Report')

--- a/packages/server/rpc/audience/index.js
+++ b/packages/server/rpc/audience/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 const METRICS_CONFIG = require('./metricsConfig');
 
@@ -69,9 +68,7 @@ module.exports = method(
   'audience',
   'fetch analytics audience for profiles and pages',
   ({ profileId, profileService, startDate, endDate }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     return requestAudience(
       profileId,
       dateRange,

--- a/packages/server/rpc/audience/index.test.js
+++ b/packages/server/rpc/audience/index.test.js
@@ -25,8 +25,8 @@ describe('rpc/audience', () => {
   });
 
   it('should request audience data for the previous week', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     audience.fn({
       startDate: start,
@@ -48,8 +48,8 @@ describe('rpc/audience', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
           profile_id: profileId,
         },
         json: true,

--- a/packages/server/rpc/average/index.js
+++ b/packages/server/rpc/average/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 // We are using this to filter down the metrics we want
@@ -154,9 +153,7 @@ module.exports = method(
   'average',
   'fetch analytics average for profiles and pages',
   ({ profileId, startDate, endDate }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     const pastDateRange = dateRange.getPreviousDateRange();
 
     const currentPeriodTotals = requestTotals(profileId, dateRange, session.analyze.accessToken);

--- a/packages/server/rpc/average/index.test.js
+++ b/packages/server/rpc/average/index.test.js
@@ -28,8 +28,8 @@ describe('rpc/average', () => {
   });
 
   it('should request for the past week', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     average.fn({
       startDate: start,
@@ -50,20 +50,20 @@ describe('rpc/average', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
         },
         json: true,
       }]);
   });
 
   it('should request for the week before that', () => {
-    const endDate = moment().subtract(1, 'days').unix();
-    const startDate = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     average.fn({
-      startDate,
-      endDate,
+      start,
+      end,
       profileId,
     }, {
       session: {
@@ -73,8 +73,8 @@ describe('rpc/average', () => {
       },
     });
 
-    const end = moment().subtract(8, 'days').format('MM/DD/YYYY');
-    const start = moment().subtract(14, 'days').format('MM/DD/YYYY');
+    const expectedEnd = moment().subtract(8, 'days').format('MM/DD/YYYY');
+    const expectedStart = moment().subtract(14, 'days').format('MM/DD/YYYY');
 
     expect(rp.mock.calls[1])
       .toEqual([{
@@ -83,8 +83,8 @@ describe('rpc/average', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: start,
-          end_date: end,
+          start_date: expectedStart,
+          end_date: expectedEnd,
         },
         json: true,
       }]);

--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -1,7 +1,6 @@
 
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 const METRICS_CONFIG = require('./metricsConfig');
 
@@ -218,9 +217,7 @@ module.exports = method(
   'compare',
   'fetch analytics compare for profiles and pages',
   ({ profileId, profileService, startDate, endDate }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     const previousDateRange = dateRange.getPreviousDateRange();
 
     const currentPeriodTotals = requestTotals(

--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -30,8 +30,8 @@ describe('rpc/compare', () => {
   });
 
   it('should request metrics to Analyze Api for Instagram', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     compare.fn({
       startDate: start,
@@ -53,8 +53,8 @@ describe('rpc/compare', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
           profile_id: profileId,
         },
         json: true,
@@ -67,8 +67,8 @@ describe('rpc/compare', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
           profile_id: profileId,
         },
         json: true,
@@ -78,8 +78,8 @@ describe('rpc/compare', () => {
 
   it('should request for the previous week', () => {
     rp.mockClear();
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     compare.fn({
       startDate: start,
@@ -101,8 +101,8 @@ describe('rpc/compare', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
           profile_id: null,
         },
         json: true,

--- a/packages/server/rpc/comparison/index.js
+++ b/packages/server/rpc/comparison/index.js
@@ -1,7 +1,6 @@
 
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 const METRIC_KEYS = [
@@ -166,9 +165,7 @@ module.exports = method(
   'comparison',
   'get daily comparison data for the given profiles',
   ({ profileIds, startDate, endDate }) => {
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     return rp({
       uri: `${process.env.ANALYZE_API_ADDR}/comparison`,
       method: 'POST',

--- a/packages/server/rpc/comparison/index.test.js
+++ b/packages/server/rpc/comparison/index.test.js
@@ -7,8 +7,6 @@ import rp from 'request-promise';
 import { response, rpcFinalResponse } from './mockResponse';
 import comparison from './';
 
-const DateRange = require('../utils/DateRange');
-
 describe('rpc/comparison', () => {
   const profileIds = ['profile1234'];
 
@@ -23,15 +21,10 @@ describe('rpc/comparison', () => {
   });
 
   it('should send a POST request to /comparison with the provided parameters for every metric', async () => {
-    const startDate = moment().subtract(7, 'days').unix();
-    const endDate = moment().subtract(1, 'days').unix();
+    const startDate = moment().subtract(7, 'days').format('MM/DD/YYYY');
+    const endDate = moment().subtract(1, 'days').format('MM/DD/YYYY');
     rp.mockReturnValue(Promise.resolve(response));
     const result = await comparison.fn({ profileIds, startDate, endDate });
-
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    console.log(start );
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    console.log(end );
 
     expect(result.metrics).toEqual(rpcFinalResponse);
 
@@ -42,8 +35,8 @@ describe('rpc/comparison', () => {
       body: {
         profiles: profileIds,
         metrics: ['audience', 'reach', 'likes', 'engagement', 'comments'],
-        start_date: start,
-        end_date: end,
+        start_date: startDate,
+        end_date: endDate,
       },
       json: true,
     }]);

--- a/packages/server/rpc/contextual/index.js
+++ b/packages/server/rpc/contextual/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 const METRICS_CONFIG = require('./metricsConfig');
 const PRESETS = require('./presets');
@@ -102,9 +101,7 @@ module.exports = method(
   'contextual',
   'fetch analytics contextual for profiles and pages',
   ({ profileId, profileService, startDate, endDate }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     return requestContextual(
       profileId,
       dateRange,

--- a/packages/server/rpc/contextual/index.test.js
+++ b/packages/server/rpc/contextual/index.test.js
@@ -25,8 +25,8 @@ describe('rpc/contextual', () => {
   });
 
   it('should request contextual data for the previous week', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     contextual.fn({
       startDate: start,
@@ -48,8 +48,8 @@ describe('rpc/contextual', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
         },
         json: true,
       }]);

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -16,9 +16,22 @@ const RPC_ENDPOINTS = {
 
 function calculateDateRange(range, timezone) {
   moment.tz.setDefault(timezone);
-  const startDate = moment().startOf('day').subtract(range, 'days').unix();
-  const endDate = moment().startOf('day').subtract(1, 'days').unix();
+  const startDate = moment().startOf('day').subtract(range, 'days').format('MM/DD/YYYY');
+  const endDate = moment().startOf('day').subtract(1, 'days').format('MM/DD/YYYY');
   moment.tz.setDefault();
+
+  return { startDate, endDate };
+}
+
+function getDateRangeFromDates(start, end, timezone) {
+  let startDate = start;
+  let endDate = end;
+  if (typeof start === 'number') {
+    moment.tz.setDefault(timezone);
+    startDate = moment.unix(start).format('MM/DD/YYYY');
+    endDate = moment.unix(end).format('MM/DD/YYYY');
+    moment.tz.setDefault();
+  }
 
   return { startDate, endDate };
 }
@@ -52,10 +65,11 @@ module.exports = method(
       if (report.date_range.range) {
         dateRange = calculateDateRange(report.date_range.range, timezone);
       } else {
-        dateRange = {
-          startDate: report.date_range.start,
-          endDate: report.date_range.end,
-        };
+        dateRange = getDateRangeFromDates(
+          report.date_range.start,
+          report.date_range.end,
+          timezone,
+        );
       }
 
       return Promise

--- a/packages/server/rpc/posts/index.js
+++ b/packages/server/rpc/posts/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 const mergeStatsWithUpdates = (stats, updates) => {
@@ -45,9 +44,7 @@ module.exports = method(
   'posts',
   'fetch analytics posts for profiles and pages',
   ({ profileId, startDate, endDate, sortBy, descending, limit }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     const posts = fetchTopPosts(
       profileId,
       dateRange,

--- a/packages/server/rpc/posts/index.test.js
+++ b/packages/server/rpc/posts/index.test.js
@@ -82,8 +82,8 @@ describe('rpc/posts', () => {
   });
 
   it('should request for the past week', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     posts.fn({
       startDate: start,
@@ -104,8 +104,8 @@ describe('rpc/posts', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
         },
         json: true,
       }]);

--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 const LABELS = {
@@ -77,9 +76,7 @@ module.exports = method(
   'posts_summary',
   'fetch analytics posts summary for profiles and pages',
   ({ profileId, profileService, startDate, endDate }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     const previousDateRange = dateRange.getPreviousDateRange();
 
     const currentPeriod = requestPostsSummary(

--- a/packages/server/rpc/postsSummary/index.test.js
+++ b/packages/server/rpc/postsSummary/index.test.js
@@ -22,8 +22,8 @@ describe('rpc/posts_summary', () => {
   });
 
   it('should request metrics to Analyze Api for Instagram', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     postsSummary.fn({
       startDate: start,
@@ -45,8 +45,8 @@ describe('rpc/posts_summary', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
           profile_id: profileId,
         },
         json: true,
@@ -55,8 +55,8 @@ describe('rpc/posts_summary', () => {
 
   it('should request for the past week', () => {
     rp.mockClear();
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     postsSummary.fn({
       startDate: start,
@@ -78,8 +78,8 @@ describe('rpc/posts_summary', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
           profile_id: profileId,
         },
         json: true,
@@ -87,8 +87,8 @@ describe('rpc/posts_summary', () => {
   });
 
   it('should request for the week before that', () => {
-    const endDate = moment().subtract(1, 'days').unix();
-    const startDate = moment().subtract(7, 'days').unix();
+    const endDate = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const startDate = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     postsSummary.fn({
       startDate,

--- a/packages/server/rpc/summary/index.js
+++ b/packages/server/rpc/summary/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 // This also also used to filter down the metrics to return
@@ -80,9 +79,7 @@ module.exports = method(
   'summary',
   'fetch analytics summary for profiles and pages',
   ({ profileId, profileService, startDate, endDate }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     const previousDateRange = dateRange.getPreviousDateRange();
 
     const currentPeriod = requestTotals(

--- a/packages/server/rpc/summary/index.test.js
+++ b/packages/server/rpc/summary/index.test.js
@@ -23,12 +23,12 @@ describe('rpc/summary', () => {
   });
 
   it('should request metrics to Analyze Api for Instagram', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const startDate = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const endDate = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     summary.fn({
-      startDate: start,
-      endDate: end,
+      startDate,
+      endDate,
       profileId,
       profileService: 'instagram',
     }, {
@@ -46,8 +46,8 @@ describe('rpc/summary', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: startDate,
+          end_date: endDate,
           profile_id: profileId,
         },
         json: true,
@@ -56,12 +56,12 @@ describe('rpc/summary', () => {
 
   it('should request for the past week', () => {
     rp.mockClear();
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const startDate = moment().subtract(7, 'days').format('MM/DD/YYYY');
+    const endDate = moment().subtract(1, 'days').format('MM/DD/YYYY');
 
     summary.fn({
-      startDate: start,
-      endDate: end,
+      startDate,
+      endDate,
       profileId,
       profileService,
     }, {
@@ -72,15 +72,15 @@ describe('rpc/summary', () => {
       },
     });
 
-    expect(rp.mock.calls[0])
+    expect(rp.mock.calls[1])
       .toEqual([{
         uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`,
         method: 'GET',
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: moment().subtract(14, 'days').format('MM/DD/YYYY'),
+          end_date: moment().subtract(8, 'days').format('MM/DD/YYYY'),
           profile_id: null,
         },
         json: true,

--- a/packages/server/rpc/topPosts/index.js
+++ b/packages/server/rpc/topPosts/index.js
@@ -1,6 +1,5 @@
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
-const moment = require('moment');
 const DateRange = require('../utils/DateRange');
 
 const mergeStatsWithUpdates = (stats, updates) => {
@@ -45,9 +44,7 @@ module.exports = method(
   'top_posts',
   'fetch analytics top posts for profiles and pages',
   ({ profileId, startDate, endDate, sortBy, descending, limit }, { session }) => {
-    const end = moment.unix(endDate).format('MM/DD/YYYY');
-    const start = moment.unix(startDate).format('MM/DD/YYYY');
-    const dateRange = new DateRange(start, end);
+    const dateRange = new DateRange(startDate, endDate);
     const topPosts = fetchTopPosts(
       profileId,
       dateRange,

--- a/packages/server/rpc/topPosts/index.test.js
+++ b/packages/server/rpc/topPosts/index.test.js
@@ -82,8 +82,8 @@ describe('rpc/top_posts', () => {
   });
 
   it('should request for the past week', () => {
-    const end = moment().subtract(1, 'days').unix();
-    const start = moment().subtract(7, 'days').unix();
+    const end = moment().subtract(1, 'days').format('MM/DD/YYYY');
+    const start = moment().subtract(7, 'days').format('MM/DD/YYYY');
 
     topPosts.fn({
       startDate: start,
@@ -104,8 +104,8 @@ describe('rpc/top_posts', () => {
         strictSSL: false,
         qs: {
           access_token: token,
-          start_date: moment.unix(start).format('MM/DD/YYYY'),
-          end_date: moment.unix(end).format('MM/DD/YYYY'),
+          start_date: start,
+          end_date: end,
         },
         json: true,
       }]);


### PR DESCRIPTION
### Purpose
Fixes a bug where positive UTC offset was pushing the date range back by one day

### Notes
This moves the conversion of the dates (from unix timestamp to `MM/DD/YYYY') from the RPC endpoint to the client, therefore ensuring that we are always converting the dates based on the client timezone.
Bonus with this is that RPC requests match the API endpoint format, and are also easier to read.

As we have a few reports already using the custom date this is adding
support for both date formats. We will remove this once we have
migrated all the reports to the new format.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
