### PR TITLE
[BAN-187] Store only current value for followers on total period

### DIFF
--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -74,6 +74,7 @@ const summarize = (
   const label = METRICS_CONFIG[profileService].config[metricKey].label;
   if (label) {
     return {
+      key: metricKey,
       diff: percentageDifference(value, previousValue),
       label,
       color: METRICS_CONFIG[profileService].config[metricKey].color,
@@ -157,12 +158,16 @@ function formatTotalPeriodDaily(formattedDailyData) {
     });
 
     day.metrics.forEach((metric, metricIndex) => {
-      metricClone = Object.assign({}, metric, {
-        value: dayIndex === 0 ? metric.value :
-          metric.value + totalPeriodDaily[dayIndex - 1].metrics[metricIndex].value,
-        previousValue: dayIndex === 0 ? metric.previousValue :
-          metric.previousValue + totalPeriodDaily[dayIndex - 1].metrics[metricIndex].previousValue,
-      });
+      if (metric.key === 'followers') {
+        metricClone = Object.assign({}, metric);
+      } else {
+        metricClone = Object.assign({}, metric, {
+          value: dayIndex === 0 ? metric.value :
+            metric.value + totalPeriodDaily[dayIndex - 1].metrics[metricIndex].value,
+          previousValue: dayIndex === 0 ? metric.previousValue :
+            metric.previousValue + totalPeriodDaily[dayIndex - 1].metrics[metricIndex].previousValue,
+        });
+      }
       delete metricClone.diff;
       dayClone.metrics.push(metricClone);
     });

--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -178,6 +178,7 @@ describe('rpc/compare', () => {
 
     expect(data.totals[0]).toEqual({
       diff: 1,
+      key: 'followers',
       label: 'Total Fans',
       color: '#FDA3F3',
       value: 99324,
@@ -204,6 +205,7 @@ describe('rpc/compare', () => {
     expect(data.totals.length).toBe(10);
     expect(data.totals[0]).toEqual({
       diff: 0,
+      key: 'followers',
       label: 'Total Fans',
       color: '#FDA3F3',
       value: 0,
@@ -230,6 +232,7 @@ describe('rpc/compare', () => {
     expect(data.totals.length).toBe(10);
     expect(data.totals[0]).toEqual({
       diff: 9932400,
+      key: 'followers',
       label: 'Total Fans',
       color: '#FDA3F3',
       value: 99324,
@@ -277,7 +280,6 @@ describe('rpc/compare', () => {
       },
     });
 
-    const firstDayMetric = data.daily[0].metrics[0];
     const secondDayMetric = data.daily[1].metrics[0];
     expect(data.totalPeriodDaily.length).toBe(7);
 
@@ -286,8 +288,8 @@ describe('rpc/compare', () => {
 
     expect(data.totalPeriodDaily[1].metrics[0]).toMatchObject({
       label: 'Total Followers',
-      value: firstDayMetric.value + secondDayMetric.value,
-      previousValue: firstDayMetric.previousValue + secondDayMetric.previousValue,
+      value: secondDayMetric.value,
+      previousValue: secondDayMetric.previousValue,
     });
   });
 


### PR DESCRIPTION
### Purpose

Follower counts on the Metrics Breakdown chart was wrong when selecting "Total period": it was displayed as a sum of the current daily value + all the previous days, where in this case it should always be the daily value.