### PR TITLE
update buffermetrics to 0.5.2

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
   },
   "author": "mike@msanroman.io",
   "dependencies": {
-    "@bufferapp/buffermetrics": "^0.5.0",
+    "@bufferapp/buffermetrics": "^0.5.2",
     "@bufferapp/connect-datadog": "^0.2.1",
     "@bufferapp/logger": "0.7.0",
     "@bufferapp/micro-rpc": "0.1.7",

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -47,6 +47,8 @@ const configureStore = (initialstate) => {
 
   const buffermetricsMiddleware = createMiddleware({
     application: 'ANALYZE',
+    batchSize: 10,
+    throttle: 1000,
     metadata: state => ({
       userId: state.appSidebar.user.id,
       profileId: state.profiles.selectedProfileId,

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -31,7 +31,7 @@
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
     "@bufferapp/audience-chart": "^0.55.1",
     "@bufferapp/average-table": "^0.55.1",
-    "@bufferapp/buffermetrics": "^0.5.0",
+    "@bufferapp/buffermetrics": "^0.5.2",
     "@bufferapp/compare-chart": "^0.55.1",
     "@bufferapp/comparison-chart": "^0.55.1",
     "@bufferapp/contextual-compare": "^0.55.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,9 +61,9 @@
     grpc "^1.8.0"
     protobufjs "~6.8.0"
 
-"@bufferapp/buffermetrics@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/buffermetrics/-/buffermetrics-0.5.0.tgz#fc5c9daf7f6a14af405db8a70c44bf7a29396a75"
+"@bufferapp/buffermetrics@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@bufferapp/buffermetrics/-/buffermetrics-0.5.2.tgz#0c710933aed2ddce61ab7d2709eed5da582c459a"
   dependencies:
     "@bufferapp/buda" "0.5.2-beta1"
     grpc "~1.8.0"


### PR DESCRIPTION
### Purpose
To fix action tracking :smile: 

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
