### PR TITLE
fix page break for posts table

### DIFF
--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -345,11 +345,11 @@ exports[`Snapshots PostItem should not render the top posts item when no metrics
       }
     }
   >
-    <tr
-      className="sc-hSdWYo kccNLr"
+    <li
+      className="sc-hSdWYo kVofMF"
     >
-      <td
-        className="sc-cvbbAY ePXgRF"
+      <div
+        className="sc-cvbbAY brUDDv"
       >
         <span
           style={
@@ -363,9 +363,9 @@ exports[`Snapshots PostItem should not render the top posts item when no metrics
         >
           123
         </span>
-      </td>
-      <td
-        className="sc-jWBwVP dITmiV"
+      </div>
+      <div
+        className="sc-jWBwVP huTTSr"
       >
         <div
           className="sc-gPEVay dafan"
@@ -445,8 +445,8 @@ exports[`Snapshots PostItem should not render the top posts item when no metrics
             src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
           />
         </div>
-      </td>
-    </tr>
+      </div>
+    </li>
   </div>
 </span>
 `;
@@ -460,11 +460,11 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
       }
     }
   >
-    <tr
-      className="sc-hSdWYo kccNLr"
+    <li
+      className="sc-hSdWYo kVofMF"
     >
-      <td
-        className="sc-cvbbAY ePXgRF"
+      <div
+        className="sc-cvbbAY brUDDv"
       >
         <span
           style={
@@ -478,9 +478,9 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
         >
           123
         </span>
-      </td>
-      <td
-        className="sc-jWBwVP dITmiV"
+      </div>
+      <div
+        className="sc-jWBwVP huTTSr"
       >
         <div
           className="sc-gPEVay dafan"
@@ -560,9 +560,9 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
             src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
           />
         </div>
-      </td>
-      <td
-        className="sc-eHgmQL IiGfj"
+      </div>
+      <div
+        className="sc-eHgmQL ifeYNG"
       >
         <div
           className="sc-kkGfuU bnbQcV"
@@ -870,8 +870,8 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
             </span>
           </span>
         </div>
-      </td>
-    </tr>
+      </div>
+    </li>
   </div>
 </span>
 `;
@@ -2722,1028 +2722,1026 @@ exports[`Snapshots PostsTable should hide posts link on export 1`] = `
           <div
             className="sc-bRBYWo jcNgcT"
           >
-            <table
-              className="sc-hzDkRC ezXTvV"
+            <ol
+              className="sc-hzDkRC dvTEeV"
             >
-              <tbody>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
+                  >
+                    <div
+                      className="sc-brqgnP lodcDk"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        5 September 04:01 am
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
+                  >
+                    <div
+                      className="sc-gipzik eHbwuA"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                            }
+                          }
+                        />
+                      </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
+                    </div>
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      1
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
-                  >
-                    <div
-                      className="sc-gPEVay dafan"
-                    >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          5 September 04:01 am
-                        </span>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#168eea",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
-                              }
-                            }
-                          />
-                        </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                      />
-                    </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
-                  >
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            35
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
-                >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      2
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          35
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
-                  >
-                    <div
-                      className="sc-gPEVay dafan"
-                    >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          6 September 06:01 am
-                        </span>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#168eea",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "📌 UPDATED for 2017:<br />
-                              The official guide to Facebook Video requirements 📹<br />
-                              <br />
-                              via Matt Navarra",
-                              }
-                            }
-                          />
-                        </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                      />
-                    </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
-                  >
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
-                >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      3
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          8 September 04:01 am
-                        </span>
-                      </div>
+                        }
+                      >
+                        6 September 06:01 am
+                      </span>
                     </div>
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
+                  >
                     <div
-                      className="sc-iRbamj dvLoaB"
+                      className="sc-gipzik eHbwuA"
                     >
-                      <div
-                        className="sc-gipzik eHbwuA"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#168eea",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
-                        >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                              <br />
-                              19 tools to help take your content to the next level in less time ⏰",
-                              }
-                            }
-                          />
-                        </span>
+                        }
+                      >
                         <div
-                          className="sc-jAaTju ezXXRW"
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "📌 UPDATED for 2017:<br />
+                            The official guide to Facebook Video requirements 📹<br />
+                            <br />
+                            via Matt Navarra",
+                            }
+                          }
                         />
-                      </div>
+                      </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          15
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    3
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-brqgnP lodcDk"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
+                        8 September 04:01 am
                       </span>
                     </div>
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
+                  >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                            <br />
+                            19 tools to help take your content to the next level in less time ⏰",
                             }
                           }
-                        >
-                          <span>
-                            6
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
+                        />
                       </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
+                        <span>
+                          6
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+            </ol>
           </div>
         </div>
       </div>
@@ -4944,1400 +4942,1398 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
           <div
             className="sc-bRBYWo jcNgcT"
           >
-            <table
-              className="sc-hzDkRC ezXTvV"
+            <ol
+              className="sc-hzDkRC dvTEeV"
             >
-              <tbody>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
                       }
-                    >
-                      1
-                    </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                    }
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          5 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678040122268428"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        5 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678040122268428"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
                             }
                           }
-                        >
-                          <span>
-                            3,067
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          post clicks
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            222
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reactions
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            35
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#D2C3AB",
-                            "borderColor": "#b4a58d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            233
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          shares
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            118.8k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15.9k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      2
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          3,067
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        post clicks
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          222
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reactions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          35
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#D2C3AB",
+                          "borderColor": "#b4a58d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          233
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        shares
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          118.8k
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          15.9k
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          6 September 06:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678667888872318"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        6 September 06:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678667888872318"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "📌 UPDATED for 2017:<br />
-                              The official guide to Facebook Video requirements 📹<br />
-                              <br />
-                              via Matt Navarra",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "📌 UPDATED for 2017:<br />
+                            The official guide to Facebook Video requirements 📹<br />
+                            <br />
+                            via Matt Navarra",
                             }
                           }
-                        >
-                          <span>
-                            1,666
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          post clicks
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            196
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reactions
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#D2C3AB",
-                            "borderColor": "#b4a58d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            54
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          shares
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            23.3k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            8,582
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      3
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          1,666
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        post clicks
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          196
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reactions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          15
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#D2C3AB",
+                          "borderColor": "#b4a58d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          54
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        shares
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          23.3k
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          8,582
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    3
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          8 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1681434551928985"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        8 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1681434551928985"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                              <br />
-                              19 tools to help take your content to the next level in less time ⏰",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                            <br />
+                            19 tools to help take your content to the next level in less time ⏰",
                             }
                           }
