### PR TITLE
Add cover page for reports when exporting

### DIFF
--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -2071,7 +2071,7 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
           <div
             style={
               Object {
-                "margin": "1.5rem 1.5rem 1rem",
+                "margin": "1.5rem 1.5rem 0rem",
                 "position": "relative",
               }
             }
@@ -2968,7 +2968,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
           <div
             style={
               Object {
-                "margin": "1.5rem 1.5rem 1rem",
+                "margin": "1.5rem 1.5rem 0rem",
                 "position": "relative",
               }
             }
@@ -3865,7 +3865,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
           <div
             style={
               Object {
-                "margin": "1.5rem 1.5rem 1rem",
+                "margin": "1.5rem 1.5rem 0rem",
                 "position": "relative",
               }
             }
@@ -4762,7 +4762,7 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
           <div
             style={
               Object {
-                "margin": "1.5rem 1.5rem 1rem",
+                "margin": "1.5rem 1.5rem 0rem",
                 "position": "relative",
               }
             }
@@ -4991,7 +4991,7 @@ exports[`Snapshots Footer should not render percentage change number only the ar
     <div
       style={
         Object {
-          "margin": "1.5rem 1.5rem 1rem",
+          "margin": "1.5rem 1.5rem 0rem",
           "position": "relative",
         }
       }
@@ -5194,7 +5194,7 @@ exports[`Snapshots Footer should not render percentage change number when previo
     <div
       style={
         Object {
-          "margin": "1.5rem 1.5rem 1rem",
+          "margin": "1.5rem 1.5rem 0rem",
           "position": "relative",
         }
       }
@@ -5371,7 +5371,7 @@ exports[`Snapshots Footer should render the table 1`] = `
     <div
       style={
         Object {
-          "margin": "1.5rem 1.5rem 1rem",
+          "margin": "1.5rem 1.5rem 0rem",
           "position": "relative",
         }
       }

--- a/packages/compare-chart/components/Footer/index.jsx
+++ b/packages/compare-chart/components/Footer/index.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  geyser,
-} from '@bufferapp/components/style/color';
-
-import {
   GridItem,
   PeriodPhrase,
   MetricIcon,
@@ -20,7 +16,7 @@ const gridStyle = {
 
 const gridContainer = {
   position: 'relative',
-  margin: '1.5rem 1.5rem 1rem',
+  margin: '1.5rem 1.5rem 0rem',
 };
 
 const Footer = ({ totals, selectedMetricLabel, startDate, endDate }) => {

--- a/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
@@ -1200,7 +1200,7 @@ exports[`Snapshots HourlyChart [TESTED] loaded chart 1`] = `
           </section>
           <div>
             <ul
-              className="sc-kkGfuU gieSId"
+              className="sc-kkGfuU MOjdh"
             >
               <li
                 className="sc-iAyFgw cbzqSt"
@@ -2075,7 +2075,7 @@ exports[`Snapshots HourlyChart [TESTED] second metric selected 1`] = `
           </section>
           <div>
             <ul
-              className="sc-kkGfuU gieSId"
+              className="sc-kkGfuU MOjdh"
             >
               <li
                 className="sc-iAyFgw cbzqSt"

--- a/packages/hourly-chart/components/HourlyEngagementChart/index.jsx
+++ b/packages/hourly-chart/components/HourlyEngagementChart/index.jsx
@@ -7,13 +7,13 @@ import {
 } from '@bufferapp/analyze-shared-components/style';
 import {
   chartConfig,
-  primarySeriesConfig
+  primarySeriesConfig,
 } from './config';
 
 class HourlyEngagementChart extends PureComponent {
   render() {
     const { metric, posts, chartRef } = this.props;
-    let hour = moment().startOf('day').subtract(1, 'hour');
+    const hour = moment().startOf('day').subtract(1, 'hour');
     const metricByHour = metric.hourlyMetrics.map((hourlyMetric, index) => {
       hour.add(1, 'hour');
       return {
@@ -39,7 +39,7 @@ class HourlyEngagementChart extends PureComponent {
 
 HourlyEngagementChart.defaultProps = {
   posts: [],
-  metric: {}
+  metric: {},
 };
 
 HourlyEngagementChart.propTypes = {

--- a/packages/hourly-chart/components/Legend/index.jsx
+++ b/packages/hourly-chart/components/Legend/index.jsx
@@ -5,8 +5,8 @@ import { Text } from '@bufferapp/components';
 import ColorIcon from '../ColorIcon';
 
 const LegendList = styled.ul`
-  padding: 1rem 1.5rem 0.5rem;
-  margin: 0 0 1rem;
+  padding: 1rem 1.5rem 0;
+  margin: 0 0 0.5rem;
   text-align: center;
 `;
 

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -549,13 +549,13 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX iUeysa"
+        className="sc-ifAKCX kNbSqy"
       >
         <div
           className="sc-EHOje jvzENE"
         >
           <div
-            className="sc-bZQynM jdccxu"
+            className="sc-bZQynM kUBhSG"
           >
             <span
               style={
@@ -594,7 +594,7 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
           </div>
           <img
             alt="Weekly Sync Report"
-            className="sc-htoDjs lghlNe"
+            className="sc-htoDjs ePEvYV"
             src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
           />
         </div>
@@ -613,13 +613,13 @@ exports[`Snapshots Cover renders a cover without a logo 1`] = `
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX iUeysa"
+        className="sc-ifAKCX kNbSqy"
       >
         <div
           className="sc-EHOje jvzENE"
         >
           <div
-            className="sc-bZQynM jdccxu"
+            className="sc-bZQynM kUBhSG"
           >
             <span
               style={
@@ -1371,7 +1371,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 exports[`Snapshots Report render in edit mode 1`] = `
 <span>
   <section
-    className="sc-fQejPQ cajZzW"
+    className="sc-fQejPQ jqDMQk"
   >
     <div
       className="sc-cooIXK dwOZln"
@@ -4493,7 +4493,7 @@ exports[`Snapshots Report render in edit mode 1`] = `
 exports[`Snapshots Report render loading 1`] = `
 <span>
   <section
-    className="sc-fQejPQ cajZzW"
+    className="sc-fQejPQ jqDMQk"
   >
     <div
       className="sc-iSDuPN bkBwuw"
@@ -4584,7 +4584,7 @@ exports[`Snapshots Report render loading 1`] = `
 exports[`Snapshots Report render only the multi-profile legend if that is available 1`] = `
 <span>
   <section
-    className="sc-fQejPQ cajZzW"
+    className="sc-fQejPQ jqDMQk"
   >
     <div
       className="sc-cooIXK dwOZln"
@@ -5175,13 +5175,13 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX iUeysa"
+        className="sc-ifAKCX kNbSqy"
       >
         <div
           className="sc-EHOje jvzENE"
         >
           <div
-            className="sc-bZQynM jdccxu"
+            className="sc-bZQynM kUBhSG"
           >
             <span
               style={
@@ -5626,7 +5626,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render with summary table and logo 1`] = `
 <span>
   <section
-    className="sc-fQejPQ cajZzW"
+    className="sc-fQejPQ jqDMQk"
   >
     <div
       className="sc-cooIXK dwOZln"
@@ -8869,13 +8869,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX iUeysa"
+        className="sc-ifAKCX kNbSqy"
       >
         <div
           className="sc-EHOje jvzENE"
         >
           <div
-            className="sc-bZQynM jdccxu"
+            className="sc-bZQynM kUBhSG"
           >
             <span
               style={
@@ -8914,7 +8914,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
           <img
             alt="Weekly Sync Report"
-            className="sc-htoDjs lghlNe"
+            className="sc-htoDjs ePEvYV"
             src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
           />
         </div>
@@ -11627,7 +11627,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
 exports[`Snapshots Report render with summary table and no logo 1`] = `
 <span>
   <section
-    className="sc-fQejPQ cajZzW"
+    className="sc-fQejPQ jqDMQk"
   >
     <div
       className="sc-cooIXK dwOZln"
@@ -14845,13 +14845,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX iUeysa"
+        className="sc-ifAKCX kNbSqy"
       >
         <div
           className="sc-EHOje jvzENE"
         >
           <div
-            className="sc-bZQynM jdccxu"
+            className="sc-bZQynM kUBhSG"
           >
             <span
               style={

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -1423,7 +1423,7 @@ exports[`Snapshots Report render in edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -2444,7 +2444,7 @@ exports[`Snapshots Report render in edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -3465,7 +3465,7 @@ exports[`Snapshots Report render in edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -4725,7 +4725,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </span>
       </div>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -5221,142 +5221,8 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </div>
       </div>
     </article>
-    <div
-      className="sc-fcdeBU kIwvDy"
-    >
-      <span
-        style={
-          Object {
-            "color": "#59626a",
-            "fontFamily": "\\"Roboto\\", sans-serif",
-            "fontSize": "1rem",
-            "fontWeight": 400,
-          }
-        }
-      >
-        <div
-          className="sc-kZmsYB hsAkSd"
-        >
-          <div
-            className="sc-gqjmRU duSJDA"
-          >
-            <div
-              className="sc-VigVT beITMy"
-            >
-              <span
-                className="sc-jzJRlG iQUWtb"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1rem",
-                      "fontWeight": 500,
-                    }
-                  }
-                >
-                  Upload logo
-                </span>
-              </span>
-              <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
-              >
-                PNG or JPG
-              </span>
-            </div>
-          </div>
-          <button
-            aria-label={null}
-            disabled={undefined}
-            onBlur={[Function]}
-            onClick={undefined}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            style={
-              Object {
-                "background": "none",
-                "backgroundColor": "unset",
-                "border": "none",
-                "borderRadius": "unset",
-                "color": "unset",
-                "cursor": "pointer",
-                "display": "unset",
-                "fontFamily": "unset",
-                "fontSize": "unset",
-                "fontWeight": "unset",
-                "lineHeight": "unset",
-                "margin": "unset",
-                "outline": "none",
-                "padding": 0,
-                "transition": "unset",
-              }
-            }
-          >
-            <h1
-              className="sc-gmeYpB hOfLfM"
-            >
-              Weekly Sync Report
-            </h1>
-          </button>
-          <div
-            className="sc-RcBXQ dEQxDt"
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#59626a",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shuttleGray"
-              >
-                <path
-                  d="M0,12.8353339 L3.16356812,15.998902 L0,15.998902 L0,12.8353339 Z M1.05452271,11.7808112 L10.5452271,2.29010681 L13.7087952,5.45367493 L4.21809083,14.9443793 L1.05452271,11.7808112 Z M11.5997498,1.2355841 L12.2903301,0.545003751 C13.0737267,-0.238392873 14.3489904,-0.2332661 15.1240254,0.541768884 L15.4571331,0.874876608 C16.2387432,1.65648666 16.2395801,2.92288997 15.4538982,3.70857187 L14.7633179,4.39915222 L11.5997498,1.2355841 Z"
-                />
-              </g>
-            </svg>
-          </div>
-        </div>
-        <span
-          style={
-            Object {
-              "color": "#000",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 700,
-            }
-          }
-        >
-          <span
-            className="sc-htpNat KtFsv"
-          >
-            February 20, 2018
-             to 
-            February 25, 2018
-          </span>
-        </span>
-      </span>
-    </div>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"
@@ -5792,7 +5658,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -6813,7 +6679,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -7834,7 +7700,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -8920,167 +8786,8 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
     </article>
-    <div
-      className="sc-fcdeBU kIwvDy"
-    >
-      <span
-        style={
-          Object {
-            "color": "#59626a",
-            "fontFamily": "\\"Roboto\\", sans-serif",
-            "fontSize": "1rem",
-            "fontWeight": 400,
-          }
-        }
-      >
-        <div
-          className="sc-kZmsYB hsAkSd"
-        >
-          <div
-            className="sc-gqjmRU duSJDA"
-          >
-            <button
-              aria-label={null}
-              disabled={undefined}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              style={
-                Object {
-                  "background": "none",
-                  "backgroundColor": "unset",
-                  "border": "none",
-                  "borderRadius": "unset",
-                  "color": "unset",
-                  "cursor": "pointer",
-                  "display": "unset",
-                  "fontFamily": "unset",
-                  "fontSize": "unset",
-                  "fontWeight": "unset",
-                  "lineHeight": "unset",
-                  "margin": "unset",
-                  "outline": "none",
-                  "padding": 0,
-                  "transition": "unset",
-                }
-              }
-            >
-              <span
-                className="sc-kAzzGY bMSYif"
-              >
-                <svg
-                  height="100%"
-                  style={
-                    Object {
-                      "fill": "#59626a",
-                      "height": "1rem",
-                      "width": "1rem",
-                    }
-                  }
-                  version="1.1"
-                  viewBox="0 0 16 16"
-                  width="100%"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <g
-                    className="shuttleGray"
-                  >
-                    <path
-                      d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
-                      transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
-                    />
-                  </g>
-                </svg>
-              </span>
-            </button>
-          </div>
-          <button
-            aria-label={null}
-            disabled={undefined}
-            onBlur={[Function]}
-            onClick={undefined}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            style={
-              Object {
-                "background": "none",
-                "backgroundColor": "unset",
-                "border": "none",
-                "borderRadius": "unset",
-                "color": "unset",
-                "cursor": "pointer",
-                "display": "unset",
-                "fontFamily": "unset",
-                "fontSize": "unset",
-                "fontWeight": "unset",
-                "lineHeight": "unset",
-                "margin": "unset",
-                "outline": "none",
-                "padding": 0,
-                "transition": "unset",
-              }
-            }
-          >
-            <h1
-              className="sc-gmeYpB hOfLfM"
-            >
-              Weekly Sync Report
-            </h1>
-          </button>
-          <div
-            className="sc-RcBXQ dEQxDt"
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#59626a",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shuttleGray"
-              >
-                <path
-                  d="M0,12.8353339 L3.16356812,15.998902 L0,15.998902 L0,12.8353339 Z M1.05452271,11.7808112 L10.5452271,2.29010681 L13.7087952,5.45367493 L4.21809083,14.9443793 L1.05452271,11.7808112 Z M11.5997498,1.2355841 L12.2903301,0.545003751 C13.0737267,-0.238392873 14.3489904,-0.2332661 15.1240254,0.541768884 L15.4571331,0.874876608 C16.2387432,1.65648666 16.2395801,2.92288997 15.4538982,3.70857187 L14.7633179,4.39915222 L11.5997498,1.2355841 Z"
-                />
-              </g>
-            </svg>
-          </div>
-        </div>
-        <span
-          style={
-            Object {
-              "color": "#000",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 700,
-            }
-          }
-        >
-          <span
-            className="sc-htpNat KtFsv"
-          >
-            February 20, 2018
-             to 
-            February 25, 2018
-          </span>
-        </span>
-      </span>
-    </div>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"
@@ -9926,7 +9633,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"
@@ -10772,7 +10479,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"
@@ -11768,7 +11475,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -12789,7 +12496,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -13810,7 +13517,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-iBEsjs hYWDoZ"
+        className="sc-iBEsjs dyJpEa"
       >
         <div
           className="sc-kxynE kZABzl"
@@ -14891,142 +14598,8 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
     </article>
-    <div
-      className="sc-fcdeBU kIwvDy"
-    >
-      <span
-        style={
-          Object {
-            "color": "#59626a",
-            "fontFamily": "\\"Roboto\\", sans-serif",
-            "fontSize": "1rem",
-            "fontWeight": 400,
-          }
-        }
-      >
-        <div
-          className="sc-kZmsYB hsAkSd"
-        >
-          <div
-            className="sc-gqjmRU duSJDA"
-          >
-            <div
-              className="sc-VigVT beITMy"
-            >
-              <span
-                className="sc-jzJRlG iQUWtb"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1rem",
-                      "fontWeight": 500,
-                    }
-                  }
-                >
-                  Upload logo
-                </span>
-              </span>
-              <span
-                style={
-                  Object {
-                    "color": "#59626a",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "0.75rem",
-                    "fontWeight": 400,
-                  }
-                }
-              >
-                PNG or JPG
-              </span>
-            </div>
-          </div>
-          <button
-            aria-label={null}
-            disabled={undefined}
-            onBlur={[Function]}
-            onClick={undefined}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            style={
-              Object {
-                "background": "none",
-                "backgroundColor": "unset",
-                "border": "none",
-                "borderRadius": "unset",
-                "color": "unset",
-                "cursor": "pointer",
-                "display": "unset",
-                "fontFamily": "unset",
-                "fontSize": "unset",
-                "fontWeight": "unset",
-                "lineHeight": "unset",
-                "margin": "unset",
-                "outline": "none",
-                "padding": 0,
-                "transition": "unset",
-              }
-            }
-          >
-            <h1
-              className="sc-gmeYpB hOfLfM"
-            >
-              Weekly Sync Report
-            </h1>
-          </button>
-          <div
-            className="sc-RcBXQ dEQxDt"
-          >
-            <svg
-              height="100%"
-              style={
-                Object {
-                  "fill": "#59626a",
-                  "height": "1rem",
-                  "width": "1rem",
-                }
-              }
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <g
-                className="shuttleGray"
-              >
-                <path
-                  d="M0,12.8353339 L3.16356812,15.998902 L0,15.998902 L0,12.8353339 Z M1.05452271,11.7808112 L10.5452271,2.29010681 L13.7087952,5.45367493 L4.21809083,14.9443793 L1.05452271,11.7808112 Z M11.5997498,1.2355841 L12.2903301,0.545003751 C13.0737267,-0.238392873 14.3489904,-0.2332661 15.1240254,0.541768884 L15.4571331,0.874876608 C16.2387432,1.65648666 16.2395801,2.92288997 15.4538982,3.70857187 L14.7633179,4.39915222 L11.5997498,1.2355841 Z"
-                />
-              </g>
-            </svg>
-          </div>
-        </div>
-        <span
-          style={
-            Object {
-              "color": "#000",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 700,
-            }
-          }
-        >
-          <span
-            className="sc-htpNat KtFsv"
-          >
-            February 20, 2018
-             to 
-            February 25, 2018
-          </span>
-        </span>
-      </span>
-    </div>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"
@@ -15872,7 +15445,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"
@@ -16718,7 +16291,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-iBEsjs hYWDoZ"
+      className="sc-iBEsjs bBgAEl"
     >
       <div
         className="sc-kxynE kZABzl"

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -549,7 +549,7 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX gxuirt"
+        className="sc-ifAKCX iUeysa"
       >
         <div
           className="sc-EHOje jvzENE"
@@ -613,7 +613,7 @@ exports[`Snapshots Cover renders a cover without a logo 1`] = `
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX gxuirt"
+        className="sc-ifAKCX iUeysa"
       >
         <div
           className="sc-EHOje jvzENE"
@@ -1374,7 +1374,7 @@ exports[`Snapshots Report render in edit mode 1`] = `
     className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-cooIXK cFMURY"
+      className="sc-cooIXK dwOZln"
       id="report-page"
     >
       <div
@@ -4587,7 +4587,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
     className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-cooIXK cFMURY"
+      className="sc-cooIXK dwOZln"
       id="report-page"
     >
       <div
@@ -5168,14 +5168,14 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render only the multi-profile legend if that is available whilst exporting 1`] = `
 <span>
   <div
-    className="sc-cooIXK cFMURY"
+    className="sc-cooIXK dwOZln"
     id="report-page"
   >
     <article
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX gxuirt"
+        className="sc-ifAKCX iUeysa"
       >
         <div
           className="sc-EHOje jvzENE"
@@ -5617,7 +5617,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
       </div>
     </section>
     <div
-      className="sc-fZwumE bxgVaL"
+      className="sc-fZwumE cBOHsv"
     />
   </div>
 </span>
@@ -5629,7 +5629,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
     className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-cooIXK cFMURY"
+      className="sc-cooIXK dwOZln"
       id="report-page"
     >
       <div
@@ -8862,14 +8862,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
 exports[`Snapshots Report render with summary table and logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-cooIXK cFMURY"
+    className="sc-cooIXK dwOZln"
     id="report-page"
   >
     <article
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX gxuirt"
+        className="sc-ifAKCX iUeysa"
       >
         <div
           className="sc-EHOje jvzENE"
@@ -11618,7 +11618,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <div
-      className="sc-fZwumE bxgVaL"
+      className="sc-fZwumE cBOHsv"
     />
   </div>
 </span>
@@ -11630,7 +11630,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
     className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-cooIXK cFMURY"
+      className="sc-cooIXK dwOZln"
       id="report-page"
     >
       <div
@@ -14838,14 +14838,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
 exports[`Snapshots Report render with summary table and no logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-cooIXK cFMURY"
+    className="sc-cooIXK dwOZln"
     id="report-page"
   >
     <article
       className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-ifAKCX gxuirt"
+        className="sc-ifAKCX iUeysa"
       >
         <div
           className="sc-EHOje jvzENE"
@@ -17564,7 +17564,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <div
-      className="sc-fZwumE bxgVaL"
+      className="sc-fZwumE cBOHsv"
     />
   </div>
 </span>

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -540,6 +540,129 @@ exports[`Snapshots ChartEditButtons they render 1`] = `
 </span>
 `;
 
+exports[`Snapshots Cover renders a cover with a logo 1`] = `
+<span>
+  <section
+    className="sc-dnqmqq gjnmZE"
+  >
+    <article
+      className="sc-bxivhb cEKEIA"
+    >
+      <div
+        className="sc-ifAKCX gxuirt"
+      >
+        <div
+          className="sc-EHOje jvzENE"
+        >
+          <div
+            className="sc-bZQynM jdccxu"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <h1
+                className="sc-gzVnrw jABNwW"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
+            </span>
+          </div>
+          <img
+            alt="Weekly Sync Report"
+            className="sc-htoDjs lghlNe"
+            src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+          />
+        </div>
+      </div>
+    </article>
+  </section>
+</span>
+`;
+
+exports[`Snapshots Cover renders a cover without a logo 1`] = `
+<span>
+  <section
+    className="sc-dnqmqq gjnmZE"
+  >
+    <article
+      className="sc-bxivhb cEKEIA"
+    >
+      <div
+        className="sc-ifAKCX gxuirt"
+      >
+        <div
+          className="sc-EHOje jvzENE"
+        >
+          <div
+            className="sc-bZQynM jdccxu"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <h1
+                className="sc-gzVnrw jABNwW"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </article>
+  </section>
+</span>
+`;
+
 exports[`Snapshots DateRange renders the date range 1`] = `
 <span>
   <span
@@ -563,15 +686,38 @@ exports[`Snapshots DateRange renders the date range 1`] = `
 </span>
 `;
 
+exports[`Snapshots DateRange renders the date range larger 1`] = `
+<span>
+  <span
+    style={
+      Object {
+        "color": "#000",
+        "fontFamily": "\\"Roboto\\", sans-serif",
+        "fontSize": "1.5rem",
+        "fontWeight": 700,
+      }
+    }
+  >
+    <span
+      className="sc-htpNat KtFsv"
+    >
+      February 20, 2018
+       to 
+      February 25, 2018
+    </span>
+  </span>
+</span>
+`;
+
 exports[`Snapshots EditTitle renders the edit title text box 1`] = `
 <span>
   <form
-    className="sc-bxivhb jKBIrB"
+    className="sc-iwsKbI dhzAcs"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-ifAKCX hibCjO"
+      className="sc-gZMcBi gwdCBi"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test Report"
@@ -608,7 +754,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
     }
   >
     <div
-      className="sc-EHOje hKVWKI"
+      className="sc-gqjmRU duSJDA"
     >
       <button
         aria-label={null}
@@ -639,7 +785,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
         }
       >
         <span
-          className="sc-gZMcBi jmJkvl"
+          className="sc-kAzzGY bMSYif"
         >
           <svg
             height="100%"
@@ -685,7 +831,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
     }
   >
     <div
-      className="sc-EHOje hKVWKI"
+      className="sc-gqjmRU duSJDA"
     >
       <button
         aria-label={null}
@@ -716,7 +862,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
         }
       >
         <span
-          className="sc-gZMcBi jmJkvl"
+          className="sc-kAzzGY bMSYif"
         >
           <svg
             height="100%"
@@ -762,13 +908,13 @@ exports[`Snapshots LogoUpload renders no logo image upload box 1`] = `
     }
   >
     <div
-      className="sc-EHOje hKVWKI"
+      className="sc-gqjmRU duSJDA"
     >
       <div
-        className="sc-bZQynM geoqxB"
+        className="sc-VigVT beITMy"
       >
         <span
-          className="sc-dnqmqq dPUIZI"
+          className="sc-jzJRlG iQUWtb"
         >
           <span
             style={
@@ -814,16 +960,16 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
     }
   >
     <div
-      className="sc-EHOje hKVWKI"
+      className="sc-gqjmRU duSJDA"
     >
       <div
-        className="sc-bZQynM geoqxB"
+        className="sc-VigVT beITMy"
       >
         <span
-          className="sc-dnqmqq dPUIZI"
+          className="sc-jzJRlG iQUWtb"
         />
         <span
-          className="sc-iwsKbI kcyktJ"
+          className="sc-cSHVUG leEiJB"
         >
           <span
             style={
@@ -847,13 +993,13 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
 exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 <span>
   <div
-    className="sc-Rmtcm kLTtGy"
+    className="sc-eqIVtm ecPLlT"
   >
     <span
-      className="sc-gipzik kIRFxz"
+      className="sc-fMiknA jXKXNS"
     >
       <div
-        className="sc-iAyFgw bABLIb"
+        className="sc-jAaTju fDFrqR"
         size="16px"
       >
         <img
@@ -920,7 +1066,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-csuQGl kjtdmC"
+        className="sc-dVhcbM fJvssG"
       >
         <span
           style={
@@ -933,7 +1079,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-jlyJG gBkPre"
+            className="sc-fBuWsC feloW"
           >
             @moreofmorris
           </span>
@@ -941,10 +1087,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-gipzik kIRFxz"
+      className="sc-fMiknA jXKXNS"
     >
       <div
-        className="sc-iAyFgw bABLIb"
+        className="sc-jAaTju fDFrqR"
         size="16px"
       >
         <img
@@ -1011,7 +1157,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-csuQGl kjtdmC"
+        className="sc-dVhcbM fJvssG"
       >
         <span
           style={
@@ -1024,7 +1170,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-jlyJG gBkPre"
+            className="sc-fBuWsC feloW"
           >
             @roughquest
           </span>
@@ -1032,10 +1178,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-gipzik kIRFxz"
+      className="sc-fMiknA jXKXNS"
     >
       <div
-        className="sc-iAyFgw bABLIb"
+        className="sc-jAaTju fDFrqR"
         size="16px"
       >
         <img
@@ -1102,7 +1248,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-csuQGl kjtdmC"
+        className="sc-dVhcbM fJvssG"
       >
         <span
           style={
@@ -1115,7 +1261,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-jlyJG gBkPre"
+            className="sc-fBuWsC feloW"
           >
             Roughquest
           </span>
@@ -1129,10 +1275,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 <span>
   <span
-    className="sc-gipzik kIRFxz"
+    className="sc-fMiknA jXKXNS"
   >
     <div
-      className="sc-iAyFgw bABLIb"
+      className="sc-jAaTju fDFrqR"
       size="16px"
     >
       <img
@@ -1199,7 +1345,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
       </div>
     </div>
     <div
-      className="sc-csuQGl kjtdmC"
+      className="sc-dVhcbM fJvssG"
     >
       <span
         style={
@@ -1212,7 +1358,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
         }
       >
         <span
-          className="sc-jlyJG gBkPre"
+          className="sc-fBuWsC feloW"
         >
           @moreofmorris
         </span>
@@ -1222,17 +1368,3230 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 </span>
 `;
 
-exports[`Snapshots Report render only the multi-profile legend if that is available 1`] = `
+exports[`Snapshots Report render in edit mode 1`] = `
 <span>
   <section
-    className="sc-kxynE jPxQWj"
+    className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-jKVCRD gcvHXT"
+      className="sc-cooIXK cFMURY"
       id="report-page"
     >
       <div
-        className="sc-kaNhvL cZRnAm"
+        className="sc-fcdeBU kIwvDy"
+      >
+        <span
+          style={
+            Object {
+              "color": "#59626a",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 400,
+            }
+          }
+        >
+          <form
+            className="sc-iwsKbI dhzAcs"
+            onSubmit={[Function]}
+          >
+            <input
+              autoFocus={true}
+              className="sc-gZMcBi gwdCBi"
+              onBlur={[Function]}
+              onChange={[Function]}
+              value="Weekly Sync Report"
+            />
+          </form>
+          <span
+            style={
+              Object {
+                "color": "#000",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+            <span
+              className="sc-htpNat KtFsv"
+            >
+              February 20, 2018
+               to 
+              February 25, 2018
+            </span>
+          </span>
+        </span>
+      </div>
+      <section
+        className="sc-iBEsjs hYWDoZ"
+      >
+        <div
+          className="sc-kxynE kZABzl"
+        >
+          <div
+            className="sc-hzNEM fsLdNR"
+          >
+            <h2
+              className="sc-jlyJG dktCpg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                Performance
+              </span>
+            </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
+          </div>
+          <div
+            className="sc-chbbiW hMUxkW"
+          >
+            <span
+              className="sc-fMiknA jXKXNS"
+            >
+              <div
+                className="sc-jAaTju fDFrqR"
+                size="16px"
+              >
+                <img
+                  alt=""
+                  src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                  style={
+                    Object {
+                      "borderRadius": "50%",
+                      "height": "16px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "16px",
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                      "borderRadius": "50%",
+                      "display": "",
+                      "height": "18px",
+                      "left": "-1px",
+                      "marginRight": "",
+                      "position": "absolute",
+                      "top": "-2px",
+                      "width": "18px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#3b5998",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="facebook"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="sc-dVhcbM fJvssG"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  <span
+                    className="sc-fBuWsC feloW"
+                  >
+                    Buffer
+                  </span>
+                </span>
+              </div>
+            </span>
+          </div>
+        </div>
+        <ul
+          className="sc-iyvyFf gBUoBU"
+        >
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Tweets
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    150
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#2FD566"
+                          transform="translate(1 2)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#2fd566",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Retweets
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    901
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        39
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Clicks
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    1,010
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        55
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Impressions
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    963.4k
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        26
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    New Followers
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    0
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Engagements
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    28.8k
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        33
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Likes
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    2,313
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        28
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Replies
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    658
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        9
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        className="sc-iBEsjs hYWDoZ"
+      >
+        <div
+          className="sc-kxynE kZABzl"
+        >
+          <div
+            className="sc-hzNEM fsLdNR"
+          >
+            <h2
+              className="sc-jlyJG dktCpg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                Performance
+              </span>
+            </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
+          </div>
+          <div
+            className="sc-chbbiW hMUxkW"
+          >
+            <span
+              className="sc-fMiknA jXKXNS"
+            >
+              <div
+                className="sc-jAaTju fDFrqR"
+                size="16px"
+              >
+                <img
+                  alt=""
+                  src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                  style={
+                    Object {
+                      "borderRadius": "50%",
+                      "height": "16px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "16px",
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                      "borderRadius": "50%",
+                      "display": "",
+                      "height": "18px",
+                      "left": "-1px",
+                      "marginRight": "",
+                      "position": "absolute",
+                      "top": "-2px",
+                      "width": "18px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#3b5998",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="facebook"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="sc-dVhcbM fJvssG"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  <span
+                    className="sc-fBuWsC feloW"
+                  >
+                    Buffer
+                  </span>
+                </span>
+              </div>
+            </span>
+          </div>
+        </div>
+        <ul
+          className="sc-iyvyFf gBUoBU"
+        >
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Tweets
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    150
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#2FD566"
+                          transform="translate(1 2)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#2fd566",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Retweets
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    901
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        39
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Clicks
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    1,010
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        55
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Impressions
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    963.4k
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        26
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    New Followers
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    0
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Engagements
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    28.8k
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        33
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Likes
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    2,313
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        28
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Replies
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    658
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        9
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section
+        className="sc-iBEsjs hYWDoZ"
+      >
+        <div
+          className="sc-kxynE kZABzl"
+        >
+          <div
+            className="sc-hzNEM fsLdNR"
+          >
+            <h2
+              className="sc-jlyJG dktCpg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                Performance
+              </span>
+            </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
+          </div>
+          <div
+            className="sc-chbbiW hMUxkW"
+          >
+            <span
+              className="sc-fMiknA jXKXNS"
+            >
+              <div
+                className="sc-jAaTju fDFrqR"
+                size="16px"
+              >
+                <img
+                  alt=""
+                  src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                  style={
+                    Object {
+                      "borderRadius": "50%",
+                      "height": "16px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "16px",
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                      "borderRadius": "50%",
+                      "display": "",
+                      "height": "18px",
+                      "left": "-1px",
+                      "marginRight": "",
+                      "position": "absolute",
+                      "top": "-2px",
+                      "width": "18px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#3b5998",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="facebook"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="sc-dVhcbM fJvssG"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  <span
+                    className="sc-fBuWsC feloW"
+                  >
+                    Buffer
+                  </span>
+                </span>
+              </div>
+            </span>
+          </div>
+        </div>
+        <ul
+          className="sc-iyvyFf gBUoBU"
+        >
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Tweets
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    150
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#2FD566"
+                          transform="translate(1 2)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#2fd566",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        25
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Retweets
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    901
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        39
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Clicks
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    1,010
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        55
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Impressions
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    963.4k
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        26
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    New Followers
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    0
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Engagements
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    28.8k
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        33
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Likes
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    2,313
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        28
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            className="sc-iAyFgw iSMySM"
+            width="25%"
+          >
+            <div
+              className="sc-hSdWYo KZWcv"
+            >
+              <span
+                className="sc-kkGfuU gJJOdT"
+              >
+                <span
+                  data-tip={null}
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.875rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Replies
+                  </span>
+                </span>
+              </span>
+              <div
+                className="sc-eHgmQL blOGAg"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1.5rem",
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  <span>
+                    658
+                  </span>
+                </span>
+                <div
+                  className="sc-eNQAEJ hmCevm"
+                >
+                  <div
+                    className="sc-hMqMXs kmzeGg"
+                  >
+                    <div
+                      className="sc-jKJlTe hScyWm"
+                    >
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 11 11"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          fill="white"
+                          height="11"
+                          width="11"
+                        />
+                        <path
+                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                          fill="#FF4040"
+                          transform="translate(10 9) rotate(-180)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-kEYyzF ihVUuK"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#ff1e1e",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      <span>
+                        9
+                      </span>
+                      %
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </section>
+</span>
+`;
+
+exports[`Snapshots Report render loading 1`] = `
+<span>
+  <section
+    className="sc-fQejPQ cajZzW"
+  >
+    <div
+      className="sc-iSDuPN bkBwuw"
+    >
+      <div
+        className="sc-kgoBCf hYcjis"
+      >
+        <div
+          className="sc-chPdSV OFRCa"
+        >
+          <div
+            style={
+              Object {
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "height": "1rem",
+                  "margin": "0 auto 1rem auto",
+                  "position": "relative",
+                  "width": "1rem",
+                }
+              }
+            >
+              <span>
+                <div
+                  style={
+                    Object {
+                      "height": "1rem",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "all 1000ms ease-in-out",
+                      "width": "1rem",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M1.10241622,4.34038738 L7.75166358,7.40469806 C7.88821853,7.46764349 8.11178147,7.46764349 8.24833642,7.40469806 L14.8975838,4.34038738 C15.0341387,4.27744195 15.0341387,4.17446518 14.8975838,4.11151975 L8.24833642,1.04720908 C8.11178147,0.984263641 7.88821853,0.984263641 7.75166358,1.04720908 L1.10241622,4.11151975 C0.965861261,4.17446518 0.965861261,4.27744195 1.10241622,4.34038738"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </span>
+            </div>
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Loading...
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</span>
+`;
+
+exports[`Snapshots Report render only the multi-profile legend if that is available 1`] = `
+<span>
+  <section
+    className="sc-fQejPQ cajZzW"
+  >
+    <div
+      className="sc-cooIXK cFMURY"
+      id="report-page"
+    >
+      <div
+        className="sc-fcdeBU kIwvDy"
       >
         <span
           style={
@@ -1245,16 +4604,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           }
         >
           <div
-            className="sc-iBEsjs iDDIrh"
+            className="sc-kZmsYB hsAkSd"
           >
             <div
-              className="sc-EHOje hKVWKI"
+              className="sc-gqjmRU duSJDA"
             >
               <div
-                className="sc-bZQynM geoqxB"
+                className="sc-VigVT beITMy"
               >
                 <span
-                  className="sc-dnqmqq dPUIZI"
+                  className="sc-jzJRlG iQUWtb"
                 >
                   <span
                     style={
@@ -1312,13 +4671,13 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-LKuAh elVZTo"
+                className="sc-gmeYpB hOfLfM"
               >
                 Weekly Sync Report
               </h1>
             </button>
             <div
-              className="sc-hzNEM iBlsLW"
+              className="sc-RcBXQ dEQxDt"
             >
               <svg
                 height="100%"
@@ -1366,16 +4725,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </span>
       </div>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -1391,18 +4750,193 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                  comparison
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <div
-              className="sc-Rmtcm kLTtGy"
+              className="sc-eqIVtm ecPLlT"
             >
               <span
-                className="sc-gipzik kIRFxz"
+                className="sc-fMiknA jXKXNS"
               >
                 <div
-                  className="sc-iAyFgw bABLIb"
+                  className="sc-jAaTju fDFrqR"
                   size="16px"
                 >
                   <img
@@ -1469,7 +5003,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-csuQGl kjtdmC"
+                  className="sc-dVhcbM fJvssG"
                 >
                   <span
                     style={
@@ -1482,7 +5016,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-jlyJG gBkPre"
+                      className="sc-fBuWsC feloW"
                     >
                       @buffer
                     </span>
@@ -1490,10 +5024,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </span>
               <span
-                className="sc-gipzik kIRFxz"
+                className="sc-fMiknA jXKXNS"
               >
                 <div
-                  className="sc-iAyFgw bABLIb"
+                  className="sc-jAaTju fDFrqR"
                   size="16px"
                 >
                   <img
@@ -1575,7 +5109,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-csuQGl kjtdmC"
+                  className="sc-dVhcbM fJvssG"
                 >
                   <span
                     style={
@@ -1588,7 +5122,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-jlyJG gBkPre"
+                      className="sc-fBuWsC feloW"
                     >
                       buffer
                     </span>
@@ -1599,16 +5133,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </div>
         </div>
         <div
-          className="sc-jTzLTM hzuoIj"
+          className="sc-kGXeez CEwfe"
         >
           <div
-            className="sc-fjdhpX jKEbEC"
+            className="sc-kpOJdX hizgiO"
           >
             <div
-              className="sc-jzJRlG eWaUDG"
+              className="sc-dxgOiQ fHLnxz"
             />
             <h1
-              className="sc-cSHVUG iLBYtn"
+              className="sc-ckVGcZ fpjiSi"
             >
               <span
                 style={
@@ -1631,77 +5165,24 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 </span>
 `;
 
-exports[`Snapshots Report renders a loading report 1`] = `
+exports[`Snapshots Report render only the multi-profile legend if that is available whilst exporting 1`] = `
 <span>
-  <section
-    className="sc-kxynE jPxQWj"
+  <div
+    className="sc-cooIXK cFMURY"
+    id="report-page"
   >
-    <div
-      className="sc-chbbiW gxUVCJ"
+    <article
+      className="sc-bxivhb cEKEIA"
     >
       <div
-        className="sc-VigVT iLurmb"
+        className="sc-ifAKCX gxuirt"
       >
         <div
-          className="sc-gqjmRU kZxquB"
+          className="sc-EHOje jvzENE"
         >
           <div
-            style={
-              Object {
-                "textAlign": "center",
-              }
-            }
+            className="sc-bZQynM jdccxu"
           >
-            <div
-              style={
-                Object {
-                  "height": "1rem",
-                  "margin": "0 auto 1rem auto",
-                  "position": "relative",
-                  "width": "1rem",
-                }
-              }
-            >
-              <span>
-                <div
-                  style={
-                    Object {
-                      "height": "1rem",
-                      "left": 0,
-                      "opacity": 0,
-                      "position": "absolute",
-                      "top": 0,
-                      "transition": "all 1000ms ease-in-out",
-                      "width": "1rem",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#59626a",
-                        "height": "1rem",
-                        "width": "1rem",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="shuttleGray"
-                    >
-                      <path
-                        d="M1.10241622,4.34038738 L7.75166358,7.40469806 C7.88821853,7.46764349 8.11178147,7.46764349 8.24833642,7.40469806 L14.8975838,4.34038738 C15.0341387,4.27744195 15.0341387,4.17446518 14.8975838,4.11151975 L8.24833642,1.04720908 C8.11178147,0.984263641 7.88821853,0.984263641 7.75166358,1.04720908 L1.10241622,4.11151975 C0.965861261,4.17446518 0.965861261,4.27744195 1.10241622,4.34038738"
-                      />
-                    </g>
-                  </svg>
-                </div>
-              </span>
-            </div>
             <span
               style={
                 Object {
@@ -1712,2624 +5193,447 @@ exports[`Snapshots Report renders a loading report 1`] = `
                 }
               }
             >
-              Loading...
+              <h1
+                className="sc-gzVnrw jABNwW"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
             </span>
           </div>
         </div>
       </div>
-    </div>
-  </section>
-</span>
-`;
-
-exports[`Snapshots Report renders a report in edit mode 1`] = `
-<span>
-  <section
-    className="sc-kxynE jPxQWj"
-  >
+    </article>
     <div
-      className="sc-jKVCRD gcvHXT"
-      id="report-page"
+      className="sc-fcdeBU kIwvDy"
     >
-      <div
-        className="sc-kaNhvL cZRnAm"
-      >
-        <span
-          style={
-            Object {
-              "color": "#59626a",
-              "fontFamily": "\\"Roboto\\", sans-serif",
-              "fontSize": "1rem",
-              "fontWeight": 400,
-            }
+      <span
+        style={
+          Object {
+            "color": "#59626a",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "fontSize": "1rem",
+            "fontWeight": 400,
           }
+        }
+      >
+        <div
+          className="sc-kZmsYB hsAkSd"
         >
-          <form
-            className="sc-bxivhb jKBIrB"
-            onSubmit={[Function]}
+          <div
+            className="sc-gqjmRU duSJDA"
           >
-            <input
-              autoFocus={true}
-              className="sc-ifAKCX hibCjO"
-              onBlur={[Function]}
-              onChange={[Function]}
-              value="Weekly Sync Report"
-            />
-          </form>
-          <span
+            <div
+              className="sc-VigVT beITMy"
+            >
+              <span
+                className="sc-jzJRlG iQUWtb"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  Upload logo
+                </span>
+              </span>
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                PNG or JPG
+              </span>
+            </div>
+          </div>
+          <button
+            aria-label={null}
+            disabled={undefined}
+            onBlur={[Function]}
+            onClick={undefined}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             style={
               Object {
-                "color": "#000",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "1rem",
-                "fontWeight": 700,
+                "background": "none",
+                "backgroundColor": "unset",
+                "border": "none",
+                "borderRadius": "unset",
+                "color": "unset",
+                "cursor": "pointer",
+                "display": "unset",
+                "fontFamily": "unset",
+                "fontSize": "unset",
+                "fontWeight": "unset",
+                "lineHeight": "unset",
+                "margin": "unset",
+                "outline": "none",
+                "padding": 0,
+                "transition": "unset",
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
+            <h1
+              className="sc-gmeYpB hOfLfM"
             >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+              Weekly Sync Report
+            </h1>
+          </button>
+          <div
+            className="sc-RcBXQ dEQxDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M0,12.8353339 L3.16356812,15.998902 L0,15.998902 L0,12.8353339 Z M1.05452271,11.7808112 L10.5452271,2.29010681 L13.7087952,5.45367493 L4.21809083,14.9443793 L1.05452271,11.7808112 Z M11.5997498,1.2355841 L12.2903301,0.545003751 C13.0737267,-0.238392873 14.3489904,-0.2332661 15.1240254,0.541768884 L15.4571331,0.874876608 C16.2387432,1.65648666 16.2395801,2.92288997 15.4538982,3.70857187 L14.7633179,4.39915222 L11.5997498,1.2355841 Z"
+                />
+              </g>
+            </svg>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "color": "#000",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 700,
+            }
+          }
+        >
+          <span
+            className="sc-htpNat KtFsv"
+          >
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
         </span>
-      </div>
-      <section
-        className="sc-bmyXtO jkDPyK"
-      >
-        <div
-          className="sc-ebFjAB joITdX"
-        >
-          <div
-            className="sc-dEoRIm bJmZfG"
-          >
-            <h2
-              className="sc-jWBwVP kAqDQk"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#000",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
-                  }
-                }
-              >
-                Performance
-              </span>
-            </h2>
-          </div>
-          <div
-            className="sc-jtggT jgpGvV"
-          >
-            <span
-              className="sc-gipzik kIRFxz"
-            >
-              <div
-                className="sc-iAyFgw bABLIb"
-                size="16px"
-              >
-                <img
-                  alt=""
-                  src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
-                  style={
-                    Object {
-                      "borderRadius": "50%",
-                      "height": "16px",
-                      "marginBottom": undefined,
-                      "marginTop": undefined,
-                      "maxHeight": undefined,
-                      "maxWidth": undefined,
-                      "minHeight": undefined,
-                      "minWidth": undefined,
-                      "objectFit": undefined,
-                      "width": "16px",
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "background": "#fff",
-                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
-                      "borderRadius": "50%",
-                      "display": "",
-                      "height": "18px",
-                      "left": "-1px",
-                      "marginRight": "",
-                      "position": "absolute",
-                      "top": "-2px",
-                      "width": "18px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#3b5998",
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="facebook"
-                    >
-                      <g
-                        fillRule="evenodd"
-                      >
-                        <path
-                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                </div>
-              </div>
-              <div
-                className="sc-csuQGl kjtdmC"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.875rem",
-                      "fontWeight": 500,
-                    }
-                  }
-                >
-                  <span
-                    className="sc-jlyJG gBkPre"
-                  >
-                    Buffer
-                  </span>
-                </span>
-              </div>
-            </span>
-          </div>
-        </div>
-        <ul
-          className="sc-elJkPf gouEjV"
-        >
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Tweets
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    150
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#2FD566"
-                          transform="translate(1 2)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#2fd566",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        25
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Retweets
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    901
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        39
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Clicks
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    1,010
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        55
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Impressions
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    963.4k
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        26
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    New Followers
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    0
-                  </span>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Engagements
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    28.8k
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        33
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Likes
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    2,313
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        28
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Replies
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    658
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        9
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </section>
-      <section
-        className="sc-bmyXtO jkDPyK"
-      >
-        <div
-          className="sc-ebFjAB joITdX"
-        >
-          <div
-            className="sc-dEoRIm bJmZfG"
-          >
-            <h2
-              className="sc-jWBwVP kAqDQk"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#000",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
-                  }
-                }
-              >
-                Performance
-              </span>
-            </h2>
-          </div>
-          <div
-            className="sc-jtggT jgpGvV"
-          >
-            <span
-              className="sc-gipzik kIRFxz"
-            >
-              <div
-                className="sc-iAyFgw bABLIb"
-                size="16px"
-              >
-                <img
-                  alt=""
-                  src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
-                  style={
-                    Object {
-                      "borderRadius": "50%",
-                      "height": "16px",
-                      "marginBottom": undefined,
-                      "marginTop": undefined,
-                      "maxHeight": undefined,
-                      "maxWidth": undefined,
-                      "minHeight": undefined,
-                      "minWidth": undefined,
-                      "objectFit": undefined,
-                      "width": "16px",
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "background": "#fff",
-                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
-                      "borderRadius": "50%",
-                      "display": "",
-                      "height": "18px",
-                      "left": "-1px",
-                      "marginRight": "",
-                      "position": "absolute",
-                      "top": "-2px",
-                      "width": "18px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#3b5998",
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="facebook"
-                    >
-                      <g
-                        fillRule="evenodd"
-                      >
-                        <path
-                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                </div>
-              </div>
-              <div
-                className="sc-csuQGl kjtdmC"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.875rem",
-                      "fontWeight": 500,
-                    }
-                  }
-                >
-                  <span
-                    className="sc-jlyJG gBkPre"
-                  >
-                    Buffer
-                  </span>
-                </span>
-              </div>
-            </span>
-          </div>
-        </div>
-        <ul
-          className="sc-elJkPf gouEjV"
-        >
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Tweets
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    150
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#2FD566"
-                          transform="translate(1 2)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#2fd566",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        25
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Retweets
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    901
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        39
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Clicks
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    1,010
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        55
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Impressions
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    963.4k
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        26
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    New Followers
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    0
-                  </span>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Engagements
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    28.8k
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        33
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Likes
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    2,313
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        28
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Replies
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    658
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        9
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </section>
-      <section
-        className="sc-bmyXtO jkDPyK"
-      >
-        <div
-          className="sc-ebFjAB joITdX"
-        >
-          <div
-            className="sc-dEoRIm bJmZfG"
-          >
-            <h2
-              className="sc-jWBwVP kAqDQk"
-            >
-              <span
-                style={
-                  Object {
-                    "color": "#000",
-                    "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
-                  }
-                }
-              >
-                Performance
-              </span>
-            </h2>
-          </div>
-          <div
-            className="sc-jtggT jgpGvV"
-          >
-            <span
-              className="sc-gipzik kIRFxz"
-            >
-              <div
-                className="sc-iAyFgw bABLIb"
-                size="16px"
-              >
-                <img
-                  alt=""
-                  src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
-                  style={
-                    Object {
-                      "borderRadius": "50%",
-                      "height": "16px",
-                      "marginBottom": undefined,
-                      "marginTop": undefined,
-                      "maxHeight": undefined,
-                      "maxWidth": undefined,
-                      "minHeight": undefined,
-                      "minWidth": undefined,
-                      "objectFit": undefined,
-                      "width": "16px",
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "background": "#fff",
-                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
-                      "borderRadius": "50%",
-                      "display": "",
-                      "height": "18px",
-                      "left": "-1px",
-                      "marginRight": "",
-                      "position": "absolute",
-                      "top": "-2px",
-                      "width": "18px",
-                    }
-                  }
-                >
-                  <svg
-                    height="100%"
-                    style={
-                      Object {
-                        "fill": "#3b5998",
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                    version="1.1"
-                    viewBox="0 0 16 16"
-                    width="100%"
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
-                  >
-                    <g
-                      className="facebook"
-                    >
-                      <g
-                        fillRule="evenodd"
-                      >
-                        <path
-                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                </div>
-              </div>
-              <div
-                className="sc-csuQGl kjtdmC"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "0.875rem",
-                      "fontWeight": 500,
-                    }
-                  }
-                >
-                  <span
-                    className="sc-jlyJG gBkPre"
-                  >
-                    Buffer
-                  </span>
-                </span>
-              </div>
-            </span>
-          </div>
-        </div>
-        <ul
-          className="sc-elJkPf gouEjV"
-        >
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Tweets
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    150
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#2FD566"
-                          transform="translate(1 2)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#2fd566",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        25
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Retweets
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    901
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        39
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Clicks
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    1,010
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        55
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Impressions
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    963.4k
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        26
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    New Followers
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    0
-                  </span>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Engagements
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    28.8k
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        33
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Likes
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    2,313
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        28
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-          <li
-            className="sc-dxgOiQ fKyTyB"
-            width="25%"
-          >
-            <div
-              className="sc-ckVGcZ kMhhDE"
-            >
-              <span
-                className="sc-kpOJdX OJJrM"
-              >
-                <span
-                  data-tip={null}
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#59626a",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "0.875rem",
-                        "fontWeight": 400,
-                      }
-                    }
-                  >
-                    Replies
-                  </span>
-                </span>
-              </span>
-              <div
-                className="sc-jKJlTe dCPwhQ"
-              >
-                <span
-                  style={
-                    Object {
-                      "color": "#323b43",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1.5rem",
-                      "fontWeight": 700,
-                    }
-                  }
-                >
-                  <span>
-                    658
-                  </span>
-                </span>
-                <div
-                  className="sc-chPdSV jzMHaP"
-                >
-                  <div
-                    className="sc-kgoBCf iujlmc"
-                  >
-                    <div
-                      className="sc-kAzzGY cnJubn"
-                    >
-                      <svg
-                        fill="none"
-                        height="11"
-                        viewBox="0 0 11 11"
-                        width="11"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="white"
-                          height="11"
-                          width="11"
-                        />
-                        <path
-                          d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
-                          fill="#FF4040"
-                          transform="translate(10 9) rotate(-180)"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-kGXeez cGxapO"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#ff1e1e",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1rem",
-                          "fontWeight": 700,
-                        }
-                      }
-                    >
-                      <span>
-                        9
-                      </span>
-                      %
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </section>
+      </span>
     </div>
-  </section>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Audience
+               comparison
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <div
+            className="sc-eqIVtm ecPLlT"
+          >
+            <span
+              className="sc-fMiknA jXKXNS"
+            >
+              <div
+                className="sc-jAaTju fDFrqR"
+                size="16px"
+              >
+                <img
+                  alt=""
+                  src="https://pbs.twimg.com/profile_images/711360318262218752/wdl3jY5t_normal.jpg"
+                  style={
+                    Object {
+                      "borderRadius": "50%",
+                      "height": "16px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "16px",
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                      "borderRadius": "50%",
+                      "display": "",
+                      "height": "18px",
+                      "left": "-1px",
+                      "marginRight": "",
+                      "position": "absolute",
+                      "top": "-2px",
+                      "width": "18px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#55acee",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="twitter"
+                    >
+                      <g
+                        fillRule="evenodd"
+                      >
+                        <path
+                          d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M12,5.32763533 C11.7037037,5.46723647 11.3888889,5.56695157 11.0555556,5.60683761 C11.3981481,5.38746439 11.6574074,5.03846154 11.7777778,4.62962963 C11.462963,4.82905983 11.1111111,4.97863248 10.7407407,5.05840456 C10.4351852,4.71937322 10.0092593,4.5 9.53703704,4.5 C8.62962963,4.5 7.89814815,5.28774929 7.89814815,6.26495726 C7.89814815,6.4045584 7.90740741,6.54415954 7.93518519,6.67378917 C6.57407407,6.59401709 5.37037037,5.92592593 4.55555556,4.85897436 C4.41666667,5.11823362 4.33333333,5.38746439 4.33333333,5.71652422 C4.33333333,6.32478632 4.62037037,6.86324786 5.06481481,7.18233618 C4.7962963,7.17236467 4.5462963,7.09259259 4.32407407,6.96296296 L4.32407407,6.98290598 C4.32407407,7.84045584 4.88888889,8.55840456 5.63888889,8.71794872 C5.5,8.75783476 5.35185185,8.77777778 5.2037037,8.77777778 C5.10185185,8.77777778 5,8.76780627 4.89814815,8.74786325 C5.10185185,9.44586895 5.71296296,9.96438746 6.42592593,9.97435897 C5.87037037,10.4529915 5.15740741,10.8119658 4.38888889,10.8119658 C4.25925926,10.8119658 4.12962963,10.8019943 4,10.7820513 C4.72222222,11.2806268 5.59259259,11.5 6.51851852,11.5 C9.53703704,11.5 11.1851852,8.80769231 11.1851852,6.47435897 L11.1851852,6.24501425 C11.5,5.9957265 11.7777778,5.68660969 12,5.32763533 L12,5.32763533 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="sc-dVhcbM fJvssG"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  <span
+                    className="sc-fBuWsC feloW"
+                  >
+                    @buffer
+                  </span>
+                </span>
+              </div>
+            </span>
+            <span
+              className="sc-fMiknA jXKXNS"
+            >
+              <div
+                className="sc-jAaTju fDFrqR"
+                size="16px"
+              >
+                <img
+                  alt=""
+                  src="https://scontent.cdninstagram.com/t51.2885-19/11243954_781009082006449_2106614257_a.jpg"
+                  style={
+                    Object {
+                      "borderRadius": "50%",
+                      "height": "16px",
+                      "marginBottom": undefined,
+                      "marginTop": undefined,
+                      "maxHeight": undefined,
+                      "maxWidth": undefined,
+                      "minHeight": undefined,
+                      "minWidth": undefined,
+                      "objectFit": undefined,
+                      "width": "16px",
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                      "borderRadius": "50%",
+                      "display": "",
+                      "height": "18px",
+                      "left": "-1px",
+                      "marginRight": "",
+                      "position": "absolute",
+                      "top": "-2px",
+                      "width": "18px",
+                    }
+                  }
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#e53c5f",
+                        "height": "100%",
+                        "width": "100%",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="instagram"
+                    >
+                      <circle
+                        cx="8"
+                        cy="8"
+                        r="8"
+                      />
+                      <g
+                        transform="translate(3.000000, 3.000000)"
+                      >
+                        <path
+                          d="M4.99843254,0.0031547619 C3.64093254,0.0031547619 3.47071429,0.00890873016 2.93757937,0.033234127 C2.40555556,0.0575 2.04220238,0.142003968 1.72426587,0.265575397 C1.3955754,0.393293651 1.1168254,0.564206349 0.838928571,0.842083333 C0.561051587,1.11998016 0.390138889,1.39873016 0.262420635,1.72742063 C0.138849206,2.04535714 0.0543452381,2.40871032 0.0300793651,2.94073413 C0.00575396825,3.47386905 0,3.6440873 0,5.0015873 C0,6.35906746 0.00575396825,6.52928571 0.0300793651,7.06242063 C0.0543452381,7.59444444 0.138849206,7.95779762 0.262420635,8.27573413 C0.390138889,8.6044246 0.561051587,8.8831746 0.838928571,9.16107143 C1.1168254,9.43894841 1.3955754,9.60986111 1.72426587,9.73759921 C2.04220238,9.86115079 2.40555556,9.94565476 2.93757937,9.96992063 C3.47071429,9.99424603 3.64093254,10 4.99843254,10 C6.3559127,10 6.52613095,9.99424603 7.05926587,9.96992063 C7.59128968,9.94565476 7.95464286,9.86115079 8.27257937,9.73759921 C8.60126984,9.60986111 8.88001984,9.43894841 9.15791667,9.16107143 C9.43579365,8.8831746 9.60670635,8.6044246 9.73444444,8.27573413 C9.85799603,7.95779762 9.9425,7.59444444 9.96676587,7.06242063 C9.99109127,6.52928571 9.99684524,6.35906746 9.99684524,5.0015873 C9.99684524,3.6440873 9.99109127,3.47386905 9.96676587,2.94073413 C9.9425,2.40871032 9.85799603,2.04535714 9.73444444,1.72742063 C9.60670635,1.39873016 9.43579365,1.11998016 9.15791667,0.842083333 C8.88001984,0.564206349 8.60126984,0.393293651 8.27257937,0.265575397 C7.95464286,0.142003968 7.59128968,0.0575 7.05926587,0.033234127 C6.52613095,0.00890873016 6.3559127,0.0031547619 4.99843254,0.0031547619 L4.99843254,0.0031547619 Z M4.99843254,0.903769841 C6.33305556,0.903769841 6.49115079,0.908869048 7.01821429,0.932916667 C7.50555556,0.955138889 7.77021825,1.03656746 7.94634921,1.10501984 C8.1796627,1.19569444 8.34617063,1.30400794 8.52107143,1.47892857 C8.69599206,1.65382937 8.80430556,1.8203373 8.89498016,2.05365079 C8.96343254,2.22978175 9.04486111,2.49444444 9.06708333,2.98178571 C9.09113095,3.50884921 9.09623016,3.66694444 9.09623016,5.0015873 C9.09623016,6.33621032 9.09113095,6.49430556 9.06708333,7.02136905 C9.04486111,7.50871032 8.96343254,7.77337302 8.89498016,7.94950397 C8.80430556,8.18281746 8.69599206,8.3493254 8.52107143,8.52422619 C8.34617063,8.69914683 8.1796627,8.80746032 7.94634921,8.89813492 C7.77021825,8.9665873 7.50555556,9.04801587 7.01821429,9.0702381 C6.49123016,9.09428571 6.33315476,9.09938492 4.99843254,9.09938492 C3.66369048,9.09938492 3.50563492,9.09428571 2.97863095,9.0702381 C2.49128968,9.04801587 2.22662698,8.9665873 2.05049603,8.89813492 C1.81718254,8.80746032 1.6506746,8.69914683 1.47577381,8.52422619 C1.30087302,8.3493254 1.19253968,8.18281746 1.10186508,7.94950397 C1.0334127,7.77337302 0.951984127,7.50871032 0.929761905,7.02136905 C0.905714286,6.49430556 0.900615079,6.33621032 0.900615079,5.0015873 C0.900615079,3.66694444 0.905714286,3.50884921 0.929761905,2.98178571 C0.951984127,2.49444444 1.0334127,2.22978175 1.10186508,2.05365079 C1.19253968,1.8203373 1.30085317,1.65382937 1.47577381,1.47892857 C1.6506746,1.30400794 1.81718254,1.19569444 2.05049603,1.10501984 C2.22662698,1.03656746 2.49128968,0.955138889 2.97863095,0.932916667 C3.50569444,0.908869048 3.66378968,0.903769841 4.99843254,0.903769841 L4.99843254,0.903769841 Z"
+                          fill="#FFFFFF"
+                          mask="url(#mask-2)"
+                        />
+                        <path
+                          d="M4.99843254,6.66771825 C4.07823413,6.66771825 3.33228175,5.92176587 3.33228175,5.0015873 C3.33228175,4.08138889 4.07823413,3.33543651 4.99843254,3.33543651 C5.91861111,3.33543651 6.66456349,4.08138889 6.66456349,5.0015873 C6.66456349,5.92176587 5.91861111,6.66771825 4.99843254,6.66771825 L4.99843254,6.66771825 Z M4.99843254,2.43482143 C3.58083333,2.43482143 2.43166667,3.5839881 2.43166667,5.0015873 C2.43166667,6.41916667 3.58083333,7.56833333 4.99843254,7.56833333 C6.4160119,7.56833333 7.56517857,6.41916667 7.56517857,5.0015873 C7.56517857,3.5839881 6.4160119,2.43482143 4.99843254,2.43482143 L4.99843254,2.43482143 Z"
+                          fill="#FFFFFF"
+                        />
+                        <path
+                          d="M8.26640873,2.3334127 C8.26640873,2.66468254 7.99785714,2.93321429 7.6665873,2.93321429 C7.3353373,2.93321429 7.06678571,2.66468254 7.06678571,2.3334127 C7.06678571,2.00214286 7.3353373,1.73359127 7.6665873,1.73359127 C7.99785714,1.73359127 8.26640873,2.00214286 8.26640873,2.3334127"
+                          fill="#FFFFFF"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="sc-dVhcbM fJvssG"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  <span
+                    className="sc-fBuWsC feloW"
+                  >
+                    buffer
+                  </span>
+                </span>
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-kGXeez CEwfe"
+      >
+        <div
+          className="sc-kpOJdX hizgiO"
+        >
+          <div
+            className="sc-dxgOiQ fHLnxz"
+          />
+          <h1
+            className="sc-ckVGcZ fpjiSi"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              There are no analytics for this date range
+            </span>
+          </h1>
+        </div>
+      </div>
+    </section>
+    <div
+      className="sc-fZwumE bxgVaL"
+    />
+  </div>
 </span>
 `;
 
-exports[`Snapshots Report renders a report with summary table and logo 1`] = `
+exports[`Snapshots Report render with summary table and logo 1`] = `
 <span>
   <section
-    className="sc-kxynE jPxQWj"
+    className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-jKVCRD gcvHXT"
+      className="sc-cooIXK cFMURY"
       id="report-page"
     >
       <div
-        className="sc-kaNhvL cZRnAm"
+        className="sc-fcdeBU kIwvDy"
       >
         <span
           style={
@@ -4342,10 +5646,10 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
           }
         >
           <div
-            className="sc-iBEsjs iDDIrh"
+            className="sc-kZmsYB hsAkSd"
           >
             <div
-              className="sc-EHOje hKVWKI"
+              className="sc-gqjmRU duSJDA"
             >
               <button
                 aria-label={null}
@@ -4376,7 +5680,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 }
               >
                 <span
-                  className="sc-gZMcBi jmJkvl"
+                  className="sc-kAzzGY bMSYif"
                 >
                   <svg
                     height="100%"
@@ -4434,13 +5738,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
               }
             >
               <h1
-                className="sc-LKuAh elVZTo"
+                className="sc-gmeYpB hOfLfM"
               >
                 Weekly Sync Report
               </h1>
             </button>
             <div
-              className="sc-hzNEM iBlsLW"
+              className="sc-RcBXQ dEQxDt"
             >
               <svg
                 height="100%"
@@ -4488,16 +5792,16 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -4512,15 +5816,190 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 Performance
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <span
-              className="sc-gipzik kIRFxz"
+              className="sc-fMiknA jXKXNS"
             >
               <div
-                className="sc-iAyFgw bABLIb"
+                className="sc-jAaTju fDFrqR"
                 size="16px"
               >
                 <img
@@ -4587,7 +6066,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-csuQGl kjtdmC"
+                className="sc-dVhcbM fJvssG"
               >
                 <span
                   style={
@@ -4600,7 +6079,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-jlyJG gBkPre"
+                    className="sc-fBuWsC feloW"
                   >
                     Buffer
                   </span>
@@ -4610,17 +6089,17 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-elJkPf gouEjV"
+          className="sc-iyvyFf gBUoBU"
         >
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -4640,7 +6119,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -4657,13 +6136,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -4686,7 +6165,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -4709,14 +6188,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -4736,7 +6215,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -4753,13 +6232,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -4782,7 +6261,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -4805,14 +6284,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -4832,7 +6311,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -4849,13 +6328,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -4878,7 +6357,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -4901,14 +6380,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -4928,7 +6407,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -4945,13 +6424,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -4974,7 +6453,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -4997,14 +6476,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5024,7 +6503,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5044,14 +6523,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5071,7 +6550,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5088,13 +6567,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5117,7 +6596,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5140,14 +6619,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5167,7 +6646,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5184,13 +6663,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5213,7 +6692,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5236,14 +6715,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5263,7 +6742,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5280,13 +6759,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5309,7 +6788,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5334,16 +6813,16 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -5358,15 +6837,190 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 Performance
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <span
-              className="sc-gipzik kIRFxz"
+              className="sc-fMiknA jXKXNS"
             >
               <div
-                className="sc-iAyFgw bABLIb"
+                className="sc-jAaTju fDFrqR"
                 size="16px"
               >
                 <img
@@ -5433,7 +7087,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-csuQGl kjtdmC"
+                className="sc-dVhcbM fJvssG"
               >
                 <span
                   style={
@@ -5446,7 +7100,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-jlyJG gBkPre"
+                    className="sc-fBuWsC feloW"
                   >
                     Buffer
                   </span>
@@ -5456,17 +7110,17 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-elJkPf gouEjV"
+          className="sc-iyvyFf gBUoBU"
         >
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5486,7 +7140,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5503,13 +7157,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5532,7 +7186,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5555,14 +7209,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5582,7 +7236,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5599,13 +7253,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5628,7 +7282,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5651,14 +7305,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5678,7 +7332,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5695,13 +7349,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5724,7 +7378,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5747,14 +7401,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5774,7 +7428,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5791,13 +7445,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5820,7 +7474,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5843,14 +7497,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5870,7 +7524,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5890,14 +7544,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -5917,7 +7571,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -5934,13 +7588,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -5963,7 +7617,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -5986,14 +7640,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6013,7 +7667,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6030,13 +7684,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6059,7 +7713,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6082,14 +7736,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6109,7 +7763,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6126,13 +7780,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6155,7 +7809,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6180,16 +7834,16 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -6204,15 +7858,190 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 Performance
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <span
-              className="sc-gipzik kIRFxz"
+              className="sc-fMiknA jXKXNS"
             >
               <div
-                className="sc-iAyFgw bABLIb"
+                className="sc-jAaTju fDFrqR"
                 size="16px"
               >
                 <img
@@ -6279,7 +8108,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-csuQGl kjtdmC"
+                className="sc-dVhcbM fJvssG"
               >
                 <span
                   style={
@@ -6292,7 +8121,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-jlyJG gBkPre"
+                    className="sc-fBuWsC feloW"
                   >
                     Buffer
                   </span>
@@ -6302,17 +8131,17 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-elJkPf gouEjV"
+          className="sc-iyvyFf gBUoBU"
         >
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6332,7 +8161,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6349,13 +8178,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6378,7 +8207,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6401,14 +8230,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6428,7 +8257,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6445,13 +8274,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6474,7 +8303,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6497,14 +8326,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6524,7 +8353,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6541,13 +8370,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6570,7 +8399,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6593,14 +8422,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6620,7 +8449,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6637,13 +8466,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6666,7 +8495,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6689,14 +8518,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6716,7 +8545,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6736,14 +8565,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6763,7 +8592,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6780,13 +8609,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6809,7 +8638,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6832,14 +8661,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6859,7 +8688,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6876,13 +8705,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -6905,7 +8734,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -6928,14 +8757,14 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -6955,7 +8784,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -6972,13 +8801,13 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7001,7 +8830,7 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7030,17 +8859,2782 @@ exports[`Snapshots Report renders a report with summary table and logo 1`] = `
 </span>
 `;
 
-exports[`Snapshots Report renders a report with summary table and no logo 1`] = `
+exports[`Snapshots Report render with summary table and logo whilst exporting 1`] = `
+<span>
+  <div
+    className="sc-cooIXK cFMURY"
+    id="report-page"
+  >
+    <article
+      className="sc-bxivhb cEKEIA"
+    >
+      <div
+        className="sc-ifAKCX gxuirt"
+      >
+        <div
+          className="sc-EHOje jvzENE"
+        >
+          <div
+            className="sc-bZQynM jdccxu"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <h1
+                className="sc-gzVnrw jABNwW"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
+            </span>
+          </div>
+          <img
+            alt="Weekly Sync Report"
+            className="sc-htoDjs lghlNe"
+            src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+          />
+        </div>
+      </div>
+    </article>
+    <div
+      className="sc-fcdeBU kIwvDy"
+    >
+      <span
+        style={
+          Object {
+            "color": "#59626a",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "fontSize": "1rem",
+            "fontWeight": 400,
+          }
+        }
+      >
+        <div
+          className="sc-kZmsYB hsAkSd"
+        >
+          <div
+            className="sc-gqjmRU duSJDA"
+          >
+            <button
+              aria-label={null}
+              disabled={undefined}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "background": "none",
+                  "backgroundColor": "unset",
+                  "border": "none",
+                  "borderRadius": "unset",
+                  "color": "unset",
+                  "cursor": "pointer",
+                  "display": "unset",
+                  "fontFamily": "unset",
+                  "fontSize": "unset",
+                  "fontWeight": "unset",
+                  "lineHeight": "unset",
+                  "margin": "unset",
+                  "outline": "none",
+                  "padding": 0,
+                  "transition": "unset",
+                }
+              }
+            >
+              <span
+                className="sc-kAzzGY bMSYif"
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#59626a",
+                      "height": "1rem",
+                      "width": "1rem",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="shuttleGray"
+                  >
+                    <path
+                      d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                      transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                    />
+                  </g>
+                </svg>
+              </span>
+            </button>
+          </div>
+          <button
+            aria-label={null}
+            disabled={undefined}
+            onBlur={[Function]}
+            onClick={undefined}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "background": "none",
+                "backgroundColor": "unset",
+                "border": "none",
+                "borderRadius": "unset",
+                "color": "unset",
+                "cursor": "pointer",
+                "display": "unset",
+                "fontFamily": "unset",
+                "fontSize": "unset",
+                "fontWeight": "unset",
+                "lineHeight": "unset",
+                "margin": "unset",
+                "outline": "none",
+                "padding": 0,
+                "transition": "unset",
+              }
+            }
+          >
+            <h1
+              className="sc-gmeYpB hOfLfM"
+            >
+              Weekly Sync Report
+            </h1>
+          </button>
+          <div
+            className="sc-RcBXQ dEQxDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M0,12.8353339 L3.16356812,15.998902 L0,15.998902 L0,12.8353339 Z M1.05452271,11.7808112 L10.5452271,2.29010681 L13.7087952,5.45367493 L4.21809083,14.9443793 L1.05452271,11.7808112 Z M11.5997498,1.2355841 L12.2903301,0.545003751 C13.0737267,-0.238392873 14.3489904,-0.2332661 15.1240254,0.541768884 L15.4571331,0.874876608 C16.2387432,1.65648666 16.2395801,2.92288997 15.4538982,3.70857187 L14.7633179,4.39915222 L11.5997498,1.2355841 Z"
+                />
+              </g>
+            </svg>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "color": "#000",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 700,
+            }
+          }
+        >
+          <span
+            className="sc-htpNat KtFsv"
+          >
+            February 20, 2018
+             to 
+            February 25, 2018
+          </span>
+        </span>
+      </span>
+    </div>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Performance
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <span
+            className="sc-fMiknA jXKXNS"
+          >
+            <div
+              className="sc-jAaTju fDFrqR"
+              size="16px"
+            >
+              <img
+                alt=""
+                src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                style={
+                  Object {
+                    "borderRadius": "50%",
+                    "height": "16px",
+                    "marginBottom": undefined,
+                    "marginTop": undefined,
+                    "maxHeight": undefined,
+                    "maxWidth": undefined,
+                    "minHeight": undefined,
+                    "minWidth": undefined,
+                    "objectFit": undefined,
+                    "width": "16px",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                    "borderRadius": "50%",
+                    "display": "",
+                    "height": "18px",
+                    "left": "-1px",
+                    "marginRight": "",
+                    "position": "absolute",
+                    "top": "-2px",
+                    "width": "18px",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="facebook"
+                  >
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              className="sc-dVhcbM fJvssG"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                  }
+                }
+              >
+                <span
+                  className="sc-fBuWsC feloW"
+                >
+                  Buffer
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <ul
+        className="sc-iyvyFf gBUoBU"
+      >
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  150
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#2FD566"
+                        transform="translate(1 2)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#2fd566",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      25
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  901
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      39
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  1,010
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      55
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  963.4k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      26
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  0
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  28.8k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      33
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  2,313
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      28
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  658
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      9
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Performance
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <span
+            className="sc-fMiknA jXKXNS"
+          >
+            <div
+              className="sc-jAaTju fDFrqR"
+              size="16px"
+            >
+              <img
+                alt=""
+                src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                style={
+                  Object {
+                    "borderRadius": "50%",
+                    "height": "16px",
+                    "marginBottom": undefined,
+                    "marginTop": undefined,
+                    "maxHeight": undefined,
+                    "maxWidth": undefined,
+                    "minHeight": undefined,
+                    "minWidth": undefined,
+                    "objectFit": undefined,
+                    "width": "16px",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                    "borderRadius": "50%",
+                    "display": "",
+                    "height": "18px",
+                    "left": "-1px",
+                    "marginRight": "",
+                    "position": "absolute",
+                    "top": "-2px",
+                    "width": "18px",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="facebook"
+                  >
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              className="sc-dVhcbM fJvssG"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                  }
+                }
+              >
+                <span
+                  className="sc-fBuWsC feloW"
+                >
+                  Buffer
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <ul
+        className="sc-iyvyFf gBUoBU"
+      >
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  150
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#2FD566"
+                        transform="translate(1 2)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#2fd566",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      25
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  901
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      39
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  1,010
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      55
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  963.4k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      26
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  0
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  28.8k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      33
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  2,313
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      28
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  658
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      9
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Performance
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <span
+            className="sc-fMiknA jXKXNS"
+          >
+            <div
+              className="sc-jAaTju fDFrqR"
+              size="16px"
+            >
+              <img
+                alt=""
+                src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                style={
+                  Object {
+                    "borderRadius": "50%",
+                    "height": "16px",
+                    "marginBottom": undefined,
+                    "marginTop": undefined,
+                    "maxHeight": undefined,
+                    "maxWidth": undefined,
+                    "minHeight": undefined,
+                    "minWidth": undefined,
+                    "objectFit": undefined,
+                    "width": "16px",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                    "borderRadius": "50%",
+                    "display": "",
+                    "height": "18px",
+                    "left": "-1px",
+                    "marginRight": "",
+                    "position": "absolute",
+                    "top": "-2px",
+                    "width": "18px",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="facebook"
+                  >
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              className="sc-dVhcbM fJvssG"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                  }
+                }
+              >
+                <span
+                  className="sc-fBuWsC feloW"
+                >
+                  Buffer
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <ul
+        className="sc-iyvyFf gBUoBU"
+      >
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  150
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#2FD566"
+                        transform="translate(1 2)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#2fd566",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      25
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  901
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      39
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  1,010
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      55
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  963.4k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      26
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  0
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  28.8k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      33
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  2,313
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      28
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  658
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      9
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <div
+      className="sc-fZwumE bxgVaL"
+    />
+  </div>
+</span>
+`;
+
+exports[`Snapshots Report render with summary table and no logo 1`] = `
 <span>
   <section
-    className="sc-kxynE jPxQWj"
+    className="sc-fQejPQ cajZzW"
   >
     <div
-      className="sc-jKVCRD gcvHXT"
+      className="sc-cooIXK cFMURY"
       id="report-page"
     >
       <div
-        className="sc-kaNhvL cZRnAm"
+        className="sc-fcdeBU kIwvDy"
       >
         <span
           style={
@@ -7053,16 +11647,16 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
           }
         >
           <div
-            className="sc-iBEsjs iDDIrh"
+            className="sc-kZmsYB hsAkSd"
           >
             <div
-              className="sc-EHOje hKVWKI"
+              className="sc-gqjmRU duSJDA"
             >
               <div
-                className="sc-bZQynM geoqxB"
+                className="sc-VigVT beITMy"
               >
                 <span
-                  className="sc-dnqmqq dPUIZI"
+                  className="sc-jzJRlG iQUWtb"
                 >
                   <span
                     style={
@@ -7120,13 +11714,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
               }
             >
               <h1
-                className="sc-LKuAh elVZTo"
+                className="sc-gmeYpB hOfLfM"
               >
                 Weekly Sync Report
               </h1>
             </button>
             <div
-              className="sc-hzNEM iBlsLW"
+              className="sc-RcBXQ dEQxDt"
             >
               <svg
                 height="100%"
@@ -7174,16 +11768,16 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
         </span>
       </div>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -7198,15 +11792,190 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 Performance
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <span
-              className="sc-gipzik kIRFxz"
+              className="sc-fMiknA jXKXNS"
             >
               <div
-                className="sc-iAyFgw bABLIb"
+                className="sc-jAaTju fDFrqR"
                 size="16px"
               >
                 <img
@@ -7273,7 +12042,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </div>
               </div>
               <div
-                className="sc-csuQGl kjtdmC"
+                className="sc-dVhcbM fJvssG"
               >
                 <span
                   style={
@@ -7286,7 +12055,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   }
                 >
                   <span
-                    className="sc-jlyJG gBkPre"
+                    className="sc-fBuWsC feloW"
                   >
                     Buffer
                   </span>
@@ -7296,17 +12065,17 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
           </div>
         </div>
         <ul
-          className="sc-elJkPf gouEjV"
+          className="sc-iyvyFf gBUoBU"
         >
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7326,7 +12095,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7343,13 +12112,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7372,7 +12141,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7395,14 +12164,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7422,7 +12191,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7439,13 +12208,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7468,7 +12237,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7491,14 +12260,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7518,7 +12287,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7535,13 +12304,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7564,7 +12333,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7587,14 +12356,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7614,7 +12383,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7631,13 +12400,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7660,7 +12429,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7683,14 +12452,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7710,7 +12479,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7730,14 +12499,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7757,7 +12526,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7774,13 +12543,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7803,7 +12572,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7826,14 +12595,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7853,7 +12622,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7870,13 +12639,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7899,7 +12668,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -7922,14 +12691,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -7949,7 +12718,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -7966,13 +12735,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -7995,7 +12764,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8020,16 +12789,16 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
         </ul>
       </section>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -8044,15 +12813,190 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 Performance
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <span
-              className="sc-gipzik kIRFxz"
+              className="sc-fMiknA jXKXNS"
             >
               <div
-                className="sc-iAyFgw bABLIb"
+                className="sc-jAaTju fDFrqR"
                 size="16px"
               >
                 <img
@@ -8119,7 +13063,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </div>
               </div>
               <div
-                className="sc-csuQGl kjtdmC"
+                className="sc-dVhcbM fJvssG"
               >
                 <span
                   style={
@@ -8132,7 +13076,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   }
                 >
                   <span
-                    className="sc-jlyJG gBkPre"
+                    className="sc-fBuWsC feloW"
                   >
                     Buffer
                   </span>
@@ -8142,17 +13086,17 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
           </div>
         </div>
         <ul
-          className="sc-elJkPf gouEjV"
+          className="sc-iyvyFf gBUoBU"
         >
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8172,7 +13116,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8189,13 +13133,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8218,7 +13162,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8241,14 +13185,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8268,7 +13212,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8285,13 +13229,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8314,7 +13258,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8337,14 +13281,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8364,7 +13308,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8381,13 +13325,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8410,7 +13354,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8433,14 +13377,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8460,7 +13404,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8477,13 +13421,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8506,7 +13450,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8529,14 +13473,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8556,7 +13500,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8576,14 +13520,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8603,7 +13547,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8620,13 +13564,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8649,7 +13593,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8672,14 +13616,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8699,7 +13643,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8716,13 +13660,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8745,7 +13689,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8768,14 +13712,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -8795,7 +13739,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -8812,13 +13756,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -8841,7 +13785,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -8866,16 +13810,16 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
         </ul>
       </section>
       <section
-        className="sc-bmyXtO jkDPyK"
+        className="sc-iBEsjs hYWDoZ"
       >
         <div
-          className="sc-ebFjAB joITdX"
+          className="sc-kxynE kZABzl"
         >
           <div
-            className="sc-dEoRIm bJmZfG"
+            className="sc-hzNEM fsLdNR"
           >
             <h2
-              className="sc-jWBwVP kAqDQk"
+              className="sc-jlyJG dktCpg"
             >
               <span
                 style={
@@ -8890,15 +13834,190 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 Performance
               </span>
             </h2>
+            <aside
+              className="sc-bdVaJa OXVli"
+            >
+              <button
+                aria-label={null}
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,3.83437656 C4.5159485,3.44536915 4.51510793,2.81708404 4.90996552,2.42499924 L4.90996552,2.42499924 C5.30208929,2.03562905 5.93536183,2.03785674 6.32490003,2.4304594 L11.2750374,7.41953907 C11.6643604,7.81192483 11.6645756,8.44590538 11.2750374,8.83605572 L6.32490003,13.7939721 C5.93557705,14.1839068 5.3048231,14.1848577 4.90996552,13.7899895 L4.90996552,13.7899895 C4.51784174,13.3978552 4.51273549,12.7696997 4.9163418,12.369326 L8.84038203,8.47671472 C9.03897712,8.27971024 9.04484713,7.96519423 8.84038203,7.76113877 L4.90573685,3.83437656 Z"
+                        transform="translate(8.089966, 8.109997) scale(-1, -1) rotate(-270.000000) translate(-8.089966, -8.109997) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M4.90573685,4.61438297 C4.5159485,4.22537555 4.51510793,3.59709045 4.90996552,3.20500565 L4.90996552,3.20500565 C5.30208929,2.81563546 5.93536183,2.81786315 6.32490003,3.21046581 L11.2750374,8.19954548 C11.6643604,8.59193123 11.6645756,9.22591178 11.2750374,9.61606213 L6.32490003,14.5739785 C5.93557705,14.9639132 5.3048231,14.9648641 4.90996552,14.5699959 L4.90996552,14.5699959 C4.51784174,14.1778616 4.51273549,13.5497061 4.9163418,13.1493324 L8.84038203,9.25672113 C9.03897712,9.05971665 9.04484713,8.74520064 8.84038203,8.54114518 L4.90573685,4.61438297 Z"
+                        transform="translate(8.089966, 8.890003) scale(-1, 1) rotate(-270.000000) translate(-8.089966, -8.890003) "
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+              <button
+                aria-label={null}
+                disabled={undefined}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "background": "none",
+                    "backgroundColor": "unset",
+                    "border": "none",
+                    "borderRadius": "unset",
+                    "color": "unset",
+                    "cursor": "pointer",
+                    "display": "unset",
+                    "fontFamily": "unset",
+                    "fontSize": "unset",
+                    "fontWeight": "unset",
+                    "lineHeight": "unset",
+                    "margin": "unset",
+                    "outline": "none",
+                    "padding": 0,
+                    "transition": "unset",
+                  }
+                }
+              >
+                <span
+                  className="sc-bwzfXH fiRkqt"
+                >
+                  <svg
+                    height="100%"
+                    style={
+                      Object {
+                        "fill": "#59626a",
+                        "height": "1rem",
+                        "width": "1rem",
+                      }
+                    }
+                    version="1.1"
+                    viewBox="0 0 16 16"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <g
+                      className="shuttleGray"
+                    >
+                      <path
+                        d="M7,9 L1.00292933,9 C0.449026756,9 -8.8817842e-16,8.55613518 -8.8817842e-16,8 L-8.8817842e-16,8 C-8.8817842e-16,7.44771525 0.437881351,7 1.00292933,7 L7,7 L7,1.00292933 C7,0.449026756 7.44386482,0 8,0 L8,0 C8.55228475,0 9,0.437881351 9,1.00292933 L9,7 L14.9970707,7 C15.5509732,7 16,7.44386482 16,8 L16,8 C16,8.55228475 15.5621186,9 14.9970707,9 L9,9 L9,14.9970707 C9,15.5509732 8.55613518,16 8,16 L8,16 C7.44771525,16 7,15.5621186 7,14.9970707 L7,9 Z"
+                        transform="translate(8.000000, 8.000000) rotate(-315.000000) translate(-8.000000, -8.000000)"
+                      />
+                    </g>
+                  </svg>
+                </span>
+              </button>
+            </aside>
           </div>
           <div
-            className="sc-jtggT jgpGvV"
+            className="sc-chbbiW hMUxkW"
           >
             <span
-              className="sc-gipzik kIRFxz"
+              className="sc-fMiknA jXKXNS"
             >
               <div
-                className="sc-iAyFgw bABLIb"
+                className="sc-jAaTju fDFrqR"
                 size="16px"
               >
                 <img
@@ -8965,7 +14084,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </div>
               </div>
               <div
-                className="sc-csuQGl kjtdmC"
+                className="sc-dVhcbM fJvssG"
               >
                 <span
                   style={
@@ -8978,7 +14097,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   }
                 >
                   <span
-                    className="sc-jlyJG gBkPre"
+                    className="sc-fBuWsC feloW"
                   >
                     Buffer
                   </span>
@@ -8988,17 +14107,17 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
           </div>
         </div>
         <ul
-          className="sc-elJkPf gouEjV"
+          className="sc-iyvyFf gBUoBU"
         >
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9018,7 +14137,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9035,13 +14154,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9064,7 +14183,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9087,14 +14206,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9114,7 +14233,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9131,13 +14250,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9160,7 +14279,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9183,14 +14302,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9210,7 +14329,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9227,13 +14346,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9256,7 +14375,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9279,14 +14398,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9306,7 +14425,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9323,13 +14442,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9352,7 +14471,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9375,14 +14494,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9402,7 +14521,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9422,14 +14541,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9449,7 +14568,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9466,13 +14585,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9495,7 +14614,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9518,14 +14637,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9545,7 +14664,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9562,13 +14681,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9591,7 +14710,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9614,14 +14733,14 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
             </div>
           </li>
           <li
-            className="sc-dxgOiQ fKyTyB"
+            className="sc-iAyFgw iSMySM"
             width="25%"
           >
             <div
-              className="sc-ckVGcZ kMhhDE"
+              className="sc-hSdWYo KZWcv"
             >
               <span
-                className="sc-kpOJdX OJJrM"
+                className="sc-kkGfuU gJJOdT"
               >
                 <span
                   data-tip={null}
@@ -9641,7 +14760,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                 </span>
               </span>
               <div
-                className="sc-jKJlTe dCPwhQ"
+                className="sc-eHgmQL blOGAg"
               >
                 <span
                   style={
@@ -9658,13 +14777,13 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                   </span>
                 </span>
                 <div
-                  className="sc-chPdSV jzMHaP"
+                  className="sc-eNQAEJ hmCevm"
                 >
                   <div
-                    className="sc-kgoBCf iujlmc"
+                    className="sc-hMqMXs kmzeGg"
                   >
                     <div
-                      className="sc-kAzzGY cnJubn"
+                      className="sc-jKJlTe hScyWm"
                     >
                       <svg
                         fill="none"
@@ -9687,7 +14806,7 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
                     </div>
                   </div>
                   <div
-                    className="sc-kGXeez cGxapO"
+                    className="sc-kEYyzF ihVUuK"
                   >
                     <span
                       style={
@@ -9713,5 +14832,2827 @@ exports[`Snapshots Report renders a report with summary table and no logo 1`] = 
       </section>
     </div>
   </section>
+</span>
+`;
+
+exports[`Snapshots Report render with summary table and no logo whilst exporting 1`] = `
+<span>
+  <div
+    className="sc-cooIXK cFMURY"
+    id="report-page"
+  >
+    <article
+      className="sc-bxivhb cEKEIA"
+    >
+      <div
+        className="sc-ifAKCX gxuirt"
+      >
+        <div
+          className="sc-EHOje jvzENE"
+        >
+          <div
+            className="sc-bZQynM jdccxu"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <h1
+                className="sc-gzVnrw jABNwW"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </article>
+    <div
+      className="sc-fcdeBU kIwvDy"
+    >
+      <span
+        style={
+          Object {
+            "color": "#59626a",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "fontSize": "1rem",
+            "fontWeight": 400,
+          }
+        }
+      >
+        <div
+          className="sc-kZmsYB hsAkSd"
+        >
+          <div
+            className="sc-gqjmRU duSJDA"
+          >
+            <div
+              className="sc-VigVT beITMy"
+            >
+              <span
+                className="sc-jzJRlG iQUWtb"
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#323b43",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "1rem",
+                      "fontWeight": 500,
+                    }
+                  }
+                >
+                  Upload logo
+                </span>
+              </span>
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                PNG or JPG
+              </span>
+            </div>
+          </div>
+          <button
+            aria-label={null}
+            disabled={undefined}
+            onBlur={[Function]}
+            onClick={undefined}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "background": "none",
+                "backgroundColor": "unset",
+                "border": "none",
+                "borderRadius": "unset",
+                "color": "unset",
+                "cursor": "pointer",
+                "display": "unset",
+                "fontFamily": "unset",
+                "fontSize": "unset",
+                "fontWeight": "unset",
+                "lineHeight": "unset",
+                "margin": "unset",
+                "outline": "none",
+                "padding": 0,
+                "transition": "unset",
+              }
+            }
+          >
+            <h1
+              className="sc-gmeYpB hOfLfM"
+            >
+              Weekly Sync Report
+            </h1>
+          </button>
+          <div
+            className="sc-RcBXQ dEQxDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M0,12.8353339 L3.16356812,15.998902 L0,15.998902 L0,12.8353339 Z M1.05452271,11.7808112 L10.5452271,2.29010681 L13.7087952,5.45367493 L4.21809083,14.9443793 L1.05452271,11.7808112 Z M11.5997498,1.2355841 L12.2903301,0.545003751 C13.0737267,-0.238392873 14.3489904,-0.2332661 15.1240254,0.541768884 L15.4571331,0.874876608 C16.2387432,1.65648666 16.2395801,2.92288997 15.4538982,3.70857187 L14.7633179,4.39915222 L11.5997498,1.2355841 Z"
+                />
+              </g>
+            </svg>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "color": "#000",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 700,
+            }
+          }
+        >
+          <span
+            className="sc-htpNat KtFsv"
+          >
+            February 20, 2018
+             to 
+            February 25, 2018
+          </span>
+        </span>
+      </span>
+    </div>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Performance
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <span
+            className="sc-fMiknA jXKXNS"
+          >
+            <div
+              className="sc-jAaTju fDFrqR"
+              size="16px"
+            >
+              <img
+                alt=""
+                src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                style={
+                  Object {
+                    "borderRadius": "50%",
+                    "height": "16px",
+                    "marginBottom": undefined,
+                    "marginTop": undefined,
+                    "maxHeight": undefined,
+                    "maxWidth": undefined,
+                    "minHeight": undefined,
+                    "minWidth": undefined,
+                    "objectFit": undefined,
+                    "width": "16px",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                    "borderRadius": "50%",
+                    "display": "",
+                    "height": "18px",
+                    "left": "-1px",
+                    "marginRight": "",
+                    "position": "absolute",
+                    "top": "-2px",
+                    "width": "18px",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="facebook"
+                  >
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              className="sc-dVhcbM fJvssG"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                  }
+                }
+              >
+                <span
+                  className="sc-fBuWsC feloW"
+                >
+                  Buffer
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <ul
+        className="sc-iyvyFf gBUoBU"
+      >
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  150
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#2FD566"
+                        transform="translate(1 2)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#2fd566",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      25
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  901
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      39
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  1,010
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      55
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  963.4k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      26
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  0
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  28.8k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      33
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  2,313
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      28
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  658
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      9
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Performance
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <span
+            className="sc-fMiknA jXKXNS"
+          >
+            <div
+              className="sc-jAaTju fDFrqR"
+              size="16px"
+            >
+              <img
+                alt=""
+                src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                style={
+                  Object {
+                    "borderRadius": "50%",
+                    "height": "16px",
+                    "marginBottom": undefined,
+                    "marginTop": undefined,
+                    "maxHeight": undefined,
+                    "maxWidth": undefined,
+                    "minHeight": undefined,
+                    "minWidth": undefined,
+                    "objectFit": undefined,
+                    "width": "16px",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                    "borderRadius": "50%",
+                    "display": "",
+                    "height": "18px",
+                    "left": "-1px",
+                    "marginRight": "",
+                    "position": "absolute",
+                    "top": "-2px",
+                    "width": "18px",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="facebook"
+                  >
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              className="sc-dVhcbM fJvssG"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                  }
+                }
+              >
+                <span
+                  className="sc-fBuWsC feloW"
+                >
+                  Buffer
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <ul
+        className="sc-iyvyFf gBUoBU"
+      >
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  150
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#2FD566"
+                        transform="translate(1 2)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#2fd566",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      25
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  901
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      39
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  1,010
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      55
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  963.4k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      26
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  0
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  28.8k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      33
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  2,313
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      28
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  658
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      9
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="sc-iBEsjs hYWDoZ"
+    >
+      <div
+        className="sc-kxynE kZABzl"
+      >
+        <div
+          className="sc-hzNEM fsLdNR"
+        >
+          <h2
+            className="sc-jlyJG dktCpg"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#000",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              Performance
+            </span>
+          </h2>
+        </div>
+        <div
+          className="sc-chbbiW hMUxkW"
+        >
+          <span
+            className="sc-fMiknA jXKXNS"
+          >
+            <div
+              className="sc-jAaTju fDFrqR"
+              size="16px"
+            >
+              <img
+                alt=""
+                src="https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/10403026_1055367724535674_7855796462569708170_n.png?oh=7e504fbcb2addb0c18e47af9ee6ae454&oe=5AF1F381"
+                style={
+                  Object {
+                    "borderRadius": "50%",
+                    "height": "16px",
+                    "marginBottom": undefined,
+                    "marginTop": undefined,
+                    "maxHeight": undefined,
+                    "maxWidth": undefined,
+                    "minHeight": undefined,
+                    "minWidth": undefined,
+                    "objectFit": undefined,
+                    "width": "16px",
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "border": "rgba(255, 255, 255, 0.5) 1px solid",
+                    "borderRadius": "50%",
+                    "display": "",
+                    "height": "18px",
+                    "left": "-1px",
+                    "marginRight": "",
+                    "position": "absolute",
+                    "top": "-2px",
+                    "width": "18px",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#3b5998",
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="facebook"
+                  >
+                    <g
+                      fillRule="evenodd"
+                    >
+                      <path
+                        d="M0,8 C0,3.581722 3.59071231,0 8,0 L8,0 C12.418278,0 16,3.59071231 16,8 L16,8 C16,12.418278 12.4092877,16 8,16 L8,16 C3.581722,16 0,12.4092877 0,8 L0,8 Z M7.18233349,12 L7.18233349,8.3508456 L6,8.3508456 L6,6.92867987 L7.18233349,6.92867987 L7.18233349,5.87988561 C7.18233349,4.66274759 7.89803602,4 8.94344305,4 C9.44416966,4 9.8745294,4.03873177 10,4.0560322 L10,5.32800198 L9.27491523,5.32835505 C8.70640526,5.32835505 8.59633378,5.60893973 8.59633378,6.0206899 L8.59633378,6.92867987 L9.95220491,6.92867987 L9.77564184,8.3508456 L8.59633378,8.3508456 L8.59633378,12 L7.18233349,12 Z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              className="sc-dVhcbM fJvssG"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                  }
+                }
+              >
+                <span
+                  className="sc-fBuWsC feloW"
+                >
+                  Buffer
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <ul
+        className="sc-iyvyFf gBUoBU"
+      >
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Tweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  150
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#2FD566"
+                        transform="translate(1 2)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#2fd566",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      25
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Retweets
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  901
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      39
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Clicks
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  1,010
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      55
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Impressions
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  963.4k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      26
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  New Followers
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  0
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Engagements
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  28.8k
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      33
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Likes
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  2,313
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      28
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          className="sc-iAyFgw iSMySM"
+          width="25%"
+        >
+          <div
+            className="sc-hSdWYo KZWcv"
+          >
+            <span
+              className="sc-kkGfuU gJJOdT"
+            >
+              <span
+                data-tip={null}
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#59626a",
+                      "fontFamily": "\\"Roboto\\", sans-serif",
+                      "fontSize": "0.875rem",
+                      "fontWeight": 400,
+                    }
+                  }
+                >
+                  Replies
+                </span>
+              </span>
+            </span>
+            <div
+              className="sc-eHgmQL blOGAg"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#323b43",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span>
+                  658
+                </span>
+              </span>
+              <div
+                className="sc-eNQAEJ hmCevm"
+              >
+                <div
+                  className="sc-hMqMXs kmzeGg"
+                >
+                  <div
+                    className="sc-jKJlTe hScyWm"
+                  >
+                    <svg
+                      fill="none"
+                      height="11"
+                      viewBox="0 0 11 11"
+                      width="11"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        fill="white"
+                        height="11"
+                        width="11"
+                      />
+                      <path
+                        d="M4.06699 0.75C4.25944 0.416667 4.74056 0.416667 4.93301 0.75L7.9641 6C8.15655 6.33333 7.91599 6.75 7.53109 6.75L1.46891 6.75C1.08401 6.75 0.843448 6.33333 1.0359 6L4.06699 0.75Z"
+                        fill="#FF4040"
+                        transform="translate(10 9) rotate(-180)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="sc-kEYyzF ihVUuK"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#ff1e1e",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    <span>
+                      9
+                    </span>
+                    %
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+    <div
+      className="sc-fZwumE bxgVaL"
+    />
+  </div>
+</span>
+`;
+
+exports[`Snapshots Report renders loading whilst exporting 1`] = `
+<span>
+  <div
+    className="sc-iSDuPN bkBwuw"
+  >
+    <div
+      className="sc-kgoBCf hYcjis"
+    >
+      <div
+        className="sc-chPdSV OFRCa"
+      >
+        <div
+          style={
+            Object {
+              "textAlign": "center",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "1rem",
+                "margin": "0 auto 1rem auto",
+                "position": "relative",
+                "width": "1rem",
+              }
+            }
+          >
+            <span>
+              <div
+                style={
+                  Object {
+                    "height": "1rem",
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "top": 0,
+                    "transition": "all 1000ms ease-in-out",
+                    "width": "1rem",
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "fill": "#59626a",
+                      "height": "1rem",
+                      "width": "1rem",
+                    }
+                  }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <g
+                    className="shuttleGray"
+                  >
+                    <path
+                      d="M1.10241622,4.34038738 L7.75166358,7.40469806 C7.88821853,7.46764349 8.11178147,7.46764349 8.24833642,7.40469806 L14.8975838,4.34038738 C15.0341387,4.27744195 15.0341387,4.17446518 14.8975838,4.11151975 L8.24833642,1.04720908 C8.11178147,0.984263641 7.88821853,0.984263641 7.75166358,1.04720908 L1.10241622,4.11151975 C0.965861261,4.17446518 0.965861261,4.27744195 1.10241622,4.34038738"
+                    />
+                  </g>
+                </svg>
+              </div>
+            </span>
+          </div>
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            Loading...
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
 </span>
 `;

--- a/packages/report/components/ChartFactory/index.jsx
+++ b/packages/report/components/ChartFactory/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Table as SummaryTable, Title as SummaryTitle } from '@bufferapp/summary-table';
 import { Table as PostsSummary, Title as PostsSummaryTitle } from '@bufferapp/posts-summary-table';
 import { Table as AverageTable, Title as AverageTitle } from '@bufferapp/average-table';
@@ -75,6 +75,11 @@ const Separator = styled.section`
   &:hover aside {
     opacity: 1;
   }
+
+  ${props => props.exporting && css`
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  `}
 `;
 
 const TitleWrapper = styled.div`
@@ -92,7 +97,7 @@ const Header = styled.div`
 
 const ChartFactory = ({ charts, moveUp, moveDown, deleteChart, exporting }) =>
   charts.map((chart, index) => (
-    <Separator key={chart._id}>
+    <Separator key={chart._id} exporting={exporting}>
       <Header>
         <TitleWrapper>
           {React.createElement(CHARTS[chart.chart_id].title, {

--- a/packages/report/components/ChartFactory/index.jsx
+++ b/packages/report/components/ChartFactory/index.jsx
@@ -65,7 +65,7 @@ const Separator = styled.section`
   page-break-inside: avoid;
 
   &:last-of-type {
-    margin-bottom: 2rem;
+    margin-bottom: 0;
   }
 
   aside {

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Text } from '@bufferapp/components';
+
+import {
+  black,
+  white,
+} from '@bufferapp/components/style/color';
+
+import DateRange from '../DateRange';
+
+const Page = styled.article`
+  position: relative;
+  overflow-y: hidden;
+  height: 1446px; /* this seems to be the exact A4 portrait size */
+  margin: 0;
+  padding: 0;
+
+  @media print {
+    page-break-after: always;
+  }
+`;
+
+const Container = styled.div`
+  height: 100%;
+  box-sizing: border-box;
+  padding: 4.5rem 3rem;
+  background: ${white};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+`;
+
+const Wrapper = styled.div``;
+
+const Inner = styled.div`
+  padding: 0 8rem 24rem;
+`;
+
+const Title = styled.h1`
+  display: block;
+  color: ${black};
+  font-size: 5rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+`;
+
+const Logo = styled.img`
+  display: block;
+  margin: 4rem auto 0;
+  min-width: 100px;
+  max-width: 300px;
+  height: auto;
+  max-height: 300px;
+`;
+
+const Cover = ({ dateRange, logoUrl, name }) =>
+  <Page>
+    <Container>
+      <Wrapper>
+        <Inner>
+          <Text>
+            <Title>{name}</Title>
+            <DateRange {...dateRange} large />
+          </Text>
+        </Inner>
+        {logoUrl && <Logo src={logoUrl} alt={name} />}
+      </Wrapper>
+    </Container>
+  </Page>;
+
+Cover.defaultProps = {
+  dateRange: {},
+  name: '',
+  logoUrl: null,
+};
+
+Cover.propTypes = {
+  dateRange: PropTypes.shape({
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+  }),
+  name: PropTypes.string,
+  logoUrl: PropTypes.string,
+};
+
+export default Cover;

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -25,12 +25,12 @@ const Page = styled.article`
 const Container = styled.div`
   height: 100%;
   box-sizing: border-box;
-  padding: 4.5rem 3rem;
+  padding: 4.5rem 1.5rem;
   background: ${white};
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  text-align: center;
+  text-align: left;
 `;
 
 const Wrapper = styled.div``;

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -28,15 +28,15 @@ const Container = styled.div`
   padding: 4.5rem 1.5rem;
   background: ${white};
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
-  text-align: left;
+  text-align: center;
 `;
 
 const Wrapper = styled.div``;
 
 const Inner = styled.div`
-  padding: 0 8rem 24rem;
+  padding: 0 0 28rem;
 `;
 
 const Title = styled.h1`
@@ -49,7 +49,7 @@ const Title = styled.h1`
 
 const Logo = styled.img`
   display: block;
-  margin: 4rem auto 0;
+  margin: 8rem auto 0;
   min-width: 100px;
   max-width: 300px;
   height: auto;

--- a/packages/report/components/Cover/story.jsx
+++ b/packages/report/components/Cover/story.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { checkA11y } from 'storybook-addon-a11y';
+import styled from 'styled-components';
+import Cover from './index';
+
+const Card = styled.section`
+  width: 880px;
+  margin: 20px auto;
+  background: #FFFFFF;
+  border: 1px solid #E2E8ED;
+  box-shadow: 0px 0px 10px rgba(48, 71, 89, 0.05);
+  border-radius: 5px;
+  padding: 4.5rem 4rem;
+`;
+
+const name = 'Weekly Sync Report';
+
+const dateRange = {
+  startDate: '02/20/2018',
+  endDate: '02/25/2018',
+};
+
+storiesOf('Cover')
+  .addDecorator(checkA11y)
+  .add('renders a cover without a logo', () => (
+    <Card>
+      <Cover
+        name={name}
+        dateRange={dateRange}
+      />
+    </Card>
+  ))
+  .add('renders a cover with a logo', () => (
+    <Card>
+      <Cover
+        name={name}
+        dateRange={dateRange}
+        logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
+      />
+    </Card>
+  ));

--- a/packages/report/components/DateRange/index.jsx
+++ b/packages/report/components/DateRange/index.jsx
@@ -1,25 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import styled from 'styled-components';
+
 import {
   Text,
 } from '@bufferapp/components';
-import styled from 'styled-components';
 
 const Range = styled.span``;
 
 const Date = ({ children }) => moment(children, 'MM/DD/YYYY').format('MMMM D, YYYY');
 
-const DateRange = ({ startDate, endDate }) =>
-  <Text weight="bold" color="black">
+const DateRange = ({ startDate, endDate, large }) =>
+  <Text
+    weight="bold"
+    color="black"
+    size={(large ? 'extra-large' : null)}
+  >
     <Range>
       <Date>{startDate}</Date> to <Date>{endDate}</Date>
     </Range>
   </Text>;
 
+DateRange.defaultProps = {
+  large: false,
+};
+
 DateRange.propTypes = {
   startDate: PropTypes.string.isRequired,
   endDate: PropTypes.string.isRequired,
+  large: PropTypes.bool,
 };
 
 export default DateRange;

--- a/packages/report/components/DateRange/story.jsx
+++ b/packages/report/components/DateRange/story.jsx
@@ -8,4 +8,7 @@ storiesOf('DateRange')
   .addDecorator(checkA11y)
   .add('renders the date range', () => (
     <DateRange startDate="02/20/2018" endDate="02/25/2018" />
+  ))
+  .add('renders the date range larger', () => (
+    <DateRange startDate="02/20/2018" endDate="02/25/2018" large />
   ));

--- a/packages/report/components/Report/index.jsx
+++ b/packages/report/components/Report/index.jsx
@@ -21,6 +21,7 @@ import {
   white,
 } from '@bufferapp/components/style/color';
 
+import Cover from '../Cover';
 import ChartFactory from '../ChartFactory';
 import DateRange from '../DateRange';
 import EditTitle from '../EditTitle';
@@ -65,6 +66,12 @@ const Centered = styled.div`
   align-items: center;
 `;
 
+const Gradient = styled.div`
+  background: rgb(255,255,255);
+  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
+  height: 2rem;
+`;
+
 class Report extends React.Component {
   componentDidUpdate() {
     if (this.shouldAddPageBreaks()) {
@@ -83,6 +90,7 @@ class Report extends React.Component {
     const { name, dateRange, charts, loading,
       edit, saveChanges, editName, moveUp, moveDown, deleteChart, exporting, uploadLogo,
         logoUrl, deleteLogo, isLogoUploading, isLogoDropzoneDisabled } = this.props;
+
     if (loading) {
       return (
         <Centered>
@@ -90,8 +98,10 @@ class Report extends React.Component {
         </Centered>
       );
     }
+
     return (
       <Page id="report-page">
+        {exporting && <Cover name={name} dateRange={dateRange} logoUrl={logoUrl} />}
         <Header>
           <Text>
             { edit && <EditTitle name={name} saveChanges={saveChanges} />}
@@ -121,6 +131,7 @@ class Report extends React.Component {
           deleteChart={deleteChart}
           exporting={exporting}
         />
+        {exporting && <Gradient />}
       </Page>
     );
   }

--- a/packages/report/components/Report/index.jsx
+++ b/packages/report/components/Report/index.jsx
@@ -29,6 +29,7 @@ import LogoUpload from '../LogoUpload';
 
 const Page = styled.div`
   background: ${offWhite};
+  padding: 0 0 2rem;
 `;
 
 const Header = styled.div`
@@ -67,6 +68,7 @@ const Centered = styled.div`
 `;
 
 const Gradient = styled.div`
+  margin: 0 0 -2rem;
   background: rgb(255,255,255);
   background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
   height: 2rem;

--- a/packages/report/components/Report/index.jsx
+++ b/packages/report/components/Report/index.jsx
@@ -104,28 +104,30 @@ class Report extends React.Component {
     return (
       <Page id="report-page">
         {exporting && <Cover name={name} dateRange={dateRange} logoUrl={logoUrl} />}
-        <Header>
-          <Text>
-            { edit && <EditTitle name={name} saveChanges={saveChanges} />}
-            { !edit &&
-              <Container>
-                <LogoUpload
-                  logoUrl={logoUrl}
-                  uploadLogo={uploadLogo}
-                  deleteLogo={deleteLogo}
-                  isLogoUploading={isLogoUploading}
-                  isLogoDropzoneDisabled={isLogoDropzoneDisabled}
-                  exporting={exporting}
-                />
-                <Button noStyle onClick={editName}>
-                  <Title>{name}</Title>
-                </Button>
-                <Icon><EditIcon /></Icon>
-              </Container>
-            }
-            <DateRange {...dateRange} />
-          </Text>
-        </Header>
+        {!exporting &&
+          <Header>
+            <Text>
+              { edit && <EditTitle name={name} saveChanges={saveChanges} />}
+              { !edit &&
+                <Container>
+                  <LogoUpload
+                    logoUrl={logoUrl}
+                    uploadLogo={uploadLogo}
+                    deleteLogo={deleteLogo}
+                    isLogoUploading={isLogoUploading}
+                    isLogoDropzoneDisabled={isLogoDropzoneDisabled}
+                    exporting={exporting}
+                  />
+                  <Button noStyle onClick={editName}>
+                    <Title>{name}</Title>
+                  </Button>
+                  <Icon><EditIcon /></Icon>
+                </Container>
+              }
+              <DateRange {...dateRange} />
+            </Text>
+          </Header>
+        }
         <ChartFactory
           charts={charts}
           moveUp={moveUp}

--- a/packages/report/components/Report/story.jsx
+++ b/packages/report/components/Report/story.jsx
@@ -14,7 +14,6 @@ const Card = styled.section`
   border: 1px solid #E2E8ED;
   box-shadow: 0px 0px 10px rgba(48, 71, 89, 0.05);
   border-radius: 5px;
-  padding: 0;
   overflow: hidden;
 `;
 

--- a/packages/report/components/Report/story.jsx
+++ b/packages/report/components/Report/story.jsx
@@ -14,7 +14,8 @@ const Card = styled.section`
   border: 1px solid #E2E8ED;
   box-shadow: 0px 0px 10px rgba(48, 71, 89, 0.05);
   border-radius: 5px;
-  padding: 4.5rem 4rem;
+  padding: 0;
+  overflow: hidden;
 `;
 
 const report = {
@@ -224,18 +225,26 @@ const dateRange = {
 
 storiesOf('Report')
   .addDecorator(checkA11y)
-  .add('renders a report with summary table and no logo', () => (
+  .add('render with summary table and no logo', () => (
     <Card>
       <Report
         {...report}
         dateRange={dateRange}
         saveChanges={() => {}}
         parsePageBreaks={() => {}}
-        exporting
       />
     </Card>
   ))
-  .add('renders a report with summary table and logo', () => (
+  .add('render with summary table and no logo whilst exporting', () => (
+    <Report
+      {...report}
+      dateRange={dateRange}
+      saveChanges={() => {}}
+      parsePageBreaks={() => {}}
+      exporting
+    />
+  ))
+  .add('render with summary table and logo', () => (
     <Card>
       <Report
         {...report}
@@ -243,9 +252,18 @@ storiesOf('Report')
         saveChanges={() => {}}
         parsePageBreaks={() => {}}
         logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
-        exporting
       />
     </Card>
+  ))
+  .add('render with summary table and logo whilst exporting', () => (
+    <Report
+      {...report}
+      dateRange={dateRange}
+      saveChanges={() => {}}
+      parsePageBreaks={() => {}}
+      logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
+      exporting
+    />
   ))
   .add('render only the multi-profile legend if that is available', () => (
     <Card>
@@ -254,24 +272,34 @@ storiesOf('Report')
         dateRange={dateRange}
         saveChanges={() => {}}
         parsePageBreaks={() => {}}
-        exporting
       />
     </Card>
   ))
-  .add('renders a report in edit mode', () => (
+  .add('render only the multi-profile legend if that is available whilst exporting', () => (
+    <Report
+      {...comparisonReport}
+      dateRange={dateRange}
+      saveChanges={() => {}}
+      parsePageBreaks={() => {}}
+      exporting
+    />
+  ))
+  .add('render in edit mode', () => (
     <Card>
       <Report
         {...report}
         dateRange={dateRange}
         saveChanges={() => {}}
         parsePageBreaks={() => {}}
-        exporting
         edit
       />
     </Card>
   ))
-  .add('renders a loading report', () => (
+  .add('render loading', () => (
     <Card>
       <Report loading />
     </Card>
+  ))
+  .add('renders loading whilst exporting', () => (
+    <Report loading exporting />
   ));

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -671,7 +671,7 @@ exports[`Snapshots App should render application 1`] = `
       }
     >
       <div
-        className="sc-gtfDJT eacHaQ"
+        className="sc-ePZHVD gzDHRN"
       >
         <div
           style={
@@ -707,7 +707,7 @@ exports[`Snapshots App should render application 1`] = `
             target="_self"
           >
             <span
-              className="sc-hgHYgh fOhZXW"
+              className="sc-bGbJRg cAAciW"
               selected={false}
             >
               <span
@@ -781,7 +781,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hgHYgh fOhZXW"
+                className="sc-bGbJRg cAAciW"
                 selected={false}
               >
                 <span
@@ -817,7 +817,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hgHYgh fOhZXW"
+                className="sc-bGbJRg cAAciW"
                 selected={false}
               >
                 <span
@@ -853,7 +853,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hgHYgh fOhZXW"
+                className="sc-bGbJRg cAAciW"
                 selected={false}
               >
                 <span
@@ -928,7 +928,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hgHYgh fOhZXW"
+                className="sc-bGbJRg cAAciW"
                 selected={false}
               >
                 <span
@@ -964,7 +964,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hgHYgh fOhZXW"
+                className="sc-bGbJRg cAAciW"
                 selected={false}
               >
                 <span
@@ -1008,7 +1008,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-eInJlc ldXziN"
+                className="sc-bEjcJn jvemlY"
               >
                 <span
                   style={
@@ -1027,7 +1027,7 @@ exports[`Snapshots App should render application 1`] = `
           </div>
         </div>
         <div
-          className="sc-fOICqy docoLO"
+          className="sc-likbZx jykgBc"
         >
           <div
             className="sc-kgoBCf fymEWw"
@@ -1062,7 +1062,7 @@ exports[`Snapshots App should render application 1`] = `
                 }
               >
                 <div
-                  className="sc-jeCdPy lpqxjv"
+                  className="sc-drMfKT YUVsq"
                   id="headway"
                 >
                   What's New
@@ -1070,7 +1070,7 @@ exports[`Snapshots App should render application 1`] = `
               </span>
             </header>
             <div
-              className="sc-hzDEsm bfRAYm"
+              className="sc-eKZiaR hcQFj"
             >
               <span
                 style={
@@ -1222,7 +1222,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hgHYgh fOhZXW"
+          className="sc-bGbJRg cAAciW"
           selected={false}
         >
           <span
@@ -1296,7 +1296,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1332,7 +1332,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1368,7 +1368,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1443,7 +1443,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1479,7 +1479,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1523,7 +1523,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-eInJlc ldXziN"
+            className="sc-bEjcJn jvemlY"
           >
             <span
               style={
@@ -1633,7 +1633,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
 exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
 <span>
   <div
-    className="sc-gtfDJT eacHaQ"
+    className="sc-ePZHVD gzDHRN"
   >
     <div
       style={
@@ -1669,7 +1669,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hgHYgh gdYoEk"
+          className="sc-bGbJRg hKapjD"
           selected={true}
         >
           <span
@@ -1743,7 +1743,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1779,7 +1779,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1815,7 +1815,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1890,7 +1890,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1926,7 +1926,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -1970,7 +1970,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-eInJlc ldXziN"
+            className="sc-bEjcJn jvemlY"
           >
             <span
               style={
@@ -1989,7 +1989,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
       </div>
     </div>
     <div
-      className="sc-fOICqy docoLO"
+      className="sc-likbZx jykgBc"
     >
       <div
         className="sc-kgoBCf fymEWw"
@@ -2024,7 +2024,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
             }
           >
             <div
-              className="sc-jeCdPy lpqxjv"
+              className="sc-drMfKT YUVsq"
               id="headway"
             >
               What's New
@@ -2032,7 +2032,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           </span>
         </header>
         <div
-          className="sc-hzDEsm bfRAYm"
+          className="sc-eKZiaR hcQFj"
         >
           <span
             style={
@@ -2182,7 +2182,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hgHYgh fOhZXW"
+          className="sc-bGbJRg cAAciW"
           selected={false}
         >
           <span
@@ -2256,7 +2256,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2292,7 +2292,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2328,7 +2328,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2403,7 +2403,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2439,7 +2439,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2483,7 +2483,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-eInJlc ldXziN"
+            className="sc-bEjcJn jvemlY"
           >
             <span
               style={
@@ -2593,7 +2593,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-jtRlXQ ermWSK"
+    className="sc-fgfRvd bfrYws"
   >
     <div
       style={
@@ -2629,7 +2629,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hgHYgh fOhZXW"
+          className="sc-bGbJRg cAAciW"
           selected={false}
         >
           <span
@@ -2703,7 +2703,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2739,7 +2739,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2775,7 +2775,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2850,7 +2850,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2886,7 +2886,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hgHYgh fOhZXW"
+            className="sc-bGbJRg cAAciW"
             selected={false}
           >
             <span
@@ -2930,7 +2930,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-eInJlc ldXziN"
+            className="sc-bEjcJn jvemlY"
           >
             <span
               style={
@@ -2949,10 +2949,10 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
       </div>
     </div>
     <div
-      className="sc-bGbJRg hRLCtp"
+      className="sc-hIVACf boCjIw"
     >
       <header
-        className="sc-ePZHVD cjfONv"
+        className="sc-gVyKpa bMUUjT"
       >
         <button
           className="sc-chPdSV dWobCQ"
@@ -2972,7 +2972,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           </span>
         </button>
         <section
-          className="sc-eKZiaR jDEZxT"
+          className="sc-cpmKsF hsdPHk"
         >
           <div
             className="sc-gisBJw dbFHUv"
@@ -3312,7 +3312,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
             />
           </div>
           <span
-            className="sc-kasBVs eRpzUD"
+            className="sc-jtRlXQ fRhCze"
           >
             <button
               className="sc-chPdSV dWobCQ"
@@ -3335,13 +3335,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </section>
       </header>
       <div
-        className="sc-bEjcJn cyWKBF"
+        className="sc-gpHHfC fWzjuN"
       >
         <section
-          className="sc-likbZx jPAJeA"
+          className="sc-eXNvrr dCrkjC"
         >
           <div
-            className="sc-iGPElx hIwNUa"
+            className="sc-hzDEsm jelIet"
           >
             <div
               className="sc-bwzfXH eFBPoz"


### PR DESCRIPTION
### Purpose
This pull request is just for adding the cover page for reports when exporting. It doesn't have all the other report features (like consistent header and footer etc). I've tried quite a few different variations for the cover page and it seems the centralised title and date works best for reports with images. I'm sure there is more we can do but it could be good to get it out there and see what people say. Though I'm aware it's not the most exciting cover page right now! Maybe we can do things like colour tinting and such in the near future.

### Review
Be great to get your eyes on this @federicoweber 👍 As for the review, on speaking with Mike he mentioned that we shouldn't worry too much when the test coverage is failing on `story.jsx` files. Aside from this, the code should be pretty simple. The design is stripped back at the mo, we can just put it out there and see what customers say and build from there.

#### Staging Deployment
_This repo is CI/CD enabled and staging deployment should be available at:
https://task-cover-page-for-reports-analyze.dev.buffer.com/ :smile:_
