### PR TITLE
Add support for staging Analyze API

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -79,6 +79,13 @@ const html = fs.readFileSync(join(__dirname, 'index.html'), 'utf8')
 app.use(logMiddleware({ name: 'BufferAnalyze' }));
 app.use(cookieParser());
 
+app.use('*', (req, res, next) => {
+  const analyzeApiAddr = req.get('ANALYZE-API-ADDR') || process.env.ANALYZE_API_ADDR;
+  app.set('analyzeApiAddr', analyzeApiAddr);
+  next();
+});
+
+
 app.get('/health-check', controller.healthCheck);
 const favicon = fs.readFileSync(join(__dirname, 'favicon.ico'));
 app.get('/favicon.ico', (req, res) => res.send(favicon));

--- a/packages/server/rpc/audience/index.js
+++ b/packages/server/rpc/audience/index.js
@@ -3,9 +3,9 @@ const rp = require('request-promise');
 const DateRange = require('../utils/DateRange');
 const METRICS_CONFIG = require('./metricsConfig');
 
-const requestAudience = (profileId, dateRange, accessToken) =>
+const requestAudience = (profileId, dateRange, accessToken, analyzeApiAddr) =>
   rp({
-    uri: `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals`,
+    uri: `${analyzeApiAddr}/metrics/daily_totals`,
     method: 'POST',
     strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
     qs: {
@@ -67,12 +67,13 @@ function formatData(
 module.exports = method(
   'audience',
   'fetch analytics audience for profiles and pages',
-  ({ profileId, profileService, startDate, endDate }, { session }) => {
+  ({ profileId, profileService, startDate, endDate }, req) => {
     const dateRange = new DateRange(startDate, endDate);
     return requestAudience(
       profileId,
       dateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     )
       .then(response => formatData(
         response.response,

--- a/packages/server/rpc/audience/index.test.js
+++ b/packages/server/rpc/audience/index.test.js
@@ -13,6 +13,16 @@ describe('rpc/audience', () => {
   const profileId = '123159ad';
   const profileService = 'instagram';
   const token = 'some token';
+  const mockedRequest = {
+    session: {
+      analyze: {
+        accessToken: token,
+      },
+    },
+    app: {
+      get() { return 'analyze-api'; },
+    },
+  };
 
   it('should have the expected name', () => {
     expect(audience.name)
@@ -33,17 +43,11 @@ describe('rpc/audience', () => {
       endDate: end,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals`,
+        uri: 'analyze-api/metrics/daily_totals',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -59,13 +63,7 @@ describe('rpc/audience', () => {
   it('it should return: data, metrics', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await audience.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await audience.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.data).toBeDefined();
     expect(data.metrics).toBeDefined();
@@ -74,13 +72,7 @@ describe('rpc/audience', () => {
   it('should return a valid response if all data is 0', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await audience.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await audience.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.metrics.length).toBe(5);
     expect(data.metrics[0]).toEqual({
@@ -93,13 +85,7 @@ describe('rpc/audience', () => {
   it('should return the daily data', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await audience.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await audience.fn({ profileId, profileService }, mockedRequest);
     expect(data.data.length).toBe(7);
     expect(data.data[0].day).toBe('1504051200000');
     expect(data.data[0].metrics.length).toBe(5);
@@ -122,13 +108,7 @@ describe('rpc/audience', () => {
 
     rp.mockReturnValueOnce(Promise.resolve(response));
 
-    const data = await audience.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await audience.fn({ profileId, profileService }, mockedRequest);
     expect(data.data.length).toBe(1);
     expect(data.data[0].metrics.length).toBe(1);
     expect(data.data[0].metrics[0]).toMatchObject({
@@ -141,13 +121,7 @@ describe('rpc/audience', () => {
   it('should return empty data if fetch failed', async() => {
     rp.mockReturnValueOnce(Promise.reject(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await audience.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await audience.fn({ profileId, profileService }, mockedRequest);
     expect(data.data.length).toBe(0);
     expect(data.metrics.length).toBe(0);
   });

--- a/packages/server/rpc/average/index.js
+++ b/packages/server/rpc/average/index.js
@@ -28,10 +28,10 @@ function shouldUseAnalyzeApi (profileService) {
   return profileService === 'instagram';
 }
 
-const requestTotals = (profileId, profileService, dateRange, accessToken) =>
+const requestTotals = (profileId, profileService, dateRange, accessToken, analyzeApiAddr) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/totals` :
+      `${analyzeApiAddr}/metrics/totals` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?
@@ -51,10 +51,10 @@ const requestTotals = (profileId, profileService, dateRange, accessToken) =>
     json: true,
   });
 
-const requestDailyTotals = (profileId, profileService, dateRange, accessToken) =>
+const requestDailyTotals = (profileId, profileService, dateRange, accessToken, analyzeApiAddr) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals` :
+      `${analyzeApiAddr}/metrics/daily_totals` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/daily_totals.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?
@@ -194,30 +194,34 @@ function formatData(
 module.exports = method(
   'average',
   'fetch analytics average for profiles and pages',
-  ({ profileId, profileService, startDate, endDate }, { session }) => {
+  ({ profileId, profileService, startDate, endDate }, req) => {
     const dateRange = new DateRange(startDate, endDate);
     const pastDateRange = dateRange.getPreviousDateRange();
 
     const currentPeriodTotals = requestTotals(profileId,
       profileService,
       dateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     );
     const pastPeriodTotals = requestTotals(profileId,
       profileService,
       pastDateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     );
 
     const currentPeriodDailyTotals = requestDailyTotals(profileId,
       profileService,
       dateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     );
     const pastPeriodDailyTotals = requestDailyTotals(profileId,
       profileService,
       pastDateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     );
 
     return Promise

--- a/packages/server/rpc/average/index.test.js
+++ b/packages/server/rpc/average/index.test.js
@@ -17,6 +17,16 @@ describe('rpc/average', () => {
   const profileId = '123159ad';
   const profileService = 'facebook';
   const token = 'some token';
+  const mockedRequest = {
+    session: {
+      analyze: {
+        accessToken: token,
+      },
+    },
+    app: {
+      get() { return 'analyze-api'; },
+    },
+  };
 
   it('should have the expected name', () => {
     expect(average.name)
@@ -37,17 +47,11 @@ describe('rpc/average', () => {
       endDate: end,
       profileId,
       profileService: 'instagram',
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/totals`,
+        uri: 'analyze-api/metrics/totals',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -61,7 +65,7 @@ describe('rpc/average', () => {
 
     expect(rp.mock.calls[2])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals`,
+        uri: 'analyze-api/metrics/daily_totals',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -84,13 +88,7 @@ describe('rpc/average', () => {
       endDate: end,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
@@ -116,13 +114,7 @@ describe('rpc/average', () => {
       end,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     const expectedEnd = moment().subtract(8, 'days').format('MM/DD/YYYY');
     const expectedStart = moment().subtract(14, 'days').format('MM/DD/YYYY');
@@ -148,13 +140,7 @@ describe('rpc/average', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await average.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await average.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.daily).toBeDefined();
     expect(data.totals).toBeDefined();
@@ -166,13 +152,7 @@ describe('rpc/average', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await average.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await average.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals.length).toEqual(3);
   });
@@ -183,13 +163,7 @@ describe('rpc/average', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await average.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await average.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals).toEqual([
       {
@@ -216,13 +190,7 @@ describe('rpc/average', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await average.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await average.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals).toEqual([
       {
@@ -249,13 +217,7 @@ describe('rpc/average', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await average.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await average.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals).toEqual([
       {
@@ -282,13 +244,7 @@ describe('rpc/average', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await average.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await average.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.daily.length).toBe(7);
     expect(data.daily[0]).toEqual({

--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -7,10 +7,10 @@ function shouldUseAnalyzeApi (profileService) {
   return profileService === 'instagram';
 }
 
-const requestTotals = (profileId, profileService, dateRange, accessToken) =>
+const requestTotals = (profileId, profileService, dateRange, accessToken, analyzeApiAddr) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/totals` :
+      `${analyzeApiAddr}/metrics/totals` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?
@@ -30,10 +30,10 @@ const requestTotals = (profileId, profileService, dateRange, accessToken) =>
     json: true,
   });
 
-const requestDailyTotals = (profileId, profileService, dateRange, accessToken) =>
+const requestDailyTotals = (profileId, profileService, dateRange, accessToken, analyzeApiAddr) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals` :
+      `${analyzeApiAddr}/metrics/daily_totals` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/daily_totals.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?
@@ -220,33 +220,39 @@ function formatData(
 module.exports = method(
   'compare',
   'fetch analytics compare for profiles and pages',
-  ({ profileId, profileService, startDate, endDate }, { session }) => {
+  ({ profileId, profileService, startDate, endDate }, req) => {
     const dateRange = new DateRange(startDate, endDate);
     const previousDateRange = dateRange.getPreviousDateRange();
+    const accessToken = req.session.analyze.accessToken;
+    const analyzeApiAddr = req.app.get('analyzeApiAddr');
 
     const currentPeriodTotals = requestTotals(
       profileId,
       profileService,
       dateRange,
-      session.analyze.accessToken,
+      accessToken,
+      analyzeApiAddr,
     );
     const previousPeriodTotals = requestTotals(
       profileId,
       profileService,
       previousDateRange,
-      session.analyze.accessToken,
+      accessToken,
+      analyzeApiAddr,
     );
     const currentPeriodDailyTotals = requestDailyTotals(
       profileId,
       profileService,
       dateRange,
-      session.analyze.accessToken,
+      accessToken,
+      analyzeApiAddr,
     );
     const previousPeriodDailyTotals = requestDailyTotals(
       profileId,
       profileService,
       previousDateRange,
-      session.analyze.accessToken,
+      accessToken,
+      analyzeApiAddr,
     );
 
     return Promise

--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -18,6 +18,16 @@ describe('rpc/compare', () => {
   const profileId = '123159ad';
   const profileService = 'facebook';
   const token = 'some token';
+  const mockedRequest = {
+    session: {
+      analyze: {
+        accessToken: token,
+      },
+    },
+    app: {
+      get() { return 'analyze-api'; },
+    },
+  };
 
   it('should have the expected name', () => {
     expect(compare.name)
@@ -38,17 +48,11 @@ describe('rpc/compare', () => {
       endDate: end,
       profileId,
       profileService: 'instagram',
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/totals`,
+        uri: 'analyze-api/metrics/totals',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -62,7 +66,7 @@ describe('rpc/compare', () => {
 
     expect(rp.mock.calls[2])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/daily_totals`,
+        uri: 'analyze-api/metrics/daily_totals',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -86,13 +90,7 @@ describe('rpc/compare', () => {
       endDate: end,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
@@ -118,13 +116,7 @@ describe('rpc/compare', () => {
       endDate,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     const end = moment().subtract(8, 'days').format('MM/DD/YYYY');
     const start = moment().subtract(14, 'days').format('MM/DD/YYYY');
@@ -150,13 +142,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.daily).toBeDefined();
     expect(data.totals).toBeDefined();
@@ -168,13 +154,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals[0]).toEqual({
       diff: 1,
@@ -194,13 +174,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals.length).toBe(11);
     expect(data.totals[0]).toEqual({
@@ -221,13 +195,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals.length).toBe(11);
     expect(data.totals[0]).toEqual({
@@ -248,13 +216,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.daily.length).toBe(7);
 
@@ -272,13 +234,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService: 'twitter' }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService: 'twitter' }, mockedRequest);
 
     const secondDayMetric = data.daily[1].metrics[0];
     expect(data.totalPeriodDaily.length).toBe(7);
@@ -299,13 +255,7 @@ describe('rpc/compare', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_PARTIAL_RESPONSE));
 
-    const data = await compare.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.daily.length).toBe(2);
 

--- a/packages/server/rpc/comparison/index.js
+++ b/packages/server/rpc/comparison/index.js
@@ -164,10 +164,10 @@ function parseResponse(response, dateRange) {
 module.exports = method(
   'comparison',
   'get daily comparison data for the given profiles',
-  ({ profileIds, startDate, endDate }) => {
+  ({ profileIds, startDate, endDate }, req) => {
     const dateRange = new DateRange(startDate, endDate);
     return rp({
-      uri: `${process.env.ANALYZE_API_ADDR}/comparison`,
+      uri: `${req.app.get('analyzeApiAddr')}/comparison`,
       method: 'POST',
       strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
       body: {

--- a/packages/server/rpc/comparison/index.test.js
+++ b/packages/server/rpc/comparison/index.test.js
@@ -24,12 +24,16 @@ describe('rpc/comparison', () => {
     const startDate = moment().subtract(7, 'days').format('MM/DD/YYYY');
     const endDate = moment().subtract(1, 'days').format('MM/DD/YYYY');
     rp.mockReturnValue(Promise.resolve(response));
-    const result = await comparison.fn({ profileIds, startDate, endDate });
+    const result = await comparison.fn({ profileIds, startDate, endDate }, {
+      app: {
+        get() { return 'analyze-api'; },
+      },
+    });
 
     expect(result.metrics).toEqual(rpcFinalResponse);
 
     expect(rp.mock.calls[0]).toEqual([{
-      uri: `${process.env.ANALYZE_API_ADDR}/comparison`,
+      uri: 'analyze-api/comparison',
       method: 'POST',
       strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
       body: {

--- a/packages/server/rpc/contextual/index.js
+++ b/packages/server/rpc/contextual/index.js
@@ -8,10 +8,10 @@ function shouldUseAnalyzeApi (profileService) {
   return profileService !== 'facebook';
 }
 
-const requestContextual = (profileId, profileService, dateRange, accessToken) =>
+const requestContextual = (profileId, profileService, dateRange, accessToken, analyzeApiAddr) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/questions` :
+      `${analyzeApiAddr}/metrics/questions` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/contextual.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?
@@ -111,13 +111,14 @@ function formatData(
 module.exports = method(
   'contextual',
   'fetch analytics contextual for profiles and pages',
-  ({ profileId, profileService, startDate, endDate }, { session }) => {
+  ({ profileId, profileService, startDate, endDate }, req) => {
     const dateRange = new DateRange(startDate, endDate);
     return requestContextual(
       profileId,
       profileService,
       dateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     )
       .then(response => formatData(
         response.response,

--- a/packages/server/rpc/contextual/index.test.js
+++ b/packages/server/rpc/contextual/index.test.js
@@ -13,6 +13,16 @@ describe('rpc/contextual', () => {
   const profileId = '123159ad';
   const profileService = 'facebook';
   const token = 'some token';
+  const mockedRequest = {
+    session: {
+      analyze: {
+        accessToken: token,
+      },
+    },
+    app: {
+      get() { return 'analyze-api'; },
+    },
+  };
 
   it('should have the expected name', () => {
     expect(contextual.name)
@@ -33,17 +43,11 @@ describe('rpc/contextual', () => {
       endDate: end,
       profileId,
       profileService: 'instagram',
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/questions`,
+        uri: 'analyze-api/metrics/questions',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -66,17 +70,11 @@ describe('rpc/contextual', () => {
       endDate: end,
       profileId,
       profileService: 'twitter',
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/questions`,
+        uri: 'analyze-api/metrics/questions',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -100,13 +98,7 @@ describe('rpc/contextual', () => {
       endDate: end,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
@@ -126,13 +118,7 @@ describe('rpc/contextual', () => {
   it('it should return: data, metrics, and presets', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.data).toBeDefined();
     expect(data.metrics).toBeDefined();
@@ -142,13 +128,7 @@ describe('rpc/contextual', () => {
   it('should return a valid response if all data is 0', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.metrics.length).toBe(10);
     expect(data.metrics[0]).toEqual({
@@ -160,13 +140,7 @@ describe('rpc/contextual', () => {
   it('should return the daily data', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
     expect(data.data.length).toBe(7);
     expect(data.data[0].day).toBe('1508371200000');
     expect(data.data[0].metrics.length).toBe(10);
@@ -196,13 +170,7 @@ describe('rpc/contextual', () => {
 
     rp.mockReturnValueOnce(Promise.resolve(response));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
     expect(data.data.length).toBe(1);
     expect(data.data[0].metrics.length).toBe(1);
     expect(data.data[0].metrics[0]).toMatchObject({
@@ -233,13 +201,7 @@ describe('rpc/contextual', () => {
     } };
     rp.mockReturnValueOnce(Promise.resolve(mockedResponse));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
     expect(data.presets.length).toBe(1);
   });
 
@@ -264,26 +226,14 @@ describe('rpc/contextual', () => {
     } };
     rp.mockReturnValueOnce(Promise.resolve(mockedResponse));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
     expect(data.presets.length).toBe(0);
   });
 
   it('should return the presets data', async() => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
     expect(data.presets.length).toBe(2);
 
     expect(data.presets[0].label).toBe('How does post frequency affect my fan count?');
@@ -307,13 +257,7 @@ describe('rpc/contextual', () => {
   it('should return empty data if fetch failed', async() => {
     rp.mockReturnValueOnce(Promise.reject(CURRENT_PERIOD_DAILY_RESPONSE));
 
-    const data = await contextual.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const data = await contextual.fn({ profileId, profileService }, mockedRequest);
     expect(data.presets.length).toBe(0);
     expect(data.data.length).toBe(0);
     expect(data.metrics.length).toBe(0);

--- a/packages/server/rpc/getReport/index.js
+++ b/packages/server/rpc/getReport/index.js
@@ -52,9 +52,9 @@ function requestChartData (chart, dateRange, session) {
 module.exports = method(
   'get_report',
   'get report details',
-  ({ _id, timezone }, { session }) =>
+  ({ _id, timezone }, req) =>
     rp({
-      uri: `${process.env.ANALYZE_API_ADDR}/get_report`,
+      uri: `${req.app.get('analyzeApiAddr')}/get_report`,
       method: 'POST',
       strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
       body: {
@@ -74,7 +74,7 @@ module.exports = method(
       }
 
       return Promise
-        .all(report.charts.map(chart => requestChartData(chart, dateRange, session)))
+        .all(report.charts.map(chart => requestChartData(chart, dateRange, req.session)))
         .then(chartMetrics =>
           Object.assign(report, {
             date_range: {

--- a/packages/server/rpc/getReport/index.test.js
+++ b/packages/server/rpc/getReport/index.test.js
@@ -16,6 +16,9 @@ describe('rpc/get_report', () => {
     session: {
       accessToken: token,
     },
+    app: {
+      get() { return 'analyze-api'; },
+    },
   };
   const id = 'report-1235asd';
   moment.tz.setDefault(timezone);
@@ -83,7 +86,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve([]));
 
-    await getReport.fn({ _id: id, timezone }, { session });
+    await getReport.fn({ _id: id, timezone }, session);
 
     expect(summary.fn.mock.calls[0])
       .toEqual([{
@@ -91,7 +94,7 @@ describe('rpc/get_report', () => {
         profileService: 'facebook',
         startDate,
         endDate,
-      }, { session }]);
+      }, { session: session.session }]);
   });
 
   it('returns chart data for each chart as a "metrics" key', async () => {
@@ -99,7 +102,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve(metrics));
 
-    const result = await getReport.fn({ _id: id, timezone }, { session });
+    const result = await getReport.fn({ _id: id, timezone }, session);
 
     expect(result.charts[0].metrics).toEqual(metrics);
   });
@@ -112,7 +115,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve(metricsEmbeddedInObject));
 
-    const result = await getReport.fn({ _id: id, timezone }, { session });
+    const result = await getReport.fn({ _id: id, timezone }, session);
 
     expect(result.charts[0].metrics).toEqual(metricsEmbeddedInObject.metrics);
     expect(result.charts[0].posts).toEqual(metricsEmbeddedInObject.posts);
@@ -126,7 +129,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve(metricsEmbeddedInObject));
 
-    await getReport.fn({ _id: id, timezone }, { session });
+    await getReport.fn({ _id: id, timezone }, session);
 
     expect(summary.fn.mock.calls[0][0]).toEqual({
       profileId: '12351wa',
@@ -145,7 +148,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve([]));
 
-    await getReport.fn({ _id: id, timezone }, { session });
+    await getReport.fn({ _id: id, timezone }, session);
 
     expect(summary.fn.mock.calls[0][0]).toEqual({
       profileId: '12351wa',
@@ -169,7 +172,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve([]));
 
-    await getReport.fn({ _id: id, timezone }, { session });
+    await getReport.fn({ _id: id, timezone }, session);
 
     expect(summary.fn.mock.calls[0][0]).toEqual({
       profileId: '12351wa',
@@ -188,7 +191,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValueOnce(Promise.resolve(metricsEmbeddedInObject));
 
-    const response = await getReport.fn({ _id: id, timezone }, { session });
+    const response = await getReport.fn({ _id: id, timezone }, session);
 
     expect(response.charts[0]).toEqual({
       ...report.charts[0],
@@ -219,7 +222,7 @@ describe('rpc/get_report', () => {
     summary.fn = jest.fn();
     summary.fn.mockReturnValue(Promise.resolve(metrics));
 
-    const result = await getReport.fn({ _id: id, timezone }, { session });
+    const result = await getReport.fn({ _id: id, timezone }, session);
 
     expect(result.charts.length).toEqual(2);
   });

--- a/packages/server/rpc/summary/index.js
+++ b/packages/server/rpc/summary/index.js
@@ -38,10 +38,10 @@ function shouldUseAnalyzeApi (profileService) {
   return profileService === 'instagram';
 }
 
-const requestTotals = (profileId, profileService, dateRange, accessToken) =>
+const requestTotals = (profileId, profileService, dateRange, accessToken, analyzeApiAddr) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/totals` :
+      `${analyzeApiAddr}/metrics/totals` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?
@@ -79,7 +79,7 @@ const summarize = (metricKey, currentPeriod, pastPeriod, profileService) => {
 module.exports = method(
   'summary',
   'fetch analytics summary for profiles and pages',
-  ({ profileId, profileService, startDate, endDate }, { session }) => {
+  ({ profileId, profileService, startDate, endDate }, req) => {
     const dateRange = new DateRange(startDate, endDate);
     const previousDateRange = dateRange.getPreviousDateRange();
 
@@ -87,13 +87,15 @@ module.exports = method(
       profileId,
       profileService,
       dateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     );
     const previousPeriod = requestTotals(
       profileId,
       profileService,
       previousDateRange,
-      session.analyze.accessToken,
+      req.session.analyze.accessToken,
+      req.app.get('analyzeApiAddr'),
     );
 
     return Promise

--- a/packages/server/rpc/summary/index.test.js
+++ b/packages/server/rpc/summary/index.test.js
@@ -11,6 +11,16 @@ describe('rpc/summary', () => {
   const profileId = '123159ad';
   const profileService = 'facebook';
   const token = 'some token';
+  const mockedRequest = {
+    session: {
+      analyze: {
+        accessToken: token,
+      },
+    },
+    app: {
+      get() { return 'analyze-api'; },
+    },
+  };
 
   it('should have the expected name', () => {
     expect(summary.name)
@@ -31,17 +41,11 @@ describe('rpc/summary', () => {
       endDate,
       profileId,
       profileService: 'instagram',
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/totals`,
+        uri: 'analyze-api/metrics/totals',
         method: 'POST',
         strictSSL: false,
         qs: {
@@ -64,13 +68,7 @@ describe('rpc/summary', () => {
       endDate,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     expect(rp.mock.calls[1])
       .toEqual([{
@@ -96,13 +94,7 @@ describe('rpc/summary', () => {
       endDate,
       profileId,
       profileService,
-    }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    }, mockedRequest);
 
     const end = moment().subtract(8, 'days').format('MM/DD/YYYY');
     const start = moment().subtract(14, 'days').format('MM/DD/YYYY');
@@ -126,13 +118,7 @@ describe('rpc/summary', () => {
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_RESPONSE));
 
-    const summaryData = await summary.fn({ profileId, profileService }, {
-      session: {
-        analyze: {
-          accessToken: token,
-        },
-      },
-    });
+    const summaryData = await summary.fn({ profileId, profileService }, mockedRequest);
 
     expect(summaryData).toEqual([{
       label: 'Engaged Users',


### PR DESCRIPTION
### Purpose
To point Analyze API to a staging environment.

### Notes
To override Analyze API address you need to set `ANALYZE-API-ADDR` headers to the expected url.
On Chrome you can use [modeHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) to set that :smile:.

It overrides the url for the following endpoints:
    - rpc/compare
    - rpc/report
    - rpc/summary
    - rpc/contextual
    - rpc/comparison
    - rpc/audience
    - rpc/average

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