-                        >
-                          <span>
-                            534
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          post clicks
-                        </span>
+                        />
                       </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            107
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reactions
+                        <span>
+                          534
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        post clicks
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            6
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
+                        <span>
+                          107
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reactions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#D2C3AB",
-                            "borderColor": "#b4a58d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            30
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          shares
+                        <span>
+                          6
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#D2C3AB",
+                          "borderColor": "#b4a58d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15.0k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
+                        <span>
+                          30
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        shares
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            6,095
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
+                        <span>
+                          15.0k
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
+                        <span>
+                          6,095
                         </span>
                       </span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+            </ol>
           </div>
         </div>
       </div>
@@ -7139,1094 +7135,1092 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
           <div
             className="sc-bRBYWo jcNgcT"
           >
-            <table
-              className="sc-hzDkRC ezXTvV"
+            <ol
+              className="sc-hzDkRC dvTEeV"
             >
-              <tbody>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
                       }
-                    >
-                      1
-                    </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                    }
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          5 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678040122268428"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        5 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678040122268428"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
                             }
                           }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            35
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      2
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          35
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          6 September 06:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678667888872318"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        6 September 06:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678667888872318"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "📌 UPDATED for 2017:<br />
-                              The official guide to Facebook Video requirements 📹<br />
-                              <br />
-                              via Matt Navarra",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "📌 UPDATED for 2017:<br />
+                            The official guide to Facebook Video requirements 📹<br />
+                            <br />
+                            via Matt Navarra",
                             }
                           }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      3
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          15
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    3
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          8 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1681434551928985"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        8 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1681434551928985"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                              <br />
-                              19 tools to help take your content to the next level in less time ⏰",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                            <br />
+                            19 tools to help take your content to the next level in less time ⏰",
                             }
                           }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
+                        />
                       </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            6
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
+                        <span>
+                          6
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+            </ol>
           </div>
         </div>
       </div>
