### PR TITLE
Show Engagement rate for IG on Metrics Breakdown Chart ANA-198

### DIFF
--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -1,5 +1,319 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Snapshots ChartTooltip should render a engagement rate tooltip 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "backgroundColor": "#343E46",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "color": "#fff",
+          "cursor": "default",
+          "fontFamily": "Roboto, sans serif",
+          "fontSize": "9pt",
+          "padding": "10px",
+          "pointerEvents": "none",
+          "whiteSpace": "normal",
+          "width": "185px",
+        }
+      }
+    >
+      <span>
+        <span
+          style={
+            Object {
+              "color": "#e6ebef",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+            }
+          }
+        >
+          12 September
+        </span>
+        <br />
+        <br />
+      </span>
+      <span>
+        <span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            There 
+            were
+             a total of 
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+            <span>
+              5
+            </span>
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             
+            posts
+             published
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             with an Engagement Rate of 
+            8
+            %
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            .
+          </span>
+        </span>
+      </span>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`Snapshots ChartTooltip should render a engagement rate tooltip with previous period 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "backgroundColor": "#343E46",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "color": "#fff",
+          "cursor": "default",
+          "fontFamily": "Roboto, sans serif",
+          "fontSize": "9pt",
+          "padding": "10px",
+          "pointerEvents": "none",
+          "whiteSpace": "normal",
+          "width": "185px",
+        }
+      }
+    >
+      <span>
+        <span
+          style={
+            Object {
+              "color": "#e6ebef",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+            }
+          }
+        >
+          12 September
+        </span>
+        <span>
+          <br />
+          <span
+            style={
+              Object {
+                "color": "#e6ebef",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            comparing to 
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#e6ebef",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            23 August
+          </span>
+        </span>
+        <br />
+        <br />
+      </span>
+      <span>
+        <span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            There 
+            were
+             a total of 
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+            <span>
+              5
+            </span>
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             
+            posts
+             published
+          </span>
+          <span
+            style={
+              Object {
+                "color": "#fff",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+             with an Engagement Rate of 
+            8
+            %
+          </span>
+          <span>
+            <span
+              style={
+                Object {
+                  "color": "#fff",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              , compared with 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#fff",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+               an Engagement Rate of 
+              8
+              % for 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#fff",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              <span>
+                10
+              </span>
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#fff",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+               
+              posts
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#fff",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+               previously.
+            </span>
+          </span>
+        </span>
+      </span>
+    </div>
+  </div>
+</span>
+`;
+
 exports[`Snapshots ChartTooltip should render a no update published message 1`] = `
 <span>
   <div

--- a/packages/compare-chart/components/ChartTooltip/index.jsx
+++ b/packages/compare-chart/components/ChartTooltip/index.jsx
@@ -12,6 +12,10 @@ function isUpdatesMetric(label) {
   return Boolean(label.match(/^(posts|tweets)$/i));
 }
 
+function isEngagementRateMetric(label) {
+  return Boolean(label.match(/^(engagement rate)$/i));
+}
+
 function postsWording(profileService, count = 1) {
   let wording = '';
   switch (profileService) {
@@ -145,6 +149,54 @@ UpdatesTooltip.defaultProps = {
   visualizePreviousPeriod: false,
 };
 
+const EngagementRateTooltip = ({
+  postsCount,
+  previousPostsCount,
+  value,
+  previousValue,
+  visualizePreviousPeriod,
+  profileService,
+}) => (
+  <span>
+    <Text color="white" size="small" >There {wasOrWere(postsCount)} a total of </Text>
+    <Text color="white" size="small" weight="bold" >
+      <TruncatedNumber>{postsCount}</TruncatedNumber>
+    </Text>
+    <Text color="white" size="small" > {postsWording(profileService, postsCount)} published</Text>
+    <Text color="white" size="small" > with an Engagement Rate of {value}%</Text>
+
+    {visualizePreviousPeriod && <span>
+      <Text color="white" size="small" >, compared with </Text>
+      <Text color="white" size="small" > an Engagement Rate of {previousValue}% for </Text>
+      <Text color="white" size="small" weight="bold" >
+        <TruncatedNumber>{previousPostsCount}</TruncatedNumber>
+      </Text>
+      <Text color="white" size="small" > {postsWording(profileService, postsCount)}</Text>
+      <Text color="white" size="small" > previously.</Text>
+    </span>}
+    {!visualizePreviousPeriod && <Text color="white" size="small" >.</Text>}
+  </span>
+);
+
+EngagementRateTooltip.propTypes = {
+  postsCount: PropTypes.number,
+  previousPostsCount: PropTypes.number,
+  visualizePreviousPeriod: PropTypes.bool,
+  profileService: PropTypes.string.isRequired,
+  value: PropTypes.number,
+  previousValue: PropTypes.number,
+};
+
+EngagementRateTooltip.defaultProps = {
+  color: null,
+  label: null,
+  postsCount: null,
+  previousPostsCount: null,
+  value: null,
+  previousValue: null,
+  visualizePreviousPeriod: false,
+};
+
 const Header = ({
   day,
   previousPeriodDay,
@@ -192,9 +244,12 @@ const ChartTooltip = ({
     <Header day={day} {...extraProps} />
     {label && <span>
       {!isUpdatesMetric(label) &&
+        !isEngagementRateMetric(label)&&
         <StandardTolltip profileService={profileService} label={label} {...extraProps} />}
       {isUpdatesMetric(label) &&
         <UpdatesTooltip profileService={profileService}label={label} {...extraProps} />}
+      {isEngagementRateMetric(label) &&
+        <EngagementRateTooltip profileService={profileService}label={label} {...extraProps} />}
     </span>}
     {!label && <span>
       <Text color="white" size="small" >There was no {postsWording(profileService)}s published at this time</Text>

--- a/packages/compare-chart/components/ChartTooltip/story.jsx
+++ b/packages/compare-chart/components/ChartTooltip/story.jsx
@@ -117,4 +117,45 @@ storiesOf('ChartTooltip')
         timezone="America/New_York"
       />
     </div>
+  ))
+  .add('should render a engagement rate tooltip', () => (
+    <div
+      style={{
+        backgroundColor: '#343E46',
+      }}
+    >
+      <ChartTooltip
+        color="#fda3f3"
+        day={dayTimestamp}
+        previousPeriodDay={previousDayTimestamp}
+        label="Engagement Rate"
+        postsCount={5}
+        previousPostsCount={10}
+        value={8}
+        previousValue={8}
+        profileService="facebook"
+        timezone="America/New_York"
+      />
+    </div>
+  ))
+  .add('should render a engagement rate tooltip with previous period', () => (
+    <div
+      style={{
+        backgroundColor: '#343E46',
+      }}
+    >
+      <ChartTooltip
+        color="#fda3f3"
+        day={dayTimestamp}
+        previousPeriodDay={previousDayTimestamp}
+        label="Engagement Rate"
+        postsCount={5}
+        previousPostsCount={10}
+        value={8}
+        previousValue={8}
+        profileService="facebook"
+        timezone="America/New_York"
+        visualizePreviousPeriod
+      />
+    </div>
   ));

--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -1,4 +1,3 @@
-
 const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
 const DateRange = require('../utils/DateRange');

--- a/packages/server/rpc/compare/metricsConfig.js
+++ b/packages/server/rpc/compare/metricsConfig.js
@@ -121,6 +121,11 @@ const instagramConfig = {
     label: 'New Fans',
     color: '#D7B5FD',
   },
+
+  engagement_rate: {
+    label: 'Engagement Rate',
+    color: '#98E8B2',
+  },
 };
 
 module.exports = {
@@ -161,6 +166,7 @@ module.exports = {
       'likes',
       'comments',
       'new_followers',
+      'engagement_rate',
     ],
   },
 };


### PR DESCRIPTION
### Purpose
To show Engagement Rate for Instagram in the Metrics Breakdown chart

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
