### PR TITLE
 Add engagement and impressions in Instagram PostsTable (ana-159)

### DIFF
--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -3329,7 +3329,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Date
+                              Engagement Rate
                             </span>
                             <span>
                                
@@ -3403,7 +3403,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Date
+                              Engagement Rate
                             </span>
                             <span>
                                
@@ -3479,7 +3479,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Engagement Rate
+                              Date
                             </span>
                             <span>
                                
@@ -3553,7 +3553,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Engagement Rate
+                              Date
                             </span>
                             <span>
                                
@@ -3897,53 +3897,6 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                       />
                     </div>
                   </div>
-                  <div>
-                    <div
-                      className="metricBarGraphContainer"
-                    >
-                      <span
-                        className="metricBarLabel"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                      <span
-                        className="metricBarGraph"
-                        data-tip="Engagement Rate"
-                        style={
-                          Object {
-                            "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
-                          }
-                        }
-                      />
-                    </div>
-                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -4037,6 +3990,53 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           Object {
                             "backgroundColor": "#FFC880",
                             "width": "13.411667662679807%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -4305,53 +4305,6 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                       />
                     </div>
                   </div>
-                  <div>
-                    <div
-                      className="metricBarGraphContainer"
-                    >
-                      <span
-                        className="metricBarLabel"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                      <span
-                        className="metricBarGraph"
-                        data-tip="Engagement Rate"
-                        style={
-                          Object {
-                            "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
-                          }
-                        }
-                      />
-                    </div>
-                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -4445,6 +4398,53 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           Object {
                             "backgroundColor": "#FFC880",
                             "width": "7.223480097974025%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -4706,53 +4706,6 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                       />
                     </div>
                   </div>
-                  <div>
-                    <div
-                      className="metricBarGraphContainer"
-                    >
-                      <span
-                        className="metricBarLabel"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                      <span
-                        className="metricBarGraph"
-                        data-tip="Engagement Rate"
-                        style={
-                          Object {
-                            "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
-                          }
-                        }
-                      />
-                    </div>
-                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -4846,6 +4799,53 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           Object {
                             "backgroundColor": "#FFC880",
                             "width": "5.130169097780434%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -5503,156 +5503,6 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                         </button>
                       </li>
                     </span>
-                    <span>
-                      <li
-                        className="dropdownListItem"
-                      >
-                        <button
-                          aria-label={null}
-                          disabled={undefined}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "background": "none",
-                              "backgroundColor": "unset",
-                              "border": "none",
-                              "borderRadius": "unset",
-                              "color": "unset",
-                              "cursor": "pointer",
-                              "display": "unset",
-                              "fontFamily": "unset",
-                              "fontSize": "unset",
-                              "fontWeight": "unset",
-                              "lineHeight": "unset",
-                              "margin": "unset",
-                              "outline": "none",
-                              "padding": 0,
-                              "transition": "unset",
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "alignItems": "center",
-                                "boxSizing": "border-box",
-                                "display": "flex",
-                                "marginTop": "7px",
-                                "padding": "5px 10px",
-                                "position": "relative",
-                                "width": "200px",
-                              }
-                            }
-                          >
-                            <span
-                              style={
-                                Object {
-                                  "color": "#59626a",
-                                  "fontFamily": "\\"Roboto\\", sans-serif",
-                                  "fontSize": "0.75rem",
-                                  "fontWeight": 700,
-                                }
-                              }
-                            >
-                              Engagement Rate
-                            </span>
-                            <span>
-                               
-                            </span>
-                            <span
-                              style={
-                                Object {
-                                  "color": "#59626a",
-                                  "fontFamily": "\\"Roboto\\", sans-serif",
-                                  "fontSize": "0.75rem",
-                                  "fontWeight": 400,
-                                }
-                              }
-                            >
-                              ASC
-                            </span>
-                          </span>
-                        </button>
-                      </li>
-                      <li
-                        className="dropdownListItem"
-                      >
-                        <button
-                          aria-label={null}
-                          disabled={undefined}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "background": "none",
-                              "backgroundColor": "unset",
-                              "border": "none",
-                              "borderRadius": "unset",
-                              "color": "unset",
-                              "cursor": "pointer",
-                              "display": "unset",
-                              "fontFamily": "unset",
-                              "fontSize": "unset",
-                              "fontWeight": "unset",
-                              "lineHeight": "unset",
-                              "margin": "unset",
-                              "outline": "none",
-                              "padding": 0,
-                              "transition": "unset",
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "alignItems": "center",
-                                "boxSizing": "border-box",
-                                "display": "flex",
-                                "marginTop": "7px",
-                                "padding": "5px 10px",
-                                "position": "relative",
-                                "width": "200px",
-                              }
-                            }
-                          >
-                            <span
-                              style={
-                                Object {
-                                  "color": "#59626a",
-                                  "fontFamily": "\\"Roboto\\", sans-serif",
-                                  "fontSize": "0.75rem",
-                                  "fontWeight": 700,
-                                }
-                              }
-                            >
-                              Engagement Rate
-                            </span>
-                            <span>
-                               
-                            </span>
-                            <span
-                              style={
-                                Object {
-                                  "color": "#59626a",
-                                  "fontFamily": "\\"Roboto\\", sans-serif",
-                                  "fontSize": "0.75rem",
-                                  "fontWeight": 400,
-                                }
-                              }
-                            >
-                              DESC
-                            </span>
-                          </span>
-                        </button>
-                      </li>
-                    </span>
                   </ul>
                 </div>
               </div>