@@ -9028,1094 +9022,1092 @@ exports[`Snapshots PostsTable should render the posts table for twitter 1`] = `
           <div
             className="sc-bRBYWo jcNgcT"
           >
-            <table
-              className="sc-hzDkRC ezXTvV"
+            <ol
+              className="sc-hzDkRC dvTEeV"
             >
-              <tbody>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
                       }
-                    >
-                      1
-                    </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                    }
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          5 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678040122268428"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        5 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678040122268428"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
                             }
                           }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          clicks
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          retweets
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8FC6DB",
-                            "borderColor": "#71a8bd",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FEC78B",
-                            "borderColor": "#e0a96d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      2
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        clicks
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        retweets
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8FC6DB",
+                          "borderColor": "#71a8bd",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FEC78B",
+                          "borderColor": "#e0a96d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          6 September 06:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678667888872318"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        6 September 06:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678667888872318"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "📌 UPDATED for 2017:<br />
-                              The official guide to Facebook Video requirements 📹<br />
-                              <br />
-                              via Matt Navarra",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "📌 UPDATED for 2017:<br />
+                            The official guide to Facebook Video requirements 📹<br />
+                            <br />
+                            via Matt Navarra",
                             }
                           }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          clicks
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          retweets
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8FC6DB",
-                            "borderColor": "#71a8bd",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FEC78B",
-                            "borderColor": "#e0a96d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      3
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        clicks
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        retweets
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8FC6DB",
+                          "borderColor": "#71a8bd",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FEC78B",
+                          "borderColor": "#e0a96d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    3
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          8 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1681434551928985"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        8 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1681434551928985"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                              <br />
-                              19 tools to help take your content to the next level in less time ⏰",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                            <br />
+                            19 tools to help take your content to the next level in less time ⏰",
                             }
                           }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          clicks
-                        </span>
+                        />
                       </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          retweets
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        clicks
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#8FC6DB",
-                            "borderColor": "#71a8bd",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          likes
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        retweets
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8FC6DB",
+                          "borderColor": "#71a8bd",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FEC78B",
-                            "borderColor": "#e0a96d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        likes
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FEC78B",
+                          "borderColor": "#e0a96d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
+                        <span>
+                          0
                         </span>
                       </span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+            </ol>
           </div>
         </div>
       </div>
@@ -11117,1400 +11109,1398 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
           <div
             className="sc-bRBYWo jcNgcT"
           >
-            <table
-              className="sc-hzDkRC ezXTvV"
+            <ol
+              className="sc-hzDkRC dvTEeV"
             >
-              <tbody>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
-                        }
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
                       }
-                    >
-                      1
-                    </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                    }
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          5 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678040122268428"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        5 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678040122268428"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
                             }
                           }
-                        >
-                          <span>
-                            3,067
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          post clicks
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            222
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reactions
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            35
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#D2C3AB",
-                            "borderColor": "#b4a58d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            233
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          shares
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            118.8k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15.9k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      2
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          3,067
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        post clicks
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          222
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reactions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          35
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#D2C3AB",
+                          "borderColor": "#b4a58d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          233
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        shares
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          118.8k
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          15.9k
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          6 September 06:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1678667888872318"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        6 September 06:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1678667888872318"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "📌 UPDATED for 2017:<br />
-                              The official guide to Facebook Video requirements 📹<br />
-                              <br />
-                              via Matt Navarra",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
-                      <img
-                        alt=""
-                        className="sc-jDwBTQ khWqDr"
-                        crossOrigin="Anonymous"
-                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                      />
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "📌 UPDATED for 2017:<br />
+                            The official guide to Facebook Video requirements 📹<br />
+                            <br />
+                            via Matt Navarra",
                             }
                           }
-                        >
-                          <span>
-                            1,666
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          post clicks
-                        </span>
+                        />
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
+                      <div
+                        className="sc-jAaTju ezXXRW"
                       />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            196
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reactions
-                        </span>
-                      </span>
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#D2C3AB",
-                            "borderColor": "#b4a58d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            54
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          shares
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            23.3k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            8,582
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
-                          }
-                        }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="sc-hSdWYo kccNLr"
+                    <img
+                      alt=""
+                      className="sc-jDwBTQ khWqDr"
+                      crossOrigin="Anonymous"
+                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
+                    />
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
                 >
-                  <td
-                    className="sc-cvbbAY ePXgRF"
+                  <div
+                    className="sc-kkGfuU bnbQcV"
                   >
                     <span
                       style={
                         Object {
-                          "color": "#323b43",
-                          "fontFamily": "\\"Roboto\\", sans-serif",
-                          "fontSize": "1.5rem",
-                          "fontWeight": 700,
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
                         }
                       }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
-                      3
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          1,666
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        post clicks
+                      </span>
                     </span>
-                  </td>
-                  <td
-                    className="sc-jWBwVP dITmiV"
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          196
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reactions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          15
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#D2C3AB",
+                          "borderColor": "#b4a58d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          54
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        shares
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          23.3k
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          8,582
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="sc-hSdWYo kVofMF"
+              >
+                <div
+                  className="sc-cvbbAY brUDDv"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#323b43",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "1.5rem",
+                        "fontWeight": 700,
+                      }
+                    }
+                  >
+                    3
+                  </span>
+                </div>
+                <div
+                  className="sc-jWBwVP huTTSr"
+                >
+                  <div
+                    className="sc-gPEVay dafan"
                   >
                     <div
-                      className="sc-gPEVay dafan"
+                      className="sc-brqgnP lodcDk"
                     >
-                      <div
-                        className="sc-brqgnP lodcDk"
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
-                        >
-                          8 September 04:01 am
-                        </span>
-                        <a
-                          className="sc-jlyJG cOfBFf"
-                          href="https://facebook.com/108311429241313/posts/1681434551928985"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          <span
-                            style={
-                              Object {
-                                "color": "#168eea",
-                                "fontFamily": "\\"Roboto\\", sans-serif",
-                                "fontSize": "0.75rem",
-                                "fontWeight": 400,
-                              }
-                            }
-                          >
-                            <i
-                              className="bi-click"
-                            />
-                            View Post
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      className="sc-iRbamj dvLoaB"
-                    >
-                      <div
-                        className="sc-gipzik eHbwuA"
+                        }
+                      >
+                        8 September 04:01 am
+                      </span>
+                      <a
+                        className="sc-jlyJG cOfBFf"
+                        href="https://facebook.com/108311429241313/posts/1681434551928985"
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
+                              "fontSize": "0.75rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <div
-                            className="sc-cMljjf qzBKB"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                              <br />
-                              19 tools to help take your content to the next level in less time ⏰",
-                              }
-                            }
+                          <i
+                            className="bi-click"
                           />
+                          View Post
                         </span>
-                        <div
-                          className="sc-jAaTju ezXXRW"
-                        />
-                      </div>
+                      </a>
                     </div>
-                  </td>
-                  <td
-                    className="sc-eHgmQL IiGfj"
+                  </div>
+                  <div
+                    className="sc-iRbamj dvLoaB"
                   >
                     <div
-                      className="sc-kkGfuU bnbQcV"
+                      className="sc-gipzik eHbwuA"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#168eea",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
+                        <div
+                          className="sc-cMljjf qzBKB"
+                          dangerouslySetInnerHTML={
                             Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
+                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                            <br />
+                            19 tools to help take your content to the next level in less time ⏰",
                             }
                           }
-                        >
-                          <span>
-                            534
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          post clicks
-                        </span>
+                        />
                       </span>
+                      <div
+                        className="sc-jAaTju ezXXRW"
+                      />
                     </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                  </div>
+                </div>
+                <div
+                  className="sc-eHgmQL ifeYNG"
+                >
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FD8F90",
-                            "borderColor": "#df7172",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            107
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reactions
+                        <span>
+                          534
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        post clicks
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FD8F90",
+                          "borderColor": "#df7172",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#EFDF00",
-                            "borderColor": "#d1c100",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            6
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          comments
+                        <span>
+                          107
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reactions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#EFDF00",
+                          "borderColor": "#d1c100",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#D2C3AB",
-                            "borderColor": "#b4a58d",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            30
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          shares
+                        <span>
+                          6
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        comments
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#D2C3AB",
+                          "borderColor": "#b4a58d",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#8AC6DE",
-                            "borderColor": "#6ca8c0",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            15.0k
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          impressions
+                        <span>
+                          30
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        shares
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#8AC6DE",
+                          "borderColor": "#6ca8c0",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#FFC880",
-                            "borderColor": "#e1aa62",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            6,095
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          reach
+                        <span>
+                          15.0k
                         </span>
                       </span>
-                    </div>
-                    <div
-                      className="sc-kkGfuU bnbQcV"
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        impressions
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#FFC880",
+                          "borderColor": "#e1aa62",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
                     >
                       <span
                         style={
                           Object {
-                            "background": "#98E8B2",
-                            "borderColor": "#7aca94",
-                            "borderRadius": "10px",
-                            "borderStyle": "solid",
-                            "borderWidth": "1px",
-                            "display": "inline-block",
-                            "height": "7px",
-                            "marginRight": "5px",
-                            "verticalAlign": "baseline",
-                            "width": "7px",
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
                           }
                         }
-                      />
-                      <span
-                        className="sc-iAyFgw kitefG"
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#323b43",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 700,
-                            }
-                          }
-                        >
-                          <span>
-                            0
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#59626a",
-                              "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.875rem",
-                              "fontWeight": 400,
-                            }
-                          }
-                        >
-                           
-                          engagement rate
+                        <span>
+                          6,095
                         </span>
                       </span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        reach
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    className="sc-kkGfuU bnbQcV"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "background": "#98E8B2",
+                          "borderColor": "#7aca94",
+                          "borderRadius": "10px",
+                          "borderStyle": "solid",
+                          "borderWidth": "1px",
+                          "display": "inline-block",
+                          "height": "7px",
+                          "marginRight": "5px",
+                          "verticalAlign": "baseline",
+                          "width": "7px",
+                        }
+                      }
+                    />
+                    <span
+                      className="sc-iAyFgw kitefG"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#323b43",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 700,
+                          }
+                        }
+                      >
+                        <span>
+                          0
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#59626a",
+                            "fontFamily": "\\"Roboto\\", sans-serif",
+                            "fontSize": "0.875rem",
+                            "fontWeight": 400,
+                          }
+                        }
+                      >
+                         
+                        engagement rate
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </li>
+            </ol>
           </div>
         </div>
       </div>

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -2725,1022 +2725,1024 @@ exports[`Snapshots PostsTable should hide posts link on export 1`] = `
             <table
               className="sc-hzDkRC ezXTvV"
             >
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
+              <tbody>
+                <tr
+                  className="sc-hSdWYo kccNLr"
                 >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
                       }
