### PR TITLE
ensure encoded URL in Lamba headers (ANA-252)

### DIFF
--- a/packages/pdf-export/middleware.js
+++ b/packages/pdf-export/middleware.js
@@ -3,7 +3,7 @@ import { actionTypes } from './actions';
 const getExportURL = ({ name, dateRange }) => {
   const { origin, pathname } = window.location;
   const exportURL = encodeURIComponent(`${origin}/export${pathname}?start_date=${dateRange.startDate}&end_date=${dateRange.endDate}`);
-  return `${origin}/report_to_pdf?name=${name}&url=${exportURL}`;
+  return `${origin}/report_to_pdf?name=${encodeURIComponent(name)}&url=${exportURL}`;
 };
 
 export default store => next => (action) => { // eslint-disable-line no-unused-vars

--- a/packages/pdf-export/middleware.test.js
+++ b/packages/pdf-export/middleware.test.js
@@ -37,7 +37,7 @@ describe('middleware', () => {
       type: actionTypes.EXPORT_TO_PDF,
     };
     const exportURL = encodeURIComponent('https://analyze.buffer.com/export/report/1234?start_date=5678&end_date=9876');
-    const expectedURL = `https://analyze.buffer.com/report_to_pdf?name=A report&url=${exportURL}`;
+    const expectedURL = `https://analyze.buffer.com/report_to_pdf?name=A%20report&url=${exportURL}`;
     middleware(store)(next)(action);
     expect(global.open).toHaveBeenCalledWith(expectedURL, '_blank');
   });

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -132,7 +132,7 @@ app.get('/report_to_pdf', (req, res) => {
   const params = {
     FunctionName: 'reportToPDF',
     Payload: JSON.stringify({
-      url: decodeURIComponent(req.query.url),
+      url: req.query.url,
       orientation: 'portrait',
       javascriptDelay: 30000,
       cookie: {


### PR DESCRIPTION
### Purpose
To prevent special characters in the report name from breaking pdf export.

### Notes
fixes https://app.bugsnag.com/buffer/buffer-analyze/errors/5b2b9f7206cee70018e74698?event_id=5b2b9f7206cee70018e74697&i=sk&m=nw


### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
