### PR TITLE
update moment-timezone to 0.5.16

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,7 +35,7 @@
     "micro-rpc-client": "0.1.2",
     "microrouter": "2.1.1",
     "moment": "^2.18.1",
-    "moment-timezone": "0.5.12",
+    "moment-timezone": "0.5.16",
     "node-dogstatsd": "0.0.6",
     "request": "2.81.0",
     "request-promise": "4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7060,9 +7060,9 @@ modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
-moment-timezone@0.5.12:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.12.tgz#d8d6fa51b365050de1ac7cc5c6e3fa969444edea"
+moment-timezone@0.5.16:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.16.tgz#661717d5f55b4d2c2e002262d726c83785192a5a"
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
### Purpose
To update IANA TZDB 2018d

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