-                    }
-                  >
-                    1
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                    >
+                      1
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-gPEVay dafan"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                      <div
+                        className="sc-brqgnP lodcDk"
                       >
-                        5 September 04:01 am
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
                             }
                           }
-                        />
-                      </span>
+                        >
+                          5 September 04:01 am
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
                       <div
-                        className="sc-jAaTju ezXXRW"
-                      />
-                    </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                        className="sc-gipzik eHbwuA"
                       >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          35
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
-                  >
-                    <div
-                      className="sc-brqgnP lodcDk"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        6 September 06:01 am
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "📌 UPDATED for 2017:<br />
-                            The official guide to Facebook Video requirements 📹<br />
-                            <br />
-                            via Matt Navarra",
+                              "color": "#168eea",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
                             }
                           }
+                        >
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                              }
+                            }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          15
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
-                      >
-                        8 September 04:01 am
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
+                      />
                       <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
+                        className="sc-iAyFgw kitefG"
                       >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                            <br />
-                            19 tools to help take your content to the next level in less time ⏰",
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
                             }
                           }
-                        />
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
                       </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            35
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      2
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
                       <div
-                        className="sc-jAaTju ezXXRW"
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          6 September 06:01 am
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#168eea",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "📌 UPDATED for 2017:<br />
+                              The official guide to Facebook Video requirements 📹<br />
+                              <br />
+                              via Matt Navarra",
+                              }
+                            }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
+                        />
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
                       />
                     </div>
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
+                  >
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
                 >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
+                  <td
+                    className="sc-cvbbAY ePXgRF"
                   >
                     <span
                       style={
                         Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
                         }
                       }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
+                      3
                     </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
                   >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    <div
+                      className="sc-gPEVay dafan"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                      <div
+                        className="sc-brqgnP lodcDk"
                       >
-                        <span>
-                          6
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          8 September 04:01 am
                         </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
+                        <span
+                          style={
+                            Object {
+                              "color": "#168eea",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                              <br />
+                              19 tools to help take your content to the next level in less time ⏰",
+                              }
+                            }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
+                        />
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            6
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
                         </span>
                       </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
                       <span
                         style={
                           Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                         
-                        engagement rate
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
                       </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </div>
         </div>
@@ -4945,1394 +4947,1396 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
             <table
               className="sc-hzDkRC ezXTvV"
             >
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
+              <tbody>
+                <tr
+                  className="sc-hSdWYo kccNLr"
                 >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
+                  <td
+                    className="sc-cvbbAY ePXgRF"
                   >
-                    1
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      1
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-gPEVay dafan"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                      <div
+                        className="sc-brqgnP lodcDk"
                       >
-                        5 September 04:01 am
-                      </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678040122268428"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          5 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678040122268428"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          3,067
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        post clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          222
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reactions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          35
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#D2C3AB",
-                          "borderColor": "#b4a58d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          233
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        shares
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          118.8k
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          15.9k
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        6 September 06:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            3,067
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          post clicks
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678667888872318"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            222
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reactions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            35
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#D2C3AB",
+                            "borderColor": "#b4a58d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            233
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          shares
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            118.8k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15.9k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      2
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          6 September 06:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678667888872318"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "📌 UPDATED for 2017:<br />
-                            The official guide to Facebook Video requirements 📹<br />
-                            <br />
-                            via Matt Navarra",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "📌 UPDATED for 2017:<br />
+                              The official guide to Facebook Video requirements 📹<br />
+                              <br />
+                              via Matt Navarra",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          1,666
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        post clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          196
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reactions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          15
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#D2C3AB",
-                          "borderColor": "#b4a58d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          54
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        shares
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          23.3k
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          8,582
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        8 September 04:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            1,666
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          post clicks
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1681434551928985"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            196
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reactions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#D2C3AB",
+                            "borderColor": "#b4a58d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            54
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          shares
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            23.3k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            8,582
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      3
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          8 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1681434551928985"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                              <br />
+                              19 tools to help take your content to the next level in less time ⏰",
+                              }
+                            }
                           />
-                          View Post
                         </span>
-                      </a>
+                        <div
+                          className="sc-jAaTju ezXXRW"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-gipzik eHbwuA"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                            <br />
-                            19 tools to help take your content to the next level in less time ⏰",
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
                             }
                           }
-                        />
+                        >
+                          <span>
+                            534
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          post clicks
+                        </span>
                       </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
-                      />
                     </div>
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          534
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            107
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reactions
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        post clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          107
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            6
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reactions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#D2C3AB",
+                            "borderColor": "#b4a58d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          6
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            30
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          shares
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#D2C3AB",
-                          "borderColor": "#b4a58d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          30
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15.0k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        shares
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          15.0k
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            6,095
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          6,095
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </div>
         </div>
@@ -7138,1088 +7142,1090 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
             <table
               className="sc-hzDkRC ezXTvV"
             >
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
+              <tbody>
+                <tr
+                  className="sc-hSdWYo kccNLr"
                 >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
+                  <td
+                    className="sc-cvbbAY ePXgRF"
                   >
-                    1
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      1
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-gPEVay dafan"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                      <div
+                        className="sc-brqgnP lodcDk"
                       >
-                        5 September 04:01 am
-                      </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678040122268428"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          5 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678040122268428"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          35
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        6 September 06:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678667888872318"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            35
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      2
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          6 September 06:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678667888872318"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "📌 UPDATED for 2017:<br />
-                            The official guide to Facebook Video requirements 📹<br />
-                            <br />
-                            via Matt Navarra",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "📌 UPDATED for 2017:<br />
+                              The official guide to Facebook Video requirements 📹<br />
+                              <br />
+                              via Matt Navarra",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          15
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        8 September 04:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1681434551928985"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      3
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          8 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1681434551928985"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                              <br />
+                              19 tools to help take your content to the next level in less time ⏰",
+                              }
+                            }
                           />
