### PR TITLE
[ANA-205] Add more meaningful titles for Contextual charts con reports

### DIFF
--- a/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
+++ b/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
@@ -3143,3 +3143,66 @@ exports[`Snapshots PresetsDropdown [TESTED] open dropdown 1`] = `
   </div>
 </span>
 `;
+
+exports[`Snapshots Title [TESTED] should render regular title even if for report if no preset was selected 1`] = `
+<span>
+  <h2
+    className="sc-gqjmRU liZjsx"
+  >
+    <span
+      style={
+        Object {
+          "color": "#000",
+          "fontFamily": "\\"Roboto\\", sans-serif",
+          "fontSize": "1.25rem",
+          "fontWeight": 700,
+        }
+      }
+    >
+      Engagement and audience
+    </span>
+  </h2>
+</span>
+`;
+
+exports[`Snapshots Title [TESTED] should render title as if for app 1`] = `
+<span>
+  <h2
+    className="sc-gqjmRU liZjsx"
+  >
+    <span
+      style={
+        Object {
+          "color": "#59626a",
+          "fontFamily": "\\"Roboto\\", sans-serif",
+          "fontSize": "1.25rem",
+          "fontWeight": 500,
+        }
+      }
+    >
+      Engagement and audience
+    </span>
+  </h2>
+</span>
+`;
+
+exports[`Snapshots Title [TESTED] should render title as if for report 1`] = `
+<span>
+  <h2
+    className="sc-gqjmRU liZjsx"
+  >
+    <span
+      style={
+        Object {
+          "color": "#000",
+          "fontFamily": "\\"Roboto\\", sans-serif",
+          "fontSize": "1.25rem",
+          "fontWeight": 700,
+        }
+      }
+    >
+      Engagement and audience
+    </span>
+  </h2>
+</span>
+`;

--- a/packages/contextual-compare/components/Title/index.jsx
+++ b/packages/contextual-compare/components/Title/index.jsx
@@ -2,18 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ChartTitle } from '@bufferapp/analyze-shared-components';
 
-const Title = ({ forReport }) => (
+const Title = ({ forReport, state, presets }) =>
   <ChartTitle forReport={forReport}>
-    Engagement and audience
-  </ChartTitle>
-);
+    { (forReport && state.mode === 0) ? presets[state.selectedPreset].label : 'Engagement and audience' }
+  </ChartTitle>;
 
 Title.propTypes = {
   forReport: PropTypes.bool,
+  state: PropTypes.shape({
+    selectedPreset: PropTypes.number,
+  }),
+  presets: PropTypes.arrayOf({
+    label: PropTypes.string,
+  }),
 };
 
 Title.defaultProps = {
   forReport: false,
+  state: {},
+  presets: [],
 };
 
 export default Title;

--- a/packages/contextual-compare/components/Title/story.jsx
+++ b/packages/contextual-compare/components/Title/story.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import Title from './index';
+
+const presets = [{
+  label: 'When is it most effective to post?',
+}];
+
+storiesOf('Title')
+  .addDecorator(checkA11y)
+  .add('[TESTED] should render title as if for app', () => (
+    <Title />
+  ))
+  .add('[TESTED] should render title as if for report', () => (
+    <Title forReport state={{ selectedPreset: 0 }} presets={presets} />
+  ))
+  .add('[TESTED] should render regular title even if for report if no preset was selected', () => (
+    <Title forReport state={{ selectedPreset: 0 }} presets={presets} />
+  ));
+

--- a/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
@@ -1217,7 +1217,7 @@ exports[`Snapshots HourlyChart [TESTED] loaded chart 1`] = `
                 }
               >
                 UTC 
-                +01:00
+                +02:00
               </span>
             </span>
           </section>
@@ -2569,7 +2569,7 @@ exports[`Snapshots HourlyChart [TESTED] second metric selected 1`] = `
                 }
               >
                 UTC 
-                +01:00
+                +02:00
               </span>
             </span>
           </section>


### PR DESCRIPTION
### Purpose

To ensure we're giving as much context on the answer they've persisted on a report by saving a contextual chart with a preset selected, the title for the chart will be the question selected in the dropdown, or "Engagements & Audience" if a custom combination was selected.