### PR TITLE
show new metrics in Instagram posts summary (ANA-158)

### DIFF
--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -21,8 +21,10 @@ const LABELS = {
   },
   instagram: {
     posts_count: 'Posts',
-    likes: 'Likes',
-    comments: 'Comments',
+    impressions: 'Post Impressions',
+    reach: 'Post Reach',
+    likes: 'Post Likes',
+    comments: 'Post Comments',
     engagement_rate: 'Engagement Rate',
   },
 };


### PR DESCRIPTION
### Purpose
To show the following metrics in Instagram Post summary table:
- Posts
- Post Impressions
- Post Reach
- Post Likes
- Post Comments
- Engagement Rate

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
