### PR TITLE
[BAN-183] Make Hourly Chart labels round to match other charts

### DIFF
--- a/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
@@ -1244,7 +1244,7 @@ exports[`Snapshots HourlyChart [TESTED] loaded chart 1`] = `
                   style={
                     Object {
                       "background": "#ced7df",
-                      "borderRadius": null,
+                      "borderRadius": "50%",
                       "display": "inline-block",
                       "height": "10px",
                       "marginRight": "5px",
@@ -1279,7 +1279,7 @@ exports[`Snapshots HourlyChart [TESTED] loaded chart 1`] = `
                   style={
                     Object {
                       "background": "#3A92D3",
-                      "borderRadius": null,
+                      "borderRadius": "50%",
                       "display": "inline-block",
                       "height": "10px",
                       "marginRight": "5px",
@@ -2596,7 +2596,7 @@ exports[`Snapshots HourlyChart [TESTED] second metric selected 1`] = `
                   style={
                     Object {
                       "background": "#ced7df",
-                      "borderRadius": null,
+                      "borderRadius": "50%",
                       "display": "inline-block",
                       "height": "10px",
                       "marginRight": "5px",
@@ -2631,7 +2631,7 @@ exports[`Snapshots HourlyChart [TESTED] second metric selected 1`] = `
                   style={
                     Object {
                       "background": "#3A92D3",
-                      "borderRadius": null,
+                      "borderRadius": "50%",
                       "display": "inline-block",
                       "height": "10px",
                       "marginRight": "5px",
@@ -2666,7 +2666,7 @@ exports[`Snapshots HourlyChart [TESTED] second metric selected 1`] = `
                   style={
                     Object {
                       "background": "#FEC78B",
-                      "borderRadius": null,
+                      "borderRadius": "50%",
                       "display": "inline-block",
                       "height": "10px",
                       "marginRight": "5px",

--- a/packages/hourly-chart/components/Legend/index.jsx
+++ b/packages/hourly-chart/components/Legend/index.jsx
@@ -20,15 +20,15 @@ const legendList = {
 const Legend = ({ metric, secondaryMetric }) =>
   <ul style={legendList}>
     <li style={legendItem}>
-      <ColorIcon />
+      <ColorIcon circle />
       <Text size="small">Tweets</Text>
     </li>
     <li style={legendItem}>
-      <ColorIcon metric={metric.label} />
+      <ColorIcon metric={metric.label} circle />
       <Text size="small">{metric.label}</Text>
     </li>
     { secondaryMetric && <li style={legendItem}>
-      <ColorIcon metric={secondaryMetric.label} />
+      <ColorIcon metric={secondaryMetric.label} circle />
       <Text size="small">{secondaryMetric.label}</Text>
     </li> }
   </ul>;


### PR DESCRIPTION
### Purpose

To make the Hourly chart more consistent with the current style for other charts by having its legend with circle labels rather than square ones.