@@ -5866,6 +5716,10 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                       />
                     </div>
                   </div>
+                </div>
+                <div
+                  className="metricColumn"
+                >
                   <div>
                     <div
                       className="metricBarGraphContainer"
@@ -5907,7 +5761,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                         style={
                           Object {
                             "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
+                            "width": "0%",
                           }
                         }
                       />
@@ -6082,6 +5936,10 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                       />
                     </div>
                   </div>
+                </div>
+                <div
+                  className="metricColumn"
+                >
                   <div>
                     <div
                       className="metricBarGraphContainer"
@@ -6123,7 +5981,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                         style={
                           Object {
                             "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
+                            "width": "0%",
                           }
                         }
                       />
@@ -6291,6 +6149,10 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                       />
                     </div>
                   </div>
+                </div>
+                <div
+                  className="metricColumn"
+                >
                   <div>
                     <div
                       className="metricBarGraphContainer"
@@ -6332,7 +6194,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                         style={
                           Object {
                             "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
+                            "width": "0%",
                           }
                         }
                       />
@@ -9624,7 +9486,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Date
+                              Engagement Rate
                             </span>
                             <span>
                                
@@ -9698,7 +9560,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Date
+                              Engagement Rate
                             </span>
                             <span>
                                
@@ -9774,7 +9636,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Engagement Rate
+                              Date
                             </span>
                             <span>
                                
@@ -9848,7 +9710,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Engagement Rate
+                              Date
                             </span>
                             <span>
                                
@@ -10192,53 +10054,6 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                       />
                     </div>
                   </div>
-                  <div>
-                    <div
-                      className="metricBarGraphContainer"
-                    >
-                      <span
-                        className="metricBarLabel"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                      <span
-                        className="metricBarGraph"
-                        data-tip="Engagement Rate"
-                        style={
-                          Object {
-                            "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
-                          }
-                        }
-                      />
-                    </div>
-                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -10332,6 +10147,53 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           Object {
                             "backgroundColor": "#FFC880",
                             "width": "13.411667662679807%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -10600,53 +10462,6 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                       />
                     </div>
                   </div>
-                  <div>
-                    <div
-                      className="metricBarGraphContainer"
-                    >
-                      <span
-                        className="metricBarLabel"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                      <span
-                        className="metricBarGraph"
-                        data-tip="Engagement Rate"
-                        style={
-                          Object {
-                            "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
-                          }
-                        }
-                      />
-                    </div>
-                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -10740,6 +10555,53 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           Object {
                             "backgroundColor": "#FFC880",
                             "width": "7.223480097974025%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />
@@ -11001,53 +10863,6 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                       />
                     </div>
                   </div>
-                  <div>
-                    <div
-                      className="metricBarGraphContainer"
-                    >
-                      <span
-                        className="metricBarLabel"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                      <span
-                        className="metricBarGraph"
-                        data-tip="Engagement Rate"
-                        style={
-                          Object {
-                            "backgroundColor": "#98E8B2",
-                            "width": "NaN%",
-                          }
-                        }
-                      />
-                    </div>
-                  </div>
                 </div>
                 <div
                   className="metricColumn"
@@ -11141,6 +10956,53 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           Object {
                             "backgroundColor": "#FFC880",
                             "width": "5.130169097780434%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Engagement Rate"
+                        style={
+                          Object {
+                            "backgroundColor": "#98E8B2",
+                            "width": "NaN%",
                           }
                         }
                       />

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -2397,7 +2397,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Post Impressions
+                              Impressions
                             </span>
                             <span>
                                
@@ -2471,7 +2471,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Post Impressions
+                              Impressions
                             </span>
                             <span>
                                
@@ -2579,7 +2579,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Post Reach
+                              Reach
                             </span>
                             <span>
                                
@@ -2653,7 +2653,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                                 }
                               }
                             >
-                              Post Reach
+                              Reach
                             </span>
                             <span>
                                
@@ -3933,12 +3933,12 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           }
                         >
                            
