### PR TITLE
Fix helm deployment file to use the last image tag

### DIFF
--- a/buffer-analyze/templates/deployment.yaml
+++ b/buffer-analyze/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         track: stable
     spec:
       containers:
-      - image: "{{ .Values.image.repository }}:8a4ae5282ceca7ee84956f1cd823f7c5c00cb516"
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}
         ports:


### PR DESCRIPTION
### Purpose

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