-                          View Post
                         </span>
-                      </a>
+                        <div
+                          className="sc-jAaTju ezXXRW"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-gipzik eHbwuA"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                            <br />
-                            19 tools to help take your content to the next level in less time ⏰",
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
                             }
                           }
-                        />
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
                       </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
-                      />
                     </div>
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            6
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          6
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </div>
         </div>
@@ -9025,1088 +9031,1090 @@ exports[`Snapshots PostsTable should render the posts table for twitter 1`] = `
             <table
               className="sc-hzDkRC ezXTvV"
             >
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
+              <tbody>
+                <tr
+                  className="sc-hSdWYo kccNLr"
                 >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
+                  <td
+                    className="sc-cvbbAY ePXgRF"
                   >
-                    1
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      1
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-gPEVay dafan"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                      <div
+                        className="sc-brqgnP lodcDk"
                       >
-                        5 September 04:01 am
-                      </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678040122268428"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          5 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678040122268428"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        retweets
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8FC6DB",
-                          "borderColor": "#71a8bd",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FEC78B",
-                          "borderColor": "#e0a96d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        6 September 06:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          clicks
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678667888872318"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          retweets
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8FC6DB",
+                            "borderColor": "#71a8bd",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FEC78B",
+                            "borderColor": "#e0a96d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      2
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          6 September 06:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678667888872318"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "📌 UPDATED for 2017:<br />
-                            The official guide to Facebook Video requirements 📹<br />
-                            <br />
-                            via Matt Navarra",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "📌 UPDATED for 2017:<br />
+                              The official guide to Facebook Video requirements 📹<br />
+                              <br />
+                              via Matt Navarra",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        retweets
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8FC6DB",
-                          "borderColor": "#71a8bd",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FEC78B",
-                          "borderColor": "#e0a96d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        8 September 04:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          clicks
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1681434551928985"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          retweets
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8FC6DB",
+                            "borderColor": "#71a8bd",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FEC78B",
+                            "borderColor": "#e0a96d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      3
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          8 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1681434551928985"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                              <br />
+                              19 tools to help take your content to the next level in less time ⏰",
+                              }
+                            }
                           />
-                          View Post
                         </span>
-                      </a>
+                        <div
+                          className="sc-jAaTju ezXXRW"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-gipzik eHbwuA"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                            <br />
-                            19 tools to help take your content to the next level in less time ⏰",
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
                             }
                           }
-                        />
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          clicks
+                        </span>
                       </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
-                      />
                     </div>
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          retweets
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#8FC6DB",
+                            "borderColor": "#71a8bd",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          likes
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        retweets
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8FC6DB",
-                          "borderColor": "#71a8bd",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FEC78B",
+                            "borderColor": "#e0a96d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        likes
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FEC78B",
-                          "borderColor": "#e0a96d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          0
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </div>
         </div>
@@ -11112,1394 +11120,1396 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
             <table
               className="sc-hzDkRC ezXTvV"
             >
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
+              <tbody>
+                <tr
+                  className="sc-hSdWYo kccNLr"
                 >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
+                  <td
+                    className="sc-cvbbAY ePXgRF"
                   >
-                    1
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      1
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-gPEVay dafan"
                     >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
+                      <div
+                        className="sc-brqgnP lodcDk"
                       >
-                        5 September 04:01 am
-                      </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678040122268428"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          5 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678040122268428"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Procaffeinating (n): the tendency to not start anything until you've had a coffee",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://buffer-media-uploads.s3.amazonaws.com/59a4711d7cbc83d309960116/5ed19955e0c4785b990ec752ff6df55c367f9808_dc779030b683e4f41ffa863f5c88795128de1d58_thumbnail"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          3,067
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        post clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          222
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reactions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          35
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#D2C3AB",
-                          "borderColor": "#b4a58d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          233
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        shares
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          118.8k
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          15.9k
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        6 September 06:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            3,067
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          post clicks
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1678667888872318"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            222
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reactions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            35
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#D2C3AB",
+                            "borderColor": "#b4a58d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            233
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          shares
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            118.8k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15.9k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      2
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          6 September 06:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1678667888872318"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
-                          />
-                          View Post
-                        </span>
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
-                  >
-                    <div
-                      className="sc-gipzik eHbwuA"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "📌 UPDATED for 2017:<br />
-                            The official guide to Facebook Video requirements 📹<br />
-                            <br />
-                            via Matt Navarra",
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "📌 UPDATED for 2017:<br />
+                              The official guide to Facebook Video requirements 📹<br />
+                              <br />
+                              via Matt Navarra",
+                              }
                             }
-                          }
+                          />
+                        </span>
+                        <div
+                          className="sc-jAaTju ezXXRW"
                         />
-                      </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
+                      </div>
+                      <img
+                        alt=""
+                        className="sc-jDwBTQ khWqDr"
+                        crossOrigin="Anonymous"
+                        src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
                       />
                     </div>
-                    <img
-                      alt=""
-                      className="sc-jDwBTQ khWqDr"
-                      crossOrigin="Anonymous"
-                      src="https://safeimage.buffer.com/https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/21314332_1678667648872342_5837561331042406631_n.jpg?oh=739aa8ab3fb7ca5dd00d11c369bde453&oe=5A153FC6"
-                    />
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          1,666
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        post clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          196
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reactions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          15
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#D2C3AB",
-                          "borderColor": "#b4a58d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          54
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        shares
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          23.3k
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          8,582
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                className="sc-hSdWYo kccNLr"
-              >
-                <td
-                  className="sc-cvbbAY ePXgRF"
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#323b43",
-                        "fontFamily": "\\"Roboto\\", sans-serif",
-                        "fontSize": "1.5rem",
-                        "fontWeight": 700,
-                      }
-                    }
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  className="sc-jWBwVP dITmiV"
-                >
-                  <div
-                    className="sc-gPEVay dafan"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-brqgnP lodcDk"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        8 September 04:01 am
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            1,666
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          post clicks
+                        </span>
                       </span>
-                      <a
-                        className="sc-jlyJG cOfBFf"
-                        href="https://facebook.com/108311429241313/posts/1681434551928985"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            196
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reactions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#D2C3AB",
+                            "borderColor": "#b4a58d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            54
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          shares
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            23.3k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            8,582
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
+                          }
+                        }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="sc-hSdWYo kccNLr"
+                >
+                  <td
+                    className="sc-cvbbAY ePXgRF"
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#323b43",
+                          "fontFamily": "\\"Roboto\\", sans-serif",
+                          "fontSize": "1.5rem",
+                          "fontWeight": 700,
+                        }
+                      }
+                    >
+                      3
+                    </span>
+                  </td>
+                  <td
+                    className="sc-jWBwVP dITmiV"
+                  >
+                    <div
+                      className="sc-gPEVay dafan"
+                    >
+                      <div
+                        className="sc-brqgnP lodcDk"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          8 September 04:01 am
+                        </span>
+                        <a
+                          className="sc-jlyJG cOfBFf"
+                          href="https://facebook.com/108311429241313/posts/1681434551928985"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#168eea",
+                                "fontFamily": "\\"Roboto\\", sans-serif",
+                                "fontSize": "0.75rem",
+                                "fontWeight": 400,
+                              }
+                            }
+                          >
+                            <i
+                              className="bi-click"
+                            />
+                            View Post
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="sc-iRbamj dvLoaB"
+                    >
+                      <div
+                        className="sc-gipzik eHbwuA"
                       >
                         <span
                           style={
                             Object {
                               "color": "#168eea",
                               "fontFamily": "\\"Roboto\\", sans-serif",
-                              "fontSize": "0.75rem",
+                              "fontSize": "0.875rem",
                               "fontWeight": 400,
                             }
                           }
                         >
-                          <i
-                            className="bi-click"
+                          <div
+                            className="sc-cMljjf qzBKB"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
+                              <br />
+                              19 tools to help take your content to the next level in less time ⏰",
+                              }
+                            }
                           />
-                          View Post
                         </span>
-                      </a>
+                        <div
+                          className="sc-jAaTju ezXXRW"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="sc-iRbamj dvLoaB"
+                  </td>
+                  <td
+                    className="sc-eHgmQL IiGfj"
                   >
                     <div
-                      className="sc-gipzik eHbwuA"
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#168eea",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <div
-                          className="sc-cMljjf qzBKB"
-                          dangerouslySetInnerHTML={
+                        <span
+                          style={
                             Object {
-                              "__html": "Creating social media content takes time... And creating great social media content takes even longer!<br />
-                            <br />
-                            19 tools to help take your content to the next level in less time ⏰",
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
                             }
                           }
-                        />
+                        >
+                          <span>
+                            534
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          post clicks
+                        </span>
                       </span>
-                      <div
-                        className="sc-jAaTju ezXXRW"
-                      />
                     </div>
-                  </div>
-                </td>
-                <td
-                  className="sc-eHgmQL IiGfj"
-                >
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FD8F90",
+                            "borderColor": "#df7172",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          534
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            107
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reactions
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        post clicks
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FD8F90",
-                          "borderColor": "#df7172",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#EFDF00",
+                            "borderColor": "#d1c100",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          107
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            6
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          comments
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reactions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#EFDF00",
-                          "borderColor": "#d1c100",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#D2C3AB",
+                            "borderColor": "#b4a58d",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          6
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            30
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          shares
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        comments
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#D2C3AB",
-                          "borderColor": "#b4a58d",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#8AC6DE",
+                            "borderColor": "#6ca8c0",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          30
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            15.0k
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          impressions
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        shares
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#8AC6DE",
-                          "borderColor": "#6ca8c0",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#FFC880",
+                            "borderColor": "#e1aa62",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          15.0k
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            6,095
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          reach
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        impressions
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#FFC880",
-                          "borderColor": "#e1aa62",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
+                    </div>
+                    <div
+                      className="sc-kkGfuU bnbQcV"
                     >
                       <span
                         style={
                           Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
+                            "background": "#98E8B2",
+                            "borderColor": "#7aca94",
+                            "borderRadius": "10px",
+                            "borderStyle": "solid",
+                            "borderWidth": "1px",
+                            "display": "inline-block",
+                            "height": "7px",
+                            "marginRight": "5px",
+                            "verticalAlign": "baseline",
+                            "width": "7px",
                           }
                         }
+                      />
+                      <span
+                        className="sc-iAyFgw kitefG"
                       >
-                        <span>
-                          6,095
+                        <span
+                          style={
+                            Object {
+                              "color": "#323b43",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 700,
+                            }
+                          }
+                        >
+                          <span>
+                            0
+                          </span>
+                        </span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#59626a",
+                              "fontFamily": "\\"Roboto\\", sans-serif",
+                              "fontSize": "0.875rem",
+                              "fontWeight": 400,
+                            }
+                          }
+                        >
+                           
+                          engagement rate
                         </span>
                       </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        reach
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    className="sc-kkGfuU bnbQcV"
-                  >
-                    <span
-                      style={
-                        Object {
-                          "background": "#98E8B2",
-                          "borderColor": "#7aca94",
-                          "borderRadius": "10px",
-                          "borderStyle": "solid",
-                          "borderWidth": "1px",
-                          "display": "inline-block",
-                          "height": "7px",
-                          "marginRight": "5px",
-                          "verticalAlign": "baseline",
-                          "width": "7px",
-                        }
-                      }
-                    />
-                    <span
-                      className="sc-iAyFgw kitefG"
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#323b43",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 700,
-                          }
-                        }
-                      >
-                        <span>
-                          0
-                        </span>
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#59626a",
-                            "fontFamily": "\\"Roboto\\", sans-serif",
-                            "fontSize": "0.875rem",
-                            "fontWeight": 400,
-                          }
-                        }
-                      >
-                         
-                        engagement rate
-                      </span>
-                    </span>
-                  </div>
-                </td>
-              </tr>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </div>
         </div>

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -346,7 +346,7 @@ exports[`Snapshots PostItem should not render the top posts item when no metrics
     }
   >
     <li
-      className="sc-hSdWYo kVofMF"
+      className="sc-hSdWYo hxLMxr"
     >
       <div
         className="sc-cvbbAY brUDDv"
@@ -461,7 +461,7 @@ exports[`Snapshots PostItem should render the top posts item 1`] = `
     }
   >
     <li
-      className="sc-hSdWYo kVofMF"
+      className="sc-hSdWYo hxLMxr"
     >
       <div
         className="sc-cvbbAY brUDDv"
@@ -2726,7 +2726,7 @@ exports[`Snapshots PostsTable should hide posts link on export 1`] = `
               className="sc-hzDkRC dvTEeV"
             >
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -3065,7 +3065,7 @@ exports[`Snapshots PostsTable should hide posts link on export 1`] = `
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -3407,7 +3407,7 @@ exports[`Snapshots PostsTable should hide posts link on export 1`] = `
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -4946,7 +4946,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
               className="sc-hzDkRC dvTEeV"
             >
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -5409,7 +5409,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -5875,7 +5875,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -7139,7 +7139,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
               className="sc-hzDkRC dvTEeV"
             >
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -7500,7 +7500,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -7864,7 +7864,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -9026,7 +9026,7 @@ exports[`Snapshots PostsTable should render the posts table for twitter 1`] = `
               className="sc-hzDkRC dvTEeV"
             >
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -9387,7 +9387,7 @@ exports[`Snapshots PostsTable should render the posts table for twitter 1`] = `
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -9751,7 +9751,7 @@ exports[`Snapshots PostsTable should render the posts table for twitter 1`] = `
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -11113,7 +11113,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
               className="sc-hzDkRC dvTEeV"
             >
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -11576,7 +11576,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"
@@ -12042,7 +12042,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                 </div>
               </li>
               <li
-                className="sc-hSdWYo kVofMF"
+                className="sc-hSdWYo hxLMxr"
               >
                 <div
                   className="sc-cvbbAY brUDDv"

--- a/packages/posts-table/components/PostsTable/components/PostItem/index.jsx
+++ b/packages/posts-table/components/PostsTable/components/PostItem/index.jsx
@@ -19,6 +19,7 @@ const PostRow = styled.li`
   align-content: stretch;
   margin: 0;
   padding: 0;
+  border-color: ${geyser};
 
   &:first-child > div {
     border-top: 1px dotted ${geyser};

--- a/packages/posts-table/components/PostsTable/components/PostItem/index.jsx
+++ b/packages/posts-table/components/PostsTable/components/PostItem/index.jsx
@@ -14,32 +14,34 @@ import {
 
 import MetricGraph from '../MetricGraph';
 
-const PostRow = styled.tr`
+const PostRow = styled.li`
+  display: flex;
+  align-content: stretch;
   margin: 0;
   padding: 0;
 
-  &:first-child td {
+  &:first-child > div {
     border-top: 1px dotted ${geyser};
   }
 
-  &:last-child td {
+  &:last-child > div {
     border-bottom: none;
   }
 `;
 
-const MetricCellInner = styled.td`
-  text-decoration: none;
+const MetricCellInner = styled.div`
   color: ${outerSpace};
   padding: 1rem 0;
-  width: 25%;
+  width: 220px;
   padding-left: 1rem;
   vertical-align: top;
   border-left: 1px dotted ${geyser};
   border-bottom: 1px dotted ${geyser};
   `;
 
-const NumberCell = styled.td`
+const NumberCell = styled.div`
   position: relative;
+  width: 46px;
   color: ${outerSpace};
   padding: 0.9rem 1rem 1.25rem 0;
   text-align: right;
@@ -48,11 +50,11 @@ const NumberCell = styled.td`
   border-bottom: 1px dotted ${geyser};
 `;
 
-const ContentCell = styled.td`
-  text-decoration: none;
+const ContentCell = styled.div`
   color: ${outerSpace};
   padding: 1rem 1rem 1.25rem;
   padding-right: 1rem;
+  width: 620px;
   vertical-align: top;
   border-bottom: 1px dotted ${geyser};
 `;

--- a/packages/posts-table/components/PostsTable/index.jsx
+++ b/packages/posts-table/components/PostsTable/index.jsx
@@ -70,19 +70,21 @@ export const Table = ({ metrics, timezone, service, exporting }) => {
   return (
     <ChartContainer>
       <PostsTableWrapper>
-        {topPosts.map((post, index) =>
-          <PostItem
-            key={post.id}
-            index={index}
-            timezone={timezone}
-            post={post}
-            maxEngagementValue={maxEngagementValue}
-            maxAudienceValue={maxAudienceValue}
-            engagementMetrics={engagementMetrics}
-            audienceMetrics={audienceMetrics}
-            exporting={exporting}
-          />,
-        )}
+        <tbody>
+          {topPosts.map((post, index) =>
+            <PostItem
+              key={post.id}
+              index={index}
+              timezone={timezone}
+              post={post}
+              maxEngagementValue={maxEngagementValue}
+              maxAudienceValue={maxAudienceValue}
+              engagementMetrics={engagementMetrics}
+              audienceMetrics={audienceMetrics}
+              exporting={exporting}
+            />,
+          )}
+        </tbody>
       </PostsTableWrapper>
     </ChartContainer>
   );

--- a/packages/posts-table/components/PostsTable/index.jsx
+++ b/packages/posts-table/components/PostsTable/index.jsx
@@ -21,9 +21,10 @@ const ChartContainer = styled.div`
   min-height: 177px;
 `;
 
-const PostsTableWrapper = styled.table`
+const PostsTableWrapper = styled.ol`
   padding: 0;
   margin: 0;
+  list-style: none;
 `;
 
 const GridContainer = styled.div`
@@ -70,7 +71,6 @@ export const Table = ({ metrics, timezone, service, exporting }) => {
   return (
     <ChartContainer>
       <PostsTableWrapper>
-        <tbody>
           {topPosts.map((post, index) =>
             <PostItem
               key={post.id}
@@ -84,7 +84,6 @@ export const Table = ({ metrics, timezone, service, exporting }) => {
               exporting={exporting}
             />,
           )}
-        </tbody>
       </PostsTableWrapper>
     </ChartContainer>
   );

--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -38,7 +38,7 @@ class PDFFormatter {
   }
 
   static canBeBrokenDownIntoMultiplePages (element) {
-    return element.getElementsByTagName('aside').length > 0 || element.getElementsByTagName('table').length > 0;
+    return element.getElementsByTagName('aside').length > 0 || element.getElementsByTagName('ol').length > 0;
   }
 
   addPageBreak(element) {
@@ -55,7 +55,7 @@ class PDFFormatter {
         this.breakIntoPages(listItems);
       } else {
         const [list] = content.children;
-        const listItems = list.getElementsByTagName('tr');
+        const listItems = list.getElementsByTagName('li');
         this.breakIntoPages(listItems);
       }
     } else {

--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -38,18 +38,26 @@ class PDFFormatter {
   }
 
   static canBeBrokenDownIntoMultiplePages (element) {
-    return element.getElementsByTagName('aside').length > 0;
+    return element.getElementsByTagName('aside').length > 0 || element.getElementsByTagName('table').length > 0;
   }
 
   addPageBreak(element) {
     if (PDFFormatter.canBeBrokenDownIntoMultiplePages(element)) {
-      const [title, aside] = element.children;
-      const [header, list] = aside.children;
       this.removeFromCurrentPage(element);
+
+      const [title, content] = element.children;
       this.addToCurrentPage(title);
-      this.addToCurrentPage(header);
-      const listItems = list.children;
-      this.breakIntoPages(listItems);
+
+      if (content.children.length > 1) {
+        const [header, list] = content.children;
+        this.addToCurrentPage(header);
+        const listItems = list.children;
+        this.breakIntoPages(listItems);
+      } else {
+        const [list] = content.children;
+        const listItems = list.getElementsByTagName('tr');
+        this.breakIntoPages(listItems);
+      }
     } else {
       this.addNewPage(element);
     }

--- a/packages/report/PDFFormatter.js
+++ b/packages/report/PDFFormatter.js
@@ -82,7 +82,7 @@ class PDFFormatter {
     const color = getComputedStyle(element).getPropertyValue('border-bottom-color');
     element.style.setProperty('border-top-color', color);
     element.style.setProperty('border-top-width', '1px');
-    element.style.setProperty('border-top-style', 'solid');
+    element.style.setProperty('border-top-style', 'dotted');
     element.style.setProperty('margin-top', '2.8rem');
   }
 }

--- a/packages/report/PDFFormatter.test.js
+++ b/packages/report/PDFFormatter.test.js
@@ -5,10 +5,14 @@ global.getComputedStyle = jest.fn(() => ({
   marginTop: 0,
 }));
 
+const elementHasPageBreak = element => (
+  false || element.style._values['page-break-before'] === 'always'
+);
+
 const hasPageBreak = (elements) => {
   let hasBreak = false;
   Array.prototype.forEach.call(elements, (element) => {
-    hasBreak = hasBreak || element.style._values['page-break-before'] === 'always';
+    hasBreak = elementHasPageBreak(element);
   });
   return hasBreak;
 };
@@ -40,6 +44,15 @@ describe('PDF formatter', () => {
       const formatter = new PDFFormatter(reportWithPageBreak);
       formatter.formatPage();
       expect(hasPageBreak(reportWithPageBreak.children)).toBeTruthy();
+    });
+
+    it('should add a page break on a table row', () => {
+      const reportWithPageBreak = require('./mocks/reportWithTable').default; // eslint-disable-line global-require
+      const formatter = new PDFFormatter(reportWithPageBreak);
+      formatter.formatPage();
+      const elementsWithPageBreak = reportWithPageBreak
+        .children[1].children[1].children[0].children[0];
+      expect(elementHasPageBreak(elementsWithPageBreak)).toBeTruthy();
     });
   });
 });

--- a/packages/report/PDFFormatter.test.js
+++ b/packages/report/PDFFormatter.test.js
@@ -49,6 +49,7 @@ describe('PDF formatter', () => {
     it('should add a page break on a table row', () => {
       const reportWithPageBreak = require('./mocks/reportWithTable').default; // eslint-disable-line global-require
       const formatter = new PDFFormatter(reportWithPageBreak);
+      console.log(reportWithPageBreak.innerHTML);
       formatter.formatPage();
       const elementsWithPageBreak = reportWithPageBreak
         .children[1].children[1].children[0].children[0];

--- a/packages/report/mocks/reportWithTable.js
+++ b/packages/report/mocks/reportWithTable.js
@@ -1,0 +1,24 @@
+import { JSDOM } from 'jsdom';
+
+const { document } = (new JSDOM(`
+  <div id="report-page">
+    <div>Title</div>
+    <div>
+        <div>Title</div>
+        <table>
+          <tbody>
+            <tr>This should break</tr>
+            <tr></tr>
+            <tr></tr>
+          </tbody>
+        </table>
+    </div>
+  </div>
+`)).window;
+const page = document.getElementById('report-page');
+Object.defineProperty(Object.getPrototypeOf(page), 'clientHeight', {
+  get: () => 800,
+  configurable: true,
+});
+
+export default page;

--- a/packages/report/mocks/reportWithTable.js
+++ b/packages/report/mocks/reportWithTable.js
@@ -5,13 +5,13 @@ const { document } = (new JSDOM(`
     <div>Title</div>
     <div>
         <div>Title</div>
-        <table>
-          <tbody>
-            <tr>This should break</tr>
-            <tr></tr>
-            <tr></tr>
-          </tbody>
-        </table>
+        <div>
+          <ol>
+            <li></li>
+            <li></li>
+            <li></li>
+          </ol>
+        </div>
     </div>
   </div>
 `)).window;


### PR DESCRIPTION
### Purpose
To fix reports pagination for Posts Tables

### Notes
This was a fun bug to track down :smile: .

The new layout was breaking the page break calculations and that was an easy fix, but then I realized that even though the calculations were working fine, the pdf was ignoring the `page-break-before` rules. Turned out rendering to pdf is ignoring page breaks for `table`; therefore I've changed the markup a bit and we are now using ordered lists.

I've added in a test to make sure the page break logic is working fine with this new layout, but that is still a bit brittle, as it's testing against a mocked layout. :thinking: It could be worth exploring some integrations tests for the export, as it's quite coupled with the actual components layouts and i think this is not the first time this is breaking cause of a layout change.

Also tok the chance to update the style of the page break border :straight_ruler:.

### Review

Hey @msanroman, would love your eyes on this one, as you are the most familiar with the PDF export logics :smile:.

@moreofmorris I'm tagging you in too, to keep you in the loop on this one :smile:. 

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
