### PR TITLE
Fix chart spacing on PDF export

### DIFF
--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -1,4 +1,5 @@
-const PDF_HEIGHT = 1122; // 842 pt to px
+// const PDF_HEIGHT = 1122; // 842 pt to px
+const PDF_HEIGHT = 1755;
 
 class PDFFormatter {
   constructor(page) {

--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -1,4 +1,5 @@
 const PDF_HEIGHT = 1404; // 11.7 in to px at 120 dpi
+const PAGE_MARGIN = 84; // 0.7 in to px at 120 dpi
 
 class PDFFormatter {
   constructor(page) {
@@ -23,7 +24,7 @@ class PDFFormatter {
   }
 
   needsPageBreak() {
-    return this.currentPageHeight >= PDF_HEIGHT;
+    return this.currentPageHeight >= (PDF_HEIGHT - PAGE_MARGIN);
   }
 
   addToCurrentPage(element) {

--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -43,10 +43,12 @@ class PDFFormatter {
 
   addPageBreak(element) {
     if (PDFFormatter.canBeBrokenDownIntoMultiplePages(element)) {
-      const [title, list] = element.children;
+      const [title, aside] = element.children;
+      const [header, list] = aside.children;
       this.removeFromCurrentPage(element);
       this.addToCurrentPage(title);
-      const listItems = list.getElementsByTagName('ul')[1].children;
+      this.addToCurrentPage(header);
+      const listItems = list.children;
       this.breakIntoPages(listItems);
     } else {
       this.addNewPage(element);

--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -1,5 +1,4 @@
-// const PDF_HEIGHT = 1122; // 842 pt to px
-const PDF_HEIGHT = 1755;
+const PDF_HEIGHT = 1404; // 11.7 in to px at 120 dpi
 
 class PDFFormatter {
   constructor(page) {

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -1161,7 +1161,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </span>
       </span>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div
@@ -1631,7 +1631,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         </span>
       </span>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div
@@ -2875,7 +2875,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div
@@ -4119,7 +4119,7 @@ exports[`Snapshots Report renders a report in edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div
@@ -5470,7 +5470,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         </span>
       </span>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div
@@ -6714,7 +6714,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         </ul>
       </section>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div
@@ -7958,7 +7958,7 @@ exports[`Snapshots Report renders a report with summary table 1`] = `
         </ul>
       </section>
       <section
-        className="sc-lkqHmb caPCsE"
+        className="sc-lkqHmb bIFGmX"
       >
         <div>
           <div

--- a/packages/report/components/ChartFactory/index.jsx
+++ b/packages/report/components/ChartFactory/index.jsx
@@ -57,7 +57,6 @@ const CHARTS = {
 
 const Separator = styled.section`
   padding-top: 1.25rem;
-  margin-top: 4rem;
   position: relative;
 `;
 


### PR DESCRIPTION
### Purpose

To ensure we use as much space available as possible per page so that there are no big chunks of whitespace lying between charts.