### PR TITLE
[ANA-128] Ensure loading and empty state is centered on Metrics Breakdown graph

### DIFF
--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -937,84 +937,7 @@ exports[`Snapshots CompareChart should render a "no data" state 1`] = `
         }
       >
         <div
-          style={
-            Object {
-              "display": "flex",
-              "padding": "20px",
-            }
-          }
-        >
-          <span
-            style={
-              Object {
-                "marginLeft": "auto",
-              }
-            }
-          >
-            <button
-              aria-label={null}
-              disabled={undefined}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              style={
-                Object {
-                  "background": "none",
-                  "backgroundColor": "unset",
-                  "border": "none",
-                  "borderRadius": "unset",
-                  "color": "unset",
-                  "cursor": "pointer",
-                  "display": "unset",
-                  "fontFamily": "unset",
-                  "fontSize": "unset",
-                  "fontWeight": "unset",
-                  "lineHeight": "unset",
-                  "margin": "unset",
-                  "outline": "none",
-                  "padding": 0,
-                  "transition": "unset",
-                }
-              }
-            >
-              <span
-                className="periodToggle"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.75rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  Previous Period
-                </span>
-                <span
-                  className="toggle"
-                  style={
-                    Object {
-                      "marginLeft": "auto",
-                    }
-                  }
-                >
-                  <span
-                    className="toggleSwitch"
-                  />
-                  <span
-                    className="toggleSwitchKnob"
-                  />
-                </span>
-              </span>
-            </button>
-          </span>
-        </div>
-        <div
-          className="sc-chPdSV hoBUjA"
+          className="sc-chPdSV haaEPG"
         >
           <div
             className="sc-bdVaJa fWzNTu"
@@ -1101,7 +1024,7 @@ exports[`Snapshots CompareChart should render a loading state 1`] = `
         }
       >
         <div
-          className="sc-chPdSV hoBUjA"
+          className="sc-chPdSV haaEPG"
         >
           <div
             style={

--- a/packages/compare-chart/components/CompareChart/index.jsx
+++ b/packages/compare-chart/components/CompareChart/index.jsx
@@ -20,7 +20,12 @@ import PeriodToggle from '../PeriodToggle';
 
 const Container = styled.div`
   position: relative;
-  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  height: 100%;
+  width: 100%;
 `;
 
 function getStartDate(dailyData) {
@@ -146,27 +151,29 @@ const CompareChart = ({
         totals={totals}
       />
     );
-    header = (
-      <div style={{ padding: '20px', display: 'flex' }} >
-        <MetricsDropdown
-          metrics={totals}
-          selectedMetricLabel={selectedMetricLabel}
-          isDropdownOpen={isDropdownOpen}
-          selectMetric={selectMetric}
-          openDropdown={openDropdown}
-          closeDropdown={closeDropdown}
-        />
-        {profileService === 'twitter' &&
-          <ModeToggle
-            baseModeLabel="Daily"
-            secondaryModeLabel="Period Total"
-            active={dailyMode === 1}
-            handleClick={selectDailyMode}
+    if (dailyData.length > 0) {
+      header = (
+        <div style={{ padding: '20px', display: 'flex' }} >
+          <MetricsDropdown
+            metrics={totals}
+            selectedMetricLabel={selectedMetricLabel}
+            isDropdownOpen={isDropdownOpen}
+            selectMetric={selectMetric}
+            openDropdown={openDropdown}
+            closeDropdown={closeDropdown}
           />
-        }
-        <PeriodToggle handleClick={togglePreviousPeriod} active={visualizePreviousPeriod} />
-      </div>
-    );
+          {profileService === 'twitter' &&
+            <ModeToggle
+              baseModeLabel="Daily"
+              secondaryModeLabel="Period Total"
+              active={dailyMode === 1}
+              handleClick={selectDailyMode}
+            />
+          }
+          <PeriodToggle handleClick={togglePreviousPeriod} active={visualizePreviousPeriod} />
+        </div>
+      );
+    }
   }
 
   const CHART_AND_HEADER_HEIGHT = '474px';

--- a/packages/compare-chart/components/CompareChart/story.jsx
+++ b/packages/compare-chart/components/CompareChart/story.jsx
@@ -146,7 +146,7 @@ storiesOf('CompareChart')
       }}
     >
       <CompareChart
-        profileService="facebook"
+        profileService="twitter"
         totalPeriodDaily={[]}
         totals={[]}
         timezone="America/Los_Angeles"


### PR DESCRIPTION
### Purpose

The loading and empty state weren't vertically centered on the Metrics Breakdown graph. This PR fixes it :)