### PR TITLE
Posts Summary Metrics (ANA-197)

### DIFF
--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -5,7 +5,6 @@ const DateRange = require('../utils/DateRange');
 const LABELS = {
   facebook: {
     posts_count: 'Posts',
-    post_impressions: 'Post Impressions',
     post_reach: 'Post Reach',
     reactions: 'Reactions',
     comments: 'Comments',

--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -15,10 +15,10 @@ const LABELS = {
   twitter: {
     posts_count: 'Posts',
     retweets: 'Retweets',
-    impressions: 'Impressions',
     replies: 'Replies',
     url_clicks: 'Clicks',
     favorites: 'Likes',
+    engagement_rate: 'Engagement Rate',
   },
   instagram: {
     posts_count: 'Posts',

--- a/packages/server/rpc/postsSummary/index.test.js
+++ b/packages/server/rpc/postsSummary/index.test.js
@@ -143,11 +143,6 @@ describe('rpc/posts_summary', () => {
         diff: -40,
       },
       {
-        label: 'Post Impressions',
-        value: 56755,
-        diff: 25,
-      },
-      {
         label: 'Post Reach',
         value: 1181030,
         diff: -0,


### PR DESCRIPTION
### Purpose
- replace Impressions with Engagement Rate to Twitter Posts Summary
- remove Impressions from Facebook Posts summary to bring it to 6 metrics

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
