### PR TITLE
Add Facebook engagement rate metric to FB compare chart ANA-122

### DIFF
--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -129,7 +129,6 @@ function formatDaily(
       null,
   })).filter(data => data.previousPeriodDay !== null).map((data) => {
     const metricKeys = METRICS_CONFIG[profileService].orderedKeys;
-    console.log(metricKeys);
     return {
       day: data.day,
       previousPeriodDay: data.previousPeriodDay,

--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -129,6 +129,7 @@ function formatDaily(
       null,
   })).filter(data => data.previousPeriodDay !== null).map((data) => {
     const metricKeys = METRICS_CONFIG[profileService].orderedKeys;
+    console.log(metricKeys);
     return {
       day: data.day,
       previousPeriodDay: data.previousPeriodDay,

--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -202,7 +202,7 @@ describe('rpc/compare', () => {
       },
     });
 
-    expect(data.totals.length).toBe(10);
+    expect(data.totals.length).toBe(11);
     expect(data.totals[0]).toEqual({
       diff: 0,
       key: 'followers',
@@ -229,7 +229,7 @@ describe('rpc/compare', () => {
       },
     });
 
-    expect(data.totals.length).toBe(10);
+    expect(data.totals.length).toBe(11);
     expect(data.totals[0]).toEqual({
       diff: 9932400,
       key: 'followers',

--- a/packages/server/rpc/compare/metricsConfig.js
+++ b/packages/server/rpc/compare/metricsConfig.js
@@ -94,6 +94,11 @@ const facebookConfig = {
     label: 'New Fans',
     color: '#D7B5FD',
   },
+
+  engagement_rate: {
+    label: 'Engagement Rate',
+    color: '#98E8B2',
+  },
 };
 
 const instagramConfig = {
@@ -156,6 +161,7 @@ module.exports = {
       'shares',
       'comments',
       'new_followers',
+      'engagement_rate',
     ],
   },
   instagram: {


### PR DESCRIPTION
### Purpose

Engagement Rate = `page_story_adds` / `page_posts_impressions`. 

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
