### PR TITLE
show Engagement rate on Instagram posts ANA-198

### DIFF
--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -5212,6 +5212,156 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                         </button>
                       </li>
                     </span>
+                    <span>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              ASC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              DESC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </span>
                   </ul>
                 </div>
               </div>

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -5425,6 +5425,53 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                       />
                     </div>
                   </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
                 </div>
               </li>
               <li
@@ -5594,6 +5641,53 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                       />
                     </div>
                   </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
                 </div>
               </li>
               <li
@@ -5751,6 +5845,53 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                           Object {
                             "backgroundColor": "#EFDF00",
                             "width": "17.142857142857142%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />

--- a/packages/posts-table/components/PostsTable/metrics.js
+++ b/packages/posts-table/components/PostsTable/metrics.js
@@ -24,9 +24,18 @@ instagram.likesMetric = {
   value: 0,
 };
 
+instagram.EngagementRateMetric = {
+  label: 'Engagement Rate',
+  key: 'engagement_rate',
+  apiKey: 'engagement_rate',
+  color: '#98E8B2',
+  value: 0,
+};
+
 instagram.topPostsEngagementMetrics = [
   instagram.likesMetric,
   instagram.commentsMetric,
+  instagram.EngagementRateMetric,
 ];
 
 instagram.postMetrics = [

--- a/packages/posts-table/components/PostsTable/metrics.js
+++ b/packages/posts-table/components/PostsTable/metrics.js
@@ -42,6 +42,7 @@ instagram.postMetrics = [
   instagram.likesMetric,
   instagram.commentsMetric,
   instagram.dateMetric,
+  instagram.EngagementRateMetric,
 ];
 
 instagram.topPostsAudienceMetrics = [];

--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -23,6 +23,7 @@ const LABELS = {
     posts_count: 'Posts',
     likes: 'Likes',
     comments: 'Comments',
+    engagement_rate: 'Engagement Rate',
   },
 };
 


### PR DESCRIPTION
### Purpose
Display posts engagement rate, and add sort by engagement rate, in Instagram posts tab

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
