### PR TITLE
Remove extra blank page in PDFs

### DIFF
--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -1,7 +1,6 @@
 const PDF_HEIGHT = 1122; // 842 pt to px
 
 class PDFFormatter {
-
   constructor(page) {
     this.currentPageHeight = 0;
     this.modules = page.children;
@@ -14,6 +13,13 @@ class PDFFormatter {
         this.addPageBreak(module);
       }
     });
+  }
+
+  static formatWrapper(wrapper) {
+    wrapper.style.setProperty('border', '1px solid white');
+    wrapper.style.setProperty('height', '99%');
+    wrapper.style.setProperty('page-break-after', 'avoid');
+    wrapper.style.setProperty('page-break-before', 'avoid');
   }
 
   needsPageBreak() {

--- a/packages/report/PDFFormatter.test.js
+++ b/packages/report/PDFFormatter.test.js
@@ -18,6 +18,15 @@ describe('PDF formatter', () => {
     expect(PDFFormatter).not.toBe(undefined);
   });
 
+  it('formatWrapper prevents page breaks after the main content', () => {
+    const wrapper = require('./mocks/smallReport').default; // eslint-disable-line global-require
+    PDFFormatter.formatWrapper(wrapper);
+    expect(wrapper.style._values.border).toBe('1px solid white');
+    expect(wrapper.style._values.height).toBe('99%');
+    expect(wrapper.style._values['page-break-before']).toBe('avoid');
+    expect(wrapper.style._values['page-break-after']).toBe('avoid');
+  });
+
   describe('adds page breaks', () => {
     it('should not add a page break if the sunm of the heights of all the children is smaller than an A4', () => {
       const smallReport = require('./mocks/smallReport').default; // eslint-disable-line global-require

--- a/packages/report/middleware.js
+++ b/packages/report/middleware.js
@@ -110,6 +110,7 @@ export default store => next => (action) => { // eslint-disable-line no-unused-v
       break;
     case actionTypes.PARSE_PAGE_BREAKS:
       formatter = new PDFFormatter(document.getElementById('report-page'));
+      PDFFormatter.formatWrapper(document.getElementById('root'));
       formatter.formatPage();
       break;
     default:

--- a/packages/report/middleware.test.js
+++ b/packages/report/middleware.test.js
@@ -198,6 +198,7 @@ describe('middleware', () => {
   it('PARSE_PAGE_BREAKS sends report page over to PDFFormatter', () => {
     Object.defineProperty(document, 'getElementById', {
       value: () => 'report html',
+      configurable: true,
     });
     const action = {
       type: actionTypes.PARSE_PAGE_BREAKS,
@@ -205,6 +206,18 @@ describe('middleware', () => {
     middleware(store)(next)(action);
     expect(PDFFormatter.mock.calls[0]).toEqual(['report html']);
     expect(PDFFormatter.mock.instances[0].formatPage).toHaveBeenCalled();
+  });
+
+  it('PARSE_PAGE_BREAKS formats the report wrapper to avoid extra page breaks', () => {
+    Object.defineProperty(document, 'getElementById', {
+      value: () => 'report wrapper',
+      configurable: true,
+    });
+    const action = {
+      type: actionTypes.PARSE_PAGE_BREAKS,
+    };
+    middleware(store)(next)(action);
+    expect(PDFFormatter.formatWrapper).toHaveBeenCalledWith('report wrapper');
   });
 
   describe('updating a report successfully', () => {


### PR DESCRIPTION
### Purpose

To remove a blank page appearing at the end of exported PDFs when the PDF has only one page.