### PR TITLE
[ANA-241] Use the new RPC endpoint for post summary table.

### DIFF
--- a/packages/server/rpc/postsSummary/index.js
+++ b/packages/server/rpc/postsSummary/index.js
@@ -36,7 +36,7 @@ function shouldUseAnalyzeApi (profileService) {
 const requestPostsSummary = (profileId, profileService, dateRange, accessToken) =>
   rp({
     uri: (shouldUseAnalyzeApi(profileService) ?
-      `${process.env.ANALYZE_API_ADDR}/metrics/totals` :
+      `${process.env.ANALYZE_API_ADDR}/metrics/post_totals` :
       `${process.env.API_ADDR}/1/profiles/${profileId}/analytics/posts_summary.json`
     ),
     method: (shouldUseAnalyzeApi(profileService) ?

--- a/packages/server/rpc/postsSummary/index.test.js
+++ b/packages/server/rpc/postsSummary/index.test.js
@@ -40,7 +40,7 @@ describe('rpc/posts_summary', () => {
 
     expect(rp.mock.calls[0])
       .toEqual([{
-        uri: `${process.env.ANALYZE_API_ADDR}/metrics/totals`,
+        uri: `${process.env.ANALYZE_API_ADDR}/metrics/post_totals`,
         method: 'POST',
         strictSSL: false,
         qs: {


### PR DESCRIPTION
### Purpose
The backend PR is coming soon. I've separated posts summary total endpoint from totals endpoint that calculates the total for the performance table. 

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
