### PR TITLE
send entire list on new page if first li too big

### DIFF
--- a/packages/report/PDFFormatter.test.js
+++ b/packages/report/PDFFormatter.test.js
@@ -49,11 +49,19 @@ describe('PDF formatter', () => {
     it('should add a page break on a table row', () => {
       const reportWithPageBreak = require('./mocks/reportWithTable').default; // eslint-disable-line global-require
       const formatter = new PDFFormatter(reportWithPageBreak);
-      console.log(reportWithPageBreak.innerHTML);
+      formatter.formatPage();
+      const elementsWithPageBreak = reportWithPageBreak
+        .children[1].children[1].children[0].children[1];
+      expect(elementHasPageBreak(elementsWithPageBreak)).toBeTruthy();
+    });
+
+    it('should add a page break before a table row if the first element will go to a new page', () => {
+      const reportWithPageBreak = require('./mocks/reportWithTable').default; // eslint-disable-line global-require
+      const formatter = new PDFFormatter(reportWithPageBreak);
       formatter.formatPage();
       const elementsWithPageBreak = reportWithPageBreak
         .children[1].children[1].children[0].children[0];
-      expect(elementHasPageBreak(elementsWithPageBreak)).toBeTruthy();
+      expect(elementHasPageBreak(elementsWithPageBreak)).toBeFalsy();
     });
   });
 });

--- a/packages/report/mocks/reportWithTable.js
+++ b/packages/report/mocks/reportWithTable.js
@@ -21,4 +21,10 @@ Object.defineProperty(Object.getPrototypeOf(page), 'clientHeight', {
   configurable: true,
 });
 
+const li = document.getElementsByTagName('li')[0];
+Object.defineProperty(Object.getPrototypeOf(li), 'clientHeight', {
+  get: () => 600,
+  configurable: true,
+});
+
 export default page;


### PR DESCRIPTION
### Purpose
If we need to push the first element of a list to a new page, we rather break before the Section title.

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