-                          post impressions
+                          impressions
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Impressions"
+                        data-tip="Impressions"
                         style={
                           Object {
                             "backgroundColor": "#8AC6DE",
@@ -3980,12 +3980,12 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           }
                         >
                            
-                          post reach
+                          reach
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Reach"
+                        data-tip="Reach"
                         style={
                           Object {
                             "backgroundColor": "#FFC880",
@@ -4341,12 +4341,12 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           }
                         >
                            
-                          post impressions
+                          impressions
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Impressions"
+                        data-tip="Impressions"
                         style={
                           Object {
                             "backgroundColor": "#8AC6DE",
@@ -4388,12 +4388,12 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           }
                         >
                            
-                          post reach
+                          reach
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Reach"
+                        data-tip="Reach"
                         style={
                           Object {
                             "backgroundColor": "#FFC880",
@@ -4742,12 +4742,12 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           }
                         >
                            
-                          post impressions
+                          impressions
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Impressions"
+                        data-tip="Impressions"
                         style={
                           Object {
                             "backgroundColor": "#8AC6DE",
@@ -4789,12 +4789,12 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                           }
                         >
                            
-                          post reach
+                          reach
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Reach"
+                        data-tip="Reach"
                         style={
                           Object {
                             "backgroundColor": "#FFC880",
@@ -9286,7 +9286,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Post Impressions
+                              Impressions
                             </span>
                             <span>
                                
@@ -9360,7 +9360,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Post Impressions
+                              Impressions
                             </span>
                             <span>
                                
@@ -9468,7 +9468,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Post Reach
+                              Reach
                             </span>
                             <span>
                                
@@ -9542,7 +9542,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                                 }
                               }
                             >
-                              Post Reach
+                              Reach
                             </span>
                             <span>
                                
@@ -10822,12 +10822,12 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           }
                         >
                            
-                          post impressions
+                          impressions
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Impressions"
+                        data-tip="Impressions"
                         style={
                           Object {
                             "backgroundColor": "#8AC6DE",
@@ -10869,12 +10869,12 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           }
                         >
                            
-                          post reach
+                          reach
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Reach"
+                        data-tip="Reach"
                         style={
                           Object {
                             "backgroundColor": "#FFC880",
@@ -11230,12 +11230,12 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           }
                         >
                            
-                          post impressions
+                          impressions
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Impressions"
+                        data-tip="Impressions"
                         style={
                           Object {
                             "backgroundColor": "#8AC6DE",
@@ -11277,12 +11277,12 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           }
                         >
                            
-                          post reach
+                          reach
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Reach"
+                        data-tip="Reach"
                         style={
                           Object {
                             "backgroundColor": "#FFC880",
@@ -11631,12 +11631,12 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           }
                         >
                            
-                          post impressions
+                          impressions
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Impressions"
+                        data-tip="Impressions"
                         style={
                           Object {
                             "backgroundColor": "#8AC6DE",
@@ -11678,12 +11678,12 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                           }
                         >
                            
-                          post reach
+                          reach
                         </span>
                       </span>
                       <span
                         className="metricBarGraph"
-                        data-tip="Post Reach"
+                        data-tip="Reach"
                         style={
                           Object {
                             "backgroundColor": "#FFC880",

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -5408,6 +5408,456 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                                 }
                               }
                             >
+                              Impressions
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              ASC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Impressions
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              DESC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </span>
+                    <span>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Reach
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              ASC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Reach
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              DESC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </span>
+                    <span>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              ASC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
+                              Engagement Rate
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 400,
+                                }
+                              }
+                            >
+                              DESC
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </span>
+                    <span>
+                      <li
+                        className="dropdownListItem"
+                      >
+                        <button
+                          aria-label={null}
+                          disabled={undefined}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": "none",
+                              "backgroundColor": "unset",
+                              "border": "none",
+                              "borderRadius": "unset",
+                              "color": "unset",
+                              "cursor": "pointer",
+                              "display": "unset",
+                              "fontFamily": "unset",
+                              "fontSize": "unset",
+                              "fontWeight": "unset",
+                              "lineHeight": "unset",
+                              "margin": "unset",
+                              "outline": "none",
+                              "padding": 0,
+                              "transition": "unset",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "marginTop": "7px",
+                                "padding": "5px 10px",
+                                "position": "relative",
+                                "width": "200px",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#59626a",
+                                  "fontFamily": "\\"Roboto\\", sans-serif",
+                                  "fontSize": "0.75rem",
+                                  "fontWeight": 700,
+                                }
+                              }
+                            >
                               Date
                             </span>
                             <span>
@@ -5752,6 +6202,100 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                           }
                         >
                            
+                          impressions
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Impressions"
+                        style={
+                          Object {
+                            "backgroundColor": "#8AC6DE",
+                            "width": "0%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Reach"
+                        style={
+                          Object {
+                            "backgroundColor": "#FFC880",
+                            "width": "0%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
                           engagement rate
                         </span>
                       </span>
@@ -5972,6 +6516,100 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                           }
                         >
                            
+                          impressions
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Impressions"
+                        style={
+                          Object {
+                            "backgroundColor": "#8AC6DE",
+                            "width": "0%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Reach"
+                        style={
+                          Object {
+                            "backgroundColor": "#FFC880",
+                            "width": "0%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
                           engagement rate
                         </span>
                       </span>
@@ -6153,6 +6791,100 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                 <div
                   className="metricColumn"
                 >
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Impressions"
+                        style={
+                          Object {
+                            "backgroundColor": "#8AC6DE",
+                            "width": "0%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      className="metricBarGraphContainer"
+                    >
+                      <span
+                        className="metricBarLabel"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.75rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                      <span
+                        className="metricBarGraph"
+                        data-tip="Reach"
+                        style={
+                          Object {
+                            "backgroundColor": "#FFC880",
+                            "width": "0%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
                   <div>
                     <div
                       className="metricBarGraphContainer"

--- a/packages/posts-table/components/PostsTable/metrics.js
+++ b/packages/posts-table/components/PostsTable/metrics.js
@@ -167,7 +167,7 @@ facebook.postClicksMetric = {
 };
 
 facebook.impressionsMetric = {
-  label: 'Post Impressions',
+  label: 'Impressions',
   key: 'post_impressions',
   apiKey: 'post_impressions',
   color: '#8AC6DE',
@@ -175,7 +175,7 @@ facebook.impressionsMetric = {
 };
 
 facebook.postReachMetric = {
-  label: 'Post Reach',
+  label: 'Reach',
   key: 'post_reach',
   apiKey: 'post_reach',
   color: '#FFC880',

--- a/packages/posts-table/components/PostsTable/metrics.js
+++ b/packages/posts-table/components/PostsTable/metrics.js
@@ -32,6 +32,22 @@ instagram.engagementRateMetric = {
   value: 0,
 };
 
+instagram.impressionsMetric = {
+  label: 'Impressions',
+  key: 'impressions',
+  apiKey: 'impressions',
+  color: '#8AC6DE',
+  value: 0,
+};
+
+instagram.reachMetric = {
+  label: 'Reach',
+  key: 'reach',
+  apiKey: 'reach',
+  color: '#FFC880',
+  value: 0,
+};
+
 instagram.topPostsEngagementMetrics = [
   instagram.likesMetric,
   instagram.commentsMetric,
@@ -40,11 +56,15 @@ instagram.topPostsEngagementMetrics = [
 instagram.postMetrics = [
   instagram.likesMetric,
   instagram.commentsMetric,
+  instagram.impressionsMetric,
+  instagram.reachMetric,
   instagram.engagementRateMetric,
   instagram.dateMetric,
 ];
 
 instagram.topPostsAudienceMetrics = [
+  instagram.impressionsMetric,
+  instagram.reachMetric,
   instagram.engagementRateMetric,
 ];
 

--- a/packages/posts-table/components/PostsTable/metrics.js
+++ b/packages/posts-table/components/PostsTable/metrics.js
@@ -24,7 +24,7 @@ instagram.likesMetric = {
   value: 0,
 };
 
-instagram.EngagementRateMetric = {
+instagram.engagementRateMetric = {
   label: 'Engagement Rate',
   key: 'engagement_rate',
   apiKey: 'engagement_rate',
@@ -35,17 +35,18 @@ instagram.EngagementRateMetric = {
 instagram.topPostsEngagementMetrics = [
   instagram.likesMetric,
   instagram.commentsMetric,
-  instagram.EngagementRateMetric,
 ];
 
 instagram.postMetrics = [
   instagram.likesMetric,
   instagram.commentsMetric,
+  instagram.engagementRateMetric,
   instagram.dateMetric,
-  instagram.EngagementRateMetric,
 ];
 
-instagram.topPostsAudienceMetrics = [];
+instagram.topPostsAudienceMetrics = [
+  instagram.engagementRateMetric,
+];
 
 
 export const twitter = {};
@@ -90,7 +91,7 @@ twitter.likesMetric = {
   value: 0,
 };
 
-twitter.EngagementRateMetric = {
+twitter.engagementRateMetric = {
   label: 'Engagement Rate',
   key: 'engagement_rate',
   apiKey: 'engagement_rate',
@@ -106,7 +107,7 @@ twitter.topPostsEngagementMetrics = [
 
 twitter.postMetrics = [
   twitter.impressionsMetric,
-  twitter.EngagementRateMetric,
+  twitter.engagementRateMetric,
   twitter.clicksMetric,
   twitter.retweetsMetric,
   twitter.likesMetric,
@@ -115,7 +116,7 @@ twitter.postMetrics = [
 
 twitter.topPostsAudienceMetrics = [
   twitter.impressionsMetric,
-  twitter.EngagementRateMetric,
+  twitter.engagementRateMetric,
 ];
 
 // Facebook Metrics Configuration
@@ -177,7 +178,7 @@ facebook.sharesMetric = {
   value: 0,
 };
 
-facebook.EngagementRateMetric = {
+facebook.engagementRateMetric = {
   label: 'Engagement Rate',
   key: 'engagement_rate',
   apiKey: 'engagement_rate',
@@ -190,7 +191,6 @@ facebook.topPostsEngagementMetrics = [
   facebook.reactionsMetric,
   facebook.commentsMetric,
   facebook.sharesMetric,
-  facebook.EngagementRateMetric,
 ];
 
 facebook.postMetrics = [
@@ -200,13 +200,14 @@ facebook.postMetrics = [
   facebook.reactionsMetric,
   facebook.commentsMetric,
   facebook.sharesMetric,
+  facebook.engagementRateMetric,
   facebook.dateMetric,
-  facebook.EngagementRateMetric,
 ];
 
 facebook.topPostsAudienceMetrics = [
   facebook.impressionsMetric,
   facebook.postReachMetric,
+  facebook.engagementRateMetric,
 ];
 
 // Exports


### PR DESCRIPTION
### Purpose
To add Engagement and Impressions metrics in Instagram Posts Table
The visible metrics are now:
- Likes
- Comments
- Post Impressions
- Post Reach
- Engagement Rate 

### Notes
This also:
- move Engagement Rate metrics into the Audience column for Facebook
- rename Post Impressions and Post Reach label for Twitter so that they enter in one line 

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
