### PR TITLE
fix compare previous averaged totals calculation

### DIFF
--- a/packages/server/rpc/compare/index.js
+++ b/packages/server/rpc/compare/index.js
@@ -172,6 +172,7 @@ function getTotalsFromDaily (dailyData) {
         currentPeriodTotals[metric.key] = 0;
         previousPeriodTotals[metric.key] = 0;
         currentMetricsToAveragEntriesCount[metric.key] = 0;
+        previousMetricsToAveragEntriesCount[metric.key] = 0;
       }
 
       if (NON_SUMMABLE_METRICS.indexOf(metric.key) !== -1) {

--- a/packages/server/rpc/compare/index.test.js
+++ b/packages/server/rpc/compare/index.test.js
@@ -8,6 +8,7 @@ import compare from './';
 import {
   DAILY_RESPONSE_EMPTY,
   DAILY_RESPONSE_AVERAGE_METRICS,
+  PAST_DAILY_RESPONSE_AVERAGE_METRICS,
   CURRENT_PERIOD_DAILY_RESPONSE,
   PAST_PERIOD_DAILY_RESPONSE,
   PAST_PERIOD_DAILY_PARTIAL_RESPONSE,
@@ -189,19 +190,19 @@ describe('rpc/compare', () => {
 
   it('should average metrics for days where the value to average is > 0', async() => {
     rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_AVERAGE_METRICS));
-    rp.mockReturnValueOnce(Promise.resolve(DAILY_RESPONSE_EMPTY));
+    rp.mockReturnValueOnce(Promise.resolve(PAST_DAILY_RESPONSE_AVERAGE_METRICS));
 
     const data = await compare.fn({ profileId, profileService }, mockedRequest);
 
     expect(data.totals[10]).toEqual({
-      diff: 115,
+      diff: 44,
       key: 'engagement_rate',
       label: 'Engagement Rate',
       color: '#98E8B2',
       value: 1.15,
-      previousValue: 0,
+      previousValue: 0.8,
       postsCount: 3,
-      previousPostsCount: 0,
+      previousPostsCount: 3,
     });
   });
 

--- a/packages/server/rpc/compare/mockResponses.js
+++ b/packages/server/rpc/compare/mockResponses.js
@@ -319,3 +319,25 @@ export const DAILY_RESPONSE_AVERAGE_METRICS = {
   },
   success: true,
 };
+
+export const PAST_DAILY_RESPONSE_AVERAGE_METRICS = {
+  response: {
+    1503446400000: {
+      posts_count: 1,
+      engagement_rate: 1.2,
+    },
+    1504137600000: {
+      posts_count: 0,
+      engagement_rate: 0,
+    },
+    1503619200000: {
+      posts_count: 0,
+      engagement_rate: 0,
+    },
+    1503705600000: {
+      posts_count: 2,
+      engagement_rate: 0.4,
+    },
+  },
+  success: true,
+};


### PR DESCRIPTION
### Purpose
To fix the previous period total calculation for averaged metrics.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
