### PR TITLE
add Answers tab (ANA-202)

### DIFF
--- a/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
+++ b/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
@@ -306,6 +306,48 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
             </span>
           </span>
         </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
         <hr
           style={
             Object {
@@ -662,6 +704,48 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
             </span>
           </span>
         </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
         <hr
           style={
             Object {
@@ -1014,6 +1098,48 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
               }
             >
               Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
             </span>
           </span>
         </a>

--- a/packages/nav-sidebar/components/Insights.jsx
+++ b/packages/nav-sidebar/components/Insights.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {
   Divider,
@@ -13,6 +12,7 @@ const Insights = ({ ...props }) =>
     <Label>Insights</Label>
     <Item href="/overview" {...props}>Overview</Item>
     <Item href="/posts" {...props}>Posts</Item>
+    <Item href="/answers/" {...props}>Answers</Item>
     <Divider marginTop="0.75rem" marginBottom="1rem" />
   </div>;
 

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -859,6 +859,48 @@ exports[`Snapshots App should render application 1`] = `
                 </span>
               </span>
             </a>
+            <a
+              href="/answers/"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "color": "#168eea",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "outline": "none",
+                  "padding": "0",
+                  "textDecoration": "none",
+                }
+              }
+              target="_self"
+            >
+              <span
+                style={
+                  Object {
+                    "borderRadius": "4px",
+                    "display": "block",
+                    "margin": "0 0.5rem",
+                    "padding": "0.75rem 0.5rem",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Answers
+                </span>
+              </span>
+            </a>
             <hr
               style={
                 Object {
@@ -1368,6 +1410,48 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
             </span>
           </span>
         </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
         <hr
           style={
             Object {
@@ -1807,6 +1891,48 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
               }
             >
               Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
             </span>
           </span>
         </a>
@@ -2317,6 +2443,48 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
             </span>
           </span>
         </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
         <hr
           style={
             Object {
@@ -2748,6 +2916,48 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
               }
             >
               Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            style={
+              Object {
+                "borderRadius": "4px",
+                "display": "block",
+                "margin": "0 0.5rem",
+                "padding": "0.75rem 0.5rem",
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
             </span>
           </span>
         </a>

--- a/packages/web/components/AnswersTab/index.jsx
+++ b/packages/web/components/AnswersTab/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import ContextualCompare from '@bufferapp/contextual-compare';
+
+const AnswersTab = ({ match }) => (
+  <div>
+    <ContextualCompare />
+  </div>
+);
+
+AnswersTab.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      service: PropTypes.string,
+    }),
+  }).isRequired,
+};
+
+export default connect()(AnswersTab);

--- a/packages/web/components/AnswersTab/index.test.jsx
+++ b/packages/web/components/AnswersTab/index.test.jsx
@@ -4,18 +4,15 @@ import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import configureMockStore from 'redux-mock-store';
 
-import SummaryTable from '@bufferapp/summary-table';
-import AverageTable from '@bufferapp/average-table';
-import CompareChart from '@bufferapp/compare-chart';
 import ContextualCompare from '@bufferapp/contextual-compare';
 
-import OverviewTab from './index';
+import AnswersTab from './index';
 
 timezoneMock.register('US/Eastern');
 
 configure({ adapter: new Adapter() });
-describe('web/OverviewTab', () => {
-  it('should render the overview for facebook', () => {
+describe('web/AnswersTab', () => {
+  it('should render the answers for facebook', () => {
     const mockStore = configureMockStore();
     const store = mockStore({});
     const match = {
@@ -24,18 +21,14 @@ describe('web/OverviewTab', () => {
         id: 'afs42',
       },
     };
-    const component = shallow(<OverviewTab
+    const component = shallow(<AnswersTab
       match={match}
       store={store}
     />).dive();
-    expect(component.find(SummaryTable).length)
-      .toBe(1);
-    expect(component.find(AverageTable).length)
-      .toBe(1);
-    expect(component.find(CompareChart).length)
+    expect(component.find(ContextualCompare).length)
       .toBe(1);
   });
-  it('should render the overview for twitter', () => {
+  it('should render the answers for twitter', () => {
     const mockStore = configureMockStore();
     const store = mockStore({});
     const match = {
@@ -44,18 +37,14 @@ describe('web/OverviewTab', () => {
         id: 'afs42',
       },
     };
-    const component = shallow(<OverviewTab
+    const component = shallow(<AnswersTab
       match={match}
       store={store}
     />).dive();
-    expect(component.find(SummaryTable).length)
-      .toBe(1);
-    expect(component.find(AverageTable).length)
-      .toBe(1);
-    expect(component.find(CompareChart).length)
+    expect(component.find(ContextualCompare).length)
       .toBe(1);
   });
-  it('should render the overview for instagram', () => {
+  it('should render the answers for instagram', () => {
     const mockStore = configureMockStore();
     const store = mockStore({});
     const match = {
@@ -64,13 +53,11 @@ describe('web/OverviewTab', () => {
         id: 'afs42',
       },
     };
-    const component = shallow(<OverviewTab
+    const component = shallow(<AnswersTab
       match={match}
       store={store}
     />).dive();
-    expect(component.find(SummaryTable).length)
-      .toBe(1);
-    expect(component.find(CompareChart).length)
+    expect(component.find(ContextualCompare).length)
       .toBe(1);
   });
 });

--- a/packages/web/components/InsightsPage/index.jsx
+++ b/packages/web/components/InsightsPage/index.jsx
@@ -11,6 +11,7 @@ import ExportPicker from '@bufferapp/analyze-export-picker';
 import { Toolbar } from '@bufferapp/analyze-shared-components';
 import PostsTab from '../PostsTab';
 import OverviewTab from '../OverviewTab';
+import AnswersTab from '../AnswersTab';
 
 const pageStyle = {
   display: 'flex',
@@ -101,6 +102,10 @@ const InsightsPage = ({
               <Route
                 path="/posts/:id?"
                 component={PostsTab}
+              />
+              <Route
+                path="/answers/:id?"
+                component={AnswersTab}
               />
             </Switch>
           </div>

--- a/packages/web/components/OverviewTab/index.jsx
+++ b/packages/web/components/OverviewTab/index.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import SummaryTable from '@bufferapp/summary-table';
 import AverageTable from '@bufferapp/average-table';
 import CompareChart from '@bufferapp/compare-chart';
-import ContextualCompare from '@bufferapp/contextual-compare';
 import HourlyChart from '@bufferapp/hourly-chart';
 
 const OverviewTab = ({ match }) => (
@@ -14,7 +13,6 @@ const OverviewTab = ({ match }) => (
     <AverageTable />
     <CompareChart />
     <HourlyChart />
-    <ContextualCompare />
   </div>
 );
 


### PR DESCRIPTION
To move the Engagement and Audience charts out of the Overview tab and
into a dedicated section called Answers.

### Purpose

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
