### PR TITLE
[ANA-239] Total fans should be the default metric for IG Metrics Breakdown chart.

### DIFF
--- a/packages/server/rpc/compare/metricsConfig.js
+++ b/packages/server/rpc/compare/metricsConfig.js
@@ -193,6 +193,7 @@ module.exports = {
   instagram: {
     config: instagramConfig,
     orderedKeys: [
+      'followers',
       'posts_count',
       'impressions',
       'reach',
@@ -201,7 +202,6 @@ module.exports = {
       'saved',
       'video_views',
       'new_followers',
-      'followers',
       'engagement_rate',
     ],
   },


### PR DESCRIPTION
### Purpose

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
