### PR TITLE
rpc/compare use daily_totals to compute totals [ANA-232] [ANA-242]

### DIFF
--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -6,9 +6,8 @@ jest.mock('request-promise');
 import rp from 'request-promise';
 import compare from './';
 import {
-  CURRENT_PERIOD_TOTALS_RESPONSE,
-  PAST_PERIOD_TOTALS_RESPONSE,
-  EMPTY_TOTALS_RESPONSE,
+  DAILY_RESPONSE_EMPTY,
+  DAILY_RESPONSE_AVERAGE_METRICS,
   CURRENT_PERIOD_DAILY_RESPONSE,
   PAST_PERIOD_DAILY_RESPONSE,
   PAST_PERIOD_DAILY_PARTIAL_RESPONSE,
@@ -52,20 +51,6 @@ describe('rpc/compare', () => {
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: 'analyze-api/metrics/totals',
-        method: 'POST',
-        strictSSL: false,
-        qs: {
-          access_token: token,
-          start_date: start,
-          end_date: end,
-          profile_id: profileId,
-        },
-        json: true,
-      }]);
-
-    expect(rp.mock.calls[2])
-      .toEqual([{
         uri: 'analyze-api/metrics/daily_totals',
         method: 'POST',
         strictSSL: false,
@@ -94,7 +79,7 @@ describe('rpc/compare', () => {
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`,
+        uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/daily_totals.json`,
         method: 'GET',
         strictSSL: false,
         qs: {
@@ -123,7 +108,7 @@ describe('rpc/compare', () => {
 
     expect(rp.mock.calls[1])
       .toEqual([{
-        uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/totals.json`,
+        uri: `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/daily_totals.json`,
         method: 'GET',
         strictSSL: false,
         qs: {
@@ -137,8 +122,6 @@ describe('rpc/compare', () => {
   });
 
   it('it should return both total and daily compares', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_TOTALS_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
@@ -149,8 +132,6 @@ describe('rpc/compare', () => {
   });
 
   it('should return the metrics value and diff, compared by total updates sent in the period', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_TOTALS_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
@@ -161,18 +142,16 @@ describe('rpc/compare', () => {
       key: 'followers',
       label: 'Total Fans',
       color: '#FDA3F3',
-      value: 99324,
-      previousValue: 98805,
-      postsCount: 3,
-      previousPostsCount: 5,
+      value: 100369,
+      previousValue: 99783,
+      postsCount: 9,
+      previousPostsCount: 8,
     });
   });
 
   it('should return a valid response if all data is 0', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(EMPTY_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(EMPTY_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
+    rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_EMPTY));
+    rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_EMPTY));
 
     const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
@@ -190,20 +169,36 @@ describe('rpc/compare', () => {
   });
 
   it('should return a valid response if previous data is 0', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(EMPTY_TOTALS_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
+    rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_EMPTY));
 
     const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals.length).toBe(11);
     expect(data.totals[0]).toEqual({
-      diff: 9932400,
+      diff: 10036900,
       key: 'followers',
       label: 'Total Fans',
       color: '#FDA3F3',
-      value: 99324,
+      value: 100369,
+      previousValue: 0,
+      postsCount: 9,
+      previousPostsCount: 0,
+    });
+  });
+
+  it('should average metrics for days where the value to average is > 0', async() => {
+    rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_AVERAGE_METRICS));
+    rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_EMPTY));
+
+    const data = await compare.fn({ profileId, profileService }, mockedRequest);
+
+    expect(data.totals[10]).toEqual({
+      diff: 115,
+      key: 'engagement_rate',
+      label: 'Engagement Rate',
+      color: '#98E8B2',
+      value: 1.15,
       previousValue: 0,
       postsCount: 3,
       previousPostsCount: 0,
@@ -211,8 +206,6 @@ describe('rpc/compare', () => {
   });
 
   it('should return the daily compares', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_TOTALS_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
@@ -229,8 +222,6 @@ describe('rpc/compare', () => {
   });
 
   it('should return Period Total data for Twitter', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_TOTALS_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_RESPONSE));
 
@@ -250,8 +241,6 @@ describe('rpc/compare', () => {
   });
 
   it('should return daily totals only for days that match with the previous period', async() => {
-    rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_TOTALS_RESPONSE));
-    rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_TOTALS_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(CURRENT_PERIOD_DAILY_RESPONSE));
     rp.mockReturnValueOnce(Promise.resolve(PAST_PERIOD_DAILY_PARTIAL_RESPONSE));
 

--- a/packages/server/rpc/compare/mockResponses.js
+++ b/packages/server/rpc/compare/mockResponses.js
@@ -1,48 +1,3 @@
-export const CURRENT_PERIOD_TOTALS_RESPONSE = {
-  response: {
-    engaged_users: 56755,
-    post_impressions: 1181030,
-    reactions: 9391,
-    post_reach: 964968,
-    page_engagements: 12831,
-    post_clicks: 59989,
-    new_followers: 645,
-    followers: 99324,
-    posts_count: 3,
-  },
-  success: true,
-};
-
-export const PAST_PERIOD_TOTALS_RESPONSE = {
-  response: {
-    engaged_users: 15327,
-    post_impressions: 391753,
-    reactions: 2886,
-    post_reach: 284436,
-    page_engagements: 5160,
-    post_clicks: 21983,
-    new_followers: 1067,
-    followers: 98805,
-    posts_count: 5,
-  },
-  success: true,
-};
-
-export const EMPTY_TOTALS_RESPONSE = {
-  response: {
-    engaged_users: 0,
-    post_impressions: 0,
-    reactions: 0,
-    post_reach: 0,
-    page_engagements: 0,
-    post_clicks: 0,
-    new_followers: 0,
-    followers: 0,
-    posts_count: 0,
-  },
-  success: true,
-};
-
 export const CURRENT_PERIOD_DAILY_RESPONSE = {
   response: {
     1504051200000: {
@@ -128,6 +83,96 @@ export const CURRENT_PERIOD_DAILY_RESPONSE = {
       post_clicks: 2516,
       post_reach: 66089,
       reactions: 167,
+    },
+  },
+  success: true,
+};
+
+export const DAILY_RESPONSE_EMPTY = {
+  response: {
+    1504051200000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
+    },
+    1504137600000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
+    },
+    1504224000000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
+    },
+    1504310400000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
+    },
+    1504396800000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
+    },
+    1504483200000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
+    },
+    1504569600000: {
+      posts_count: 0,
+      shares: 0,
+      comments: 0,
+      followers: 0,
+      new_followers: 0,
+      page_engagements: 0,
+      post_impressions: 0,
+      post_clicks: 0,
+      post_reach: 0,
+      reactions: 0,
     },
   },
   success: true,
@@ -248,6 +293,28 @@ export const PAST_PERIOD_DAILY_PARTIAL_RESPONSE = {
       post_clicks: 2599,
       post_reach: 45702,
       reactions: 288,
+    },
+  },
+  success: true,
+};
+
+export const DAILY_RESPONSE_AVERAGE_METRICS = {
+  response: {
+    1504051200000: {
+      posts_count: 1,
+      engagement_rate: 1.5,
+    },
+    1504137600000: {
+      posts_count: 0,
+      engagement_rate: 0,
+    },
+    1504224000000: {
+      posts_count: 2,
+      engagement_rate: 0.8,
+    },
+    1504310400000: {
+      posts_count: 0,
+      engagement_rate: 0,
     },
   },
   success: true,


### PR DESCRIPTION
### Purpose
To save two requests and ensure that the total always matches the values in the charts.

### Notes
It also fixes `engagement_rate` and `comments` totals for Facebook.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
