### PR TITLE
Add engagement rate to Facebook posts tab (summary and post breakdown) ANA-122

### DIFF
--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -3424,6 +3424,156 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                         </button>
                       </li>
                     </span>
+                    <span>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              ASC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              DESC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </span>
                   </ul>
                 </div>
               </div>
@@ -3742,6 +3892,53 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           Object {
                             "backgroundColor": "#D2C3AB",
                             "width": "7.597000326051516%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -4108,6 +4305,53 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                       />
                     </div>
                   </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -4457,6 +4701,53 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           Object {
                             "backgroundColor": "#D2C3AB",
                             "width": "0.9781545484186501%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -9137,6 +9428,156 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                         </button>
                       </li>
                     </span>
+                    <span>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              ASC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              DESC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </span>
                   </ul>
                 </div>
               </div>
@@ -9455,6 +9896,53 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           Object {
                             "backgroundColor": "#D2C3AB",
                             "width": "7.597000326051516%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -9821,6 +10309,53 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                       />
                     </div>
                   </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -10170,6 +10705,53 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           Object {
                             "backgroundColor": "#D2C3AB",
                             "width": "0.9781545484186501%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />

--- a/packages/posts-table/components/PostsTable/metrics.js
+++ b/packages/posts-table/components/PostsTable/metrics.js
@@ -167,11 +167,20 @@ facebook.sharesMetric = {
   value: 0,
 };
 
+facebook.EngagementRateMetric = {
+  label: 'Engagement Rate',
+  key: 'engagement_rate',
+  apiKey: 'engagement_rate',
+  color: '#98E8B2',
+  value: 0,
+};
+
 facebook.topPostsEngagementMetrics = [
   facebook.postClicksMetric,
   facebook.reactionsMetric,
   facebook.commentsMetric,
   facebook.sharesMetric,
+  facebook.EngagementRateMetric,
 ];
 
 facebook.postMetrics = [
@@ -182,6 +191,7 @@ facebook.postMetrics = [
   facebook.commentsMetric,
   facebook.sharesMetric,
   facebook.dateMetric,
+  facebook.EngagementRateMetric,
 ];
 
 facebook.topPostsAudienceMetrics = [

--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -10,6 +10,7 @@ const LABELS = {
     reactions: 'Reactions',
     comments: 'Comments',
     shares: 'Shares',
+    engagement_rate: 'Engagement Rate',
   },
   twitter: {
     posts_count: 'Posts',

--- a/packages/server/rpc/postsSummary/index.test.js
+++ b/packages/server/rpc/postsSummary/index.test.js
@@ -167,6 +167,11 @@ describe('rpc/posts_summary', () => {
         value: 5,
         diff: 150,
       },
+      {
+        label: 'Engagement Rate',
+        value: 12,
+        diff: 100,
+      },
     ]);
   });
 });

--- a/packages/server/rpc/postsSummary/mockResponses.js
+++ b/packages/server/rpc/postsSummary/mockResponses.js
@@ -6,6 +6,7 @@ export const CURRENT_PERIOD_RESPONSE = {
     posts_count: 3,
     reactions: 9391,
     shares: 5,
+    engagement_rate: 12,
   },
   success: true,
 };
@@ -17,6 +18,7 @@ export const PAST_PERIOD_RESPONSE = {
     posts_count: 5,
     reactions: 9391,
     shares: 2,
+    engagement_rate: 6,
   },
   success: true,
 };


### PR DESCRIPTION
### Purpose
We should display engagement rate metric on FB "Post Summary" and "Post Breakdown" tables.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
