### PR TITLE
Report cover updates

### DIFF
--- a/packages/audience-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/audience-chart/__snapshots__/snapshot.test.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshots AudienceChart [TESTED] Should render 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >

--- a/packages/average-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/average-table/__snapshots__/snapshot.test.js.snap
@@ -1247,7 +1247,7 @@ exports[`Snapshots Title should render title as if for report 1`] = `
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,

--- a/packages/average-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/average-table/__snapshots__/snapshot.test.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshots AverageTable should render a "no data" state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -93,7 +93,7 @@ exports[`Snapshots AverageTable should render a loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -213,7 +213,7 @@ exports[`Snapshots AverageTable should render the average table for 7 days 1`] =
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -556,7 +556,7 @@ exports[`Snapshots AverageTable should render the average table for 30 days 1`] 
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -899,7 +899,7 @@ exports[`Snapshots AverageTable should render the average table for 90 days 1`] 
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1229,7 +1229,7 @@ exports[`Snapshots Title should render title as if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -1249,8 +1249,8 @@ exports[`Snapshots Title should render title as if for report 1`] = `
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -1224,7 +1224,7 @@ exports[`Snapshots CompareChart should render a "no data" state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1296,7 +1296,7 @@ exports[`Snapshots CompareChart should render a loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1415,7 +1415,7 @@ exports[`Snapshots CompareChart should render the compare chart 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2312,7 +2312,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -3209,7 +3209,7 @@ exports[`Snapshots CompareChart should render the compare chart for Posts metric
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -4106,7 +4106,7 @@ exports[`Snapshots CompareChart should render the compare chart with previous pe
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -5758,7 +5758,7 @@ exports[`Snapshots Title should render title as if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -5778,8 +5778,8 @@ exports[`Snapshots Title should render title as if for report 1`] = `
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/compare-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/compare-chart/__snapshots__/snapshot.test.js.snap
@@ -5776,7 +5776,7 @@ exports[`Snapshots Title should render title as if for report 1`] = `
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,

--- a/packages/comparison_chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/comparison_chart/__snapshots__/snapshot.test.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshots ComparisonChart [TESTED] should render Instagram in the reach
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -468,7 +468,7 @@ exports[`Snapshots ComparisonChart [TESTED] should render a "no data" state 1`] 
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -537,7 +537,7 @@ exports[`Snapshots ComparisonChart [TESTED] should render a loading state 1`] = 
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -657,7 +657,7 @@ exports[`Snapshots ComparisonChart [TESTED] should render the audience compariso
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >

--- a/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
+++ b/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
@@ -3236,7 +3236,7 @@ exports[`Snapshots Title [TESTED] should render regular title even if for report
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,
@@ -3278,7 +3278,7 @@ exports[`Snapshots Title [TESTED] should render title as if for report 1`] = `
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,

--- a/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
+++ b/packages/contextual-compare/__snapshots__/snapshot.test.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render Posts metrics as col
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -802,7 +802,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Custom mode 1`] =
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1580,7 +1580,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2142,7 +2142,7 @@ exports[`Snapshots ContextualCompare [TESTED] Should render in Presets mode with
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2740,7 +2740,7 @@ exports[`Snapshots ContextualCompare [TESTED] should render a "no data" state 1`
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2808,7 +2808,7 @@ exports[`Snapshots ContextualCompare [TESTED] should render a loading state 1`] 
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -3238,8 +3238,8 @@ exports[`Snapshots Title [TESTED] should render regular title even if for report
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >
@@ -3260,7 +3260,7 @@ exports[`Snapshots Title [TESTED] should render title as if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -3280,8 +3280,8 @@ exports[`Snapshots Title [TESTED] should render title as if for report 1`] = `
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
@@ -2173,7 +2173,7 @@ exports[`Snapshots Title should render title as if for report 1`] = `
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,

--- a/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
+++ b/packages/hourly-chart/__snapshots__/snapshot.test.js.snap
@@ -538,7 +538,7 @@ exports[`Snapshots HourlyChart [TESTED] loaded chart 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1293,7 +1293,7 @@ exports[`Snapshots HourlyChart [TESTED] loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1413,7 +1413,7 @@ exports[`Snapshots HourlyChart [TESTED] second metric selected 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2155,7 +2155,7 @@ exports[`Snapshots Title should render title as if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -2175,8 +2175,8 @@ exports[`Snapshots Title should render title as if for report 1`] = `
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-summary-table/__snapshots__/snapshot.test.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshots PostsSummaryTable should render a "no data" state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -94,7 +94,7 @@ exports[`Snapshots PostsSummaryTable should render a loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -215,7 +215,7 @@ exports[`Snapshots PostsSummaryTable should render the posts summary table 1`] =
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -12538,7 +12538,7 @@ exports[`Snapshots Title should render title as if for report 1`] = `
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,
@@ -12580,7 +12580,7 @@ exports[`Snapshots Title should render title for Twitter is if for report 1`] = 
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,

--- a/packages/posts-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/posts-table/__snapshots__/snapshot.test.js.snap
@@ -1953,7 +1953,7 @@ exports[`Snapshots PostsTable should hide posts link on export 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -3774,7 +3774,7 @@ exports[`Snapshots PostsTable should render a "no data" state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -3842,7 +3842,7 @@ exports[`Snapshots PostsTable should render a loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -3973,7 +3973,7 @@ exports[`Snapshots PostsTable should render the posts table 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -6366,7 +6366,7 @@ exports[`Snapshots PostsTable should render the posts table for instagram 1`] = 
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -8253,7 +8253,7 @@ exports[`Snapshots PostsTable should render the posts table for twitter 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -10140,7 +10140,7 @@ exports[`Snapshots PostsTable should render the posts table with default selecte
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -12520,7 +12520,7 @@ exports[`Snapshots Title should render title as if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -12540,8 +12540,8 @@ exports[`Snapshots Title should render title as if for report 1`] = `
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >
@@ -12562,7 +12562,7 @@ exports[`Snapshots Title should render title for Twitter is if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -12582,8 +12582,8 @@ exports[`Snapshots Title should render title for Twitter is if for report 1`] = 
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/profile-overview/__snapshots__/snapshot.test.js.snap
+++ b/packages/profile-overview/__snapshots__/snapshot.test.js.snap
@@ -499,7 +499,7 @@ exports[`Snapshots ProfilesTable should render a loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -630,7 +630,7 @@ exports[`Snapshots ProfilesTable should render the profiles overview 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2288,7 +2288,7 @@ exports[`Snapshots ProfilesTable should render the profiles overview without met
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -3037,7 +3037,7 @@ exports[`Snapshots Title should render title 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -571,7 +571,7 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
                 src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
               />
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -581,7 +581,7 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -630,7 +630,7 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                 src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
               />
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -640,7 +640,7 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -699,7 +699,7 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
               }
             >
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -709,7 +709,7 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -753,7 +753,7 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
               }
             >
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -763,7 +763,7 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -804,7 +804,7 @@ exports[`Snapshots DateRange renders the date range 1`] = `
         "color": "#000",
         "fontFamily": "\\"Roboto\\", sans-serif",
         "fontSize": "1rem",
-        "fontWeight": 700,
+        "fontWeight": 500,
       }
     }
   >
@@ -823,7 +823,7 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
         "color": "#000",
         "fontFamily": "\\"Roboto\\", sans-serif",
         "fontSize": "1rem",
-        "fontWeight": 700,
+        "fontWeight": 500,
       }
     }
   >
@@ -859,7 +859,7 @@ exports[`Snapshots EditTitle renders the edit title text box 1`] = `
   >
     <input
       autoFocus={true}
-      className="sc-gqjmRU kZfPWj"
+      className="sc-gqjmRU hieDIv"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test Report"
@@ -1627,7 +1627,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               }
             >
               <h1
-                className="sc-RcBXQ cdxqGl"
+                className="sc-RcBXQ ljXeou"
               >
                 Weekly Sync Report
               </h1>
@@ -1639,7 +1639,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 500,
               }
             }
           >
@@ -1678,8 +1678,8 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -2699,8 +2699,8 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -3720,8 +3720,8 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -4757,7 +4757,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           >
             <input
               autoFocus={true}
-              className="sc-gqjmRU kZfPWj"
+              className="sc-gqjmRU hieDIv"
               onBlur={[Function]}
               onChange={[Function]}
               value="Weekly Sync Report"
@@ -4769,7 +4769,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 500,
               }
             }
           >
@@ -4861,8 +4861,8 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -5882,8 +5882,8 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -6903,8 +6903,8 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -8120,7 +8120,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-RcBXQ cdxqGl"
+                className="sc-RcBXQ ljXeou"
               >
                 Weekly Sync Report
               </h1>
@@ -8132,7 +8132,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 500,
               }
             }
           >
@@ -8224,8 +8224,8 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -8675,7 +8675,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -8685,7 +8685,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -8731,8 +8731,8 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -9124,7 +9124,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h1
-                className="sc-RcBXQ cdxqGl"
+                className="sc-RcBXQ ljXeou"
               >
                 Weekly Sync Report
               </h1>
@@ -9136,7 +9136,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 500,
               }
             }
           >
@@ -9228,8 +9228,8 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -10249,8 +10249,8 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -11270,8 +11270,8 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -12311,7 +12311,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
               />
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -12321,7 +12321,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -12367,8 +12367,8 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -13213,8 +13213,8 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -14059,8 +14059,8 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -15012,7 +15012,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h1
-                className="sc-RcBXQ cdxqGl"
+                className="sc-RcBXQ ljXeou"
               >
                 Weekly Sync Report
               </h1>
@@ -15024,7 +15024,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 500,
               }
             }
           >
@@ -15116,8 +15116,8 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -16137,8 +16137,8 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -17158,8 +17158,8 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -18194,7 +18194,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               }
             >
               <h1
-                className="sc-EHOje lfSVpT"
+                className="sc-EHOje jrTCNW"
               >
                 Weekly Sync Report
               </h1>
@@ -18204,7 +18204,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 700,
+                    "fontWeight": 500,
                   }
                 }
               >
@@ -18250,8 +18250,8 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -19096,8 +19096,8 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -19942,8 +19942,8 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 Object {
                   "color": "#000",
                   "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1.5rem",
-                  "fontWeight": 700,
+                  "fontSize": "1.25rem",
+                  "fontWeight": 600,
                 }
               }
             >
@@ -20895,7 +20895,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               }
             >
               <h1
-                className="sc-RcBXQ cdxqGl"
+                className="sc-RcBXQ ljXeou"
               >
                 Weekly Sync Report New
               </h1>
@@ -20907,7 +20907,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 500,
               }
             }
           >
@@ -21000,8 +21000,8 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
-                    "fontWeight": 700,
+                    "fontSize": "1.25rem",
+                    "fontWeight": 600,
                   }
                 }
               >

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -566,14 +566,14 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -629,14 +629,14 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -648,7 +648,7 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                 February 25, 2018
               </span>
               <h2
-                className="sc-bZQynM dTUqdE"
+                className="sc-bZQynM kgzbaK"
               >
                 This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
               </h2>
@@ -696,14 +696,14 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -750,14 +750,14 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -769,7 +769,7 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
                 February 25, 2018
               </span>
               <h2
-                className="sc-bZQynM dTUqdE"
+                className="sc-bZQynM kgzbaK"
               >
                 This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
               </h2>
@@ -787,7 +787,7 @@ exports[`Snapshots DateRange renders the date range 1`] = `
   <span
     style={
       Object {
-        "color": "#000",
+        "color": undefined,
         "fontFamily": "\\"Roboto\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 600,
@@ -806,7 +806,7 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
   <span
     style={
       Object {
-        "color": "#000",
+        "color": undefined,
         "fontFamily": "\\"Roboto\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 600,
@@ -1613,7 +1613,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               }
             >
               <h1
-                className="sc-iSDuPN hvxUgq"
+                className="sc-iSDuPN czKrYp"
               >
                 Weekly Sync Report
               </h1>
@@ -1622,7 +1622,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           <span
             style={
               Object {
-                "color": "#000",
+                "color": undefined,
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
                 "fontWeight": 600,
@@ -1662,7 +1662,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -2683,7 +2683,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -3704,7 +3704,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -4752,7 +4752,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           <span
             style={
               Object {
-                "color": "#000",
+                "color": undefined,
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
                 "fontWeight": 600,
@@ -4845,7 +4845,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -5866,7 +5866,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -6887,7 +6887,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -8106,7 +8106,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-iSDuPN hvxUgq"
+                className="sc-iSDuPN czKrYp"
               >
                 Weekly Sync Report
               </h1>
@@ -8115,7 +8115,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           <span
             style={
               Object {
-                "color": "#000",
+                "color": undefined,
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
                 "fontWeight": 600,
@@ -8208,7 +8208,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -8661,14 +8661,14 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -8680,7 +8680,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 February 25, 2018
               </span>
               <h2
-                className="sc-bZQynM dTUqdE"
+                className="sc-bZQynM kgzbaK"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
               </h2>
@@ -8704,7 +8704,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -9099,7 +9099,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h1
-                className="sc-iSDuPN hvxUgq"
+                className="sc-iSDuPN czKrYp"
               >
                 Weekly Sync Report
               </h1>
@@ -9108,7 +9108,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           <span
             style={
               Object {
-                "color": "#000",
+                "color": undefined,
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
                 "fontWeight": 600,
@@ -9201,7 +9201,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -10222,7 +10222,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -11243,7 +11243,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -12281,14 +12281,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -12300,7 +12300,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 February 25, 2018
               </span>
               <h2
-                className="sc-bZQynM dTUqdE"
+                className="sc-bZQynM kgzbaK"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -12333,7 +12333,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -13179,7 +13179,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -14025,7 +14025,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -14980,7 +14980,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h1
-                className="sc-iSDuPN hvxUgq"
+                className="sc-iSDuPN czKrYp"
               >
                 Weekly Sync Report
               </h1>
@@ -14989,7 +14989,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           <span
             style={
               Object {
-                "color": "#000",
+                "color": undefined,
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
                 "fontWeight": 600,
@@ -15082,7 +15082,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -16103,7 +16103,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -17124,7 +17124,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,
@@ -18162,14 +18162,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               }
             >
               <h1
-                className="sc-EHOje jrTCNW"
+                className="sc-EHOje igWyUE"
               >
                 Weekly Sync Report
               </h1>
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": undefined,
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
                     "fontWeight": 600,
@@ -18181,7 +18181,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 February 25, 2018
               </span>
               <h2
-                className="sc-bZQynM dTUqdE"
+                className="sc-bZQynM kgzbaK"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -18205,7 +18205,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -19051,7 +19051,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -19897,7 +19897,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
             <span
               style={
                 Object {
-                  "color": "#000",
+                  "color": "#323b43",
                   "fontFamily": "\\"Roboto\\", sans-serif",
                   "fontSize": "1.25rem",
                   "fontWeight": 600,
@@ -20852,7 +20852,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               }
             >
               <h1
-                className="sc-iSDuPN hvxUgq"
+                className="sc-iSDuPN czKrYp"
               >
                 Weekly Sync Report New
               </h1>
@@ -20861,7 +20861,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           <span
             style={
               Object {
-                "color": "#000",
+                "color": undefined,
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
                 "fontWeight": 600,
@@ -20955,7 +20955,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               <span
                 style={
                   Object {
-                    "color": "#000",
+                    "color": "#323b43",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1.25rem",
                     "fontWeight": 600,

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -540,22 +540,20 @@ exports[`Snapshots ChartEditButtons they render 1`] = `
 </span>
 `;
 
-exports[`Snapshots Cover renders a cover with a logo 1`] = `
+exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
 <span>
   <section
-    className="sc-iwsKbI hgkCET"
+    className="sc-dnqmqq gjnmZE"
   >
     <article
-      className="sc-bxivhb cEKEIA"
+      className="sc-bxivhb csPkxY"
     >
       <div
-        className="sc-ifAKCX kNbSqy"
+        className="sc-ifAKCX ieKocY"
       >
-        <div
-          className="sc-EHOje jvzENE"
-        >
+        <div>
           <div
-            className="sc-bZQynM kUBhSG"
+            className="sc-EHOje dClLkx"
           >
             <span
               style={
@@ -567,8 +565,13 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
                 }
               }
             >
+              <img
+                alt="Weekly Sync Report"
+                className="sc-htoDjs hYowVK"
+                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+              />
               <h1
-                className="sc-gzVnrw jABNwW"
+                className="sc-bZQynM lckfgS"
               >
                 Weekly Sync Report
               </h1>
@@ -577,7 +580,7 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
+                    "fontSize": "1rem",
                     "fontWeight": 700,
                   }
                 }
@@ -590,18 +593,9 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
                   February 25, 2018
                 </span>
               </span>
-              <h2
-                className="sc-htoDjs eoFwiH"
-              >
-                
-              </h2>
             </span>
           </div>
-          <img
-            alt="Weekly Sync Report"
-            className="sc-dnqmqq bomrRH"
-            src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
-          />
+          
         </div>
       </div>
     </article>
@@ -609,22 +603,20 @@ exports[`Snapshots Cover renders a cover with a logo 1`] = `
 </span>
 `;
 
-exports[`Snapshots Cover renders a cover without a logo 1`] = `
+exports[`Snapshots Cover renders a cover with logo, name, date and description 1`] = `
 <span>
   <section
-    className="sc-iwsKbI hgkCET"
+    className="sc-dnqmqq gjnmZE"
   >
     <article
-      className="sc-bxivhb cEKEIA"
+      className="sc-bxivhb csPkxY"
     >
       <div
-        className="sc-ifAKCX kNbSqy"
+        className="sc-ifAKCX ieKocY"
       >
-        <div
-          className="sc-EHOje jvzENE"
-        >
+        <div>
           <div
-            className="sc-bZQynM kUBhSG"
+            className="sc-EHOje dClLkx"
           >
             <span
               style={
@@ -636,8 +628,13 @@ exports[`Snapshots Cover renders a cover without a logo 1`] = `
                 }
               }
             >
+              <img
+                alt="Weekly Sync Report"
+                className="sc-htoDjs hYowVK"
+                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+              />
               <h1
-                className="sc-gzVnrw jABNwW"
+                className="sc-bZQynM lckfgS"
               >
                 Weekly Sync Report
               </h1>
@@ -646,7 +643,7 @@ exports[`Snapshots Cover renders a cover without a logo 1`] = `
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
+                    "fontSize": "1rem",
                     "fontWeight": 700,
                   }
                 }
@@ -659,13 +656,155 @@ exports[`Snapshots Cover renders a cover without a logo 1`] = `
                   February 25, 2018
                 </span>
               </span>
-              <h2
-                className="sc-htoDjs eoFwiH"
-              >
-                Weekly report of all the social account of Buffer. We only use organic posts in this report. t is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.
-              </h2>
             </span>
           </div>
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            <h2
+              className="sc-gzVnrw dkdfDA"
+            >
+              Weekly report of all the social account of Buffer. We only use organic posts in this report. It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.
+            </h2>
+          </span>
+        </div>
+      </div>
+    </article>
+  </section>
+</span>
+`;
+
+exports[`Snapshots Cover renders a cover with name and date 1`] = `
+<span>
+  <section
+    className="sc-dnqmqq gjnmZE"
+  >
+    <article
+      className="sc-bxivhb csPkxY"
+    >
+      <div
+        className="sc-ifAKCX ieKocY"
+      >
+        <div>
+          <div
+            className="sc-EHOje dClLkx"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <h1
+                className="sc-bZQynM lckfgS"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
+            </span>
+          </div>
+          
+        </div>
+      </div>
+    </article>
+  </section>
+</span>
+`;
+
+exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
+<span>
+  <section
+    className="sc-dnqmqq gjnmZE"
+  >
+    <article
+      className="sc-bxivhb csPkxY"
+    >
+      <div
+        className="sc-ifAKCX ieKocY"
+      >
+        <div>
+          <div
+            className="sc-EHOje dClLkx"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              <h1
+                className="sc-bZQynM lckfgS"
+              >
+                Weekly Sync Report
+              </h1>
+              <span
+                style={
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 700,
+                  }
+                }
+              >
+                <span
+                  className="sc-htpNat KtFsv"
+                >
+                  February 20, 2018
+                   to 
+                  February 25, 2018
+                </span>
+              </span>
+            </span>
+          </div>
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            <h2
+              className="sc-gzVnrw dkdfDA"
+            >
+              Weekly report of all the social account of Buffer. We only use organic posts in this report. It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.
+            </h2>
+          </span>
         </div>
       </div>
     </article>
@@ -722,12 +861,12 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
 exports[`Snapshots EditDescription renders the edit description text box 1`] = `
 <span>
   <form
-    className="sc-gZMcBi kniurN"
+    className="sc-iwsKbI mLnRN"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-gqjmRU gLjgwy"
+      className="sc-gZMcBi fpDrjl"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test report description"
@@ -739,12 +878,12 @@ exports[`Snapshots EditDescription renders the edit description text box 1`] = `
 exports[`Snapshots EditTitle renders the edit title text box 1`] = `
 <span>
   <form
-    className="sc-VigVT koZmyN"
+    className="sc-gqjmRU liZjsx"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-jTzLTM dqfOIL"
+      className="sc-VigVT leLWkf"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test Report"
@@ -781,7 +920,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
     }
   >
     <div
-      className="sc-fjdhpX iPdpdv"
+      className="sc-jTzLTM fXZkZI"
     >
       <button
         aria-label={null}
@@ -812,7 +951,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
         }
       >
         <span
-          className="sc-kGXeez cqGbwk"
+          className="sc-kgoBCf byUlgs"
         >
           <svg
             height="100%"
@@ -858,7 +997,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
     }
   >
     <div
-      className="sc-fjdhpX iPdpdv"
+      className="sc-jTzLTM fXZkZI"
     >
       <button
         aria-label={null}
@@ -889,7 +1028,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
         }
       >
         <span
-          className="sc-kGXeez cqGbwk"
+          className="sc-kgoBCf byUlgs"
         >
           <svg
             height="100%"
@@ -935,13 +1074,13 @@ exports[`Snapshots LogoUpload renders no logo image upload box 1`] = `
     }
   >
     <div
-      className="sc-fjdhpX iPdpdv"
+      className="sc-jTzLTM fXZkZI"
     >
       <div
-        className="sc-jzJRlG lgArNv"
+        className="sc-fjdhpX LgDyd"
       >
         <span
-          className="sc-chPdSV egNpeK"
+          className="sc-kAzzGY gMJrTE"
         >
           <span
             style={
@@ -987,16 +1126,16 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
     }
   >
     <div
-      className="sc-fjdhpX iPdpdv"
+      className="sc-jTzLTM fXZkZI"
     >
       <div
-        className="sc-jzJRlG lgArNv"
+        className="sc-fjdhpX LgDyd"
       >
         <span
-          className="sc-chPdSV egNpeK"
+          className="sc-kAzzGY gMJrTE"
         />
         <span
-          className="sc-kgoBCf hbdICY"
+          className="sc-chPdSV gccHCf"
         >
           <span
             style={
@@ -1020,13 +1159,13 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
 exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 <span>
   <div
-    className="sc-kjoXOD hlUEhm"
+    className="sc-gisBJw cCWpwM"
   >
     <span
-      className="sc-caSCKo mUdMp"
+      className="sc-fAjcbJ fclNrM"
     >
       <div
-        className="sc-jlyJG jGwGPa"
+        className="sc-iRbamj kNGkEx"
         size="16px"
       >
         <img
@@ -1093,7 +1232,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-gisBJw feZXCW"
+        className="sc-caSCKo dBUfBz"
       >
         <span
           style={
@@ -1106,7 +1245,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-fAjcbJ kjdNkf"
+            className="sc-eqIVtm ecxnvs"
           >
             @moreofmorris
           </span>
@@ -1114,10 +1253,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-caSCKo mUdMp"
+      className="sc-fAjcbJ fclNrM"
     >
       <div
-        className="sc-jlyJG jGwGPa"
+        className="sc-iRbamj kNGkEx"
         size="16px"
       >
         <img
@@ -1184,7 +1323,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-gisBJw feZXCW"
+        className="sc-caSCKo dBUfBz"
       >
         <span
           style={
@@ -1197,7 +1336,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-fAjcbJ kjdNkf"
+            className="sc-eqIVtm ecxnvs"
           >
             @roughquest
           </span>
@@ -1205,10 +1344,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-caSCKo mUdMp"
+      className="sc-fAjcbJ fclNrM"
     >
       <div
-        className="sc-jlyJG jGwGPa"
+        className="sc-iRbamj kNGkEx"
         size="16px"
       >
         <img
@@ -1275,7 +1414,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-gisBJw feZXCW"
+        className="sc-caSCKo dBUfBz"
       >
         <span
           style={
@@ -1288,7 +1427,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-fAjcbJ kjdNkf"
+            className="sc-eqIVtm ecxnvs"
           >
             Roughquest
           </span>
@@ -1302,10 +1441,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 <span>
   <span
-    className="sc-caSCKo mUdMp"
+    className="sc-fAjcbJ fclNrM"
   >
     <div
-      className="sc-jlyJG jGwGPa"
+      className="sc-iRbamj kNGkEx"
       size="16px"
     >
       <img
@@ -1372,7 +1511,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
       </div>
     </div>
     <div
-      className="sc-gisBJw feZXCW"
+      className="sc-caSCKo dBUfBz"
     >
       <span
         style={
@@ -1385,7 +1524,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
         }
       >
         <span
-          className="sc-fAjcbJ kjdNkf"
+          className="sc-eqIVtm ecxnvs"
         >
           @moreofmorris
         </span>
@@ -1398,14 +1537,14 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 exports[`Snapshots Report render in description edit mode 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-RcBXQ dhnDzi"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-iSDuPN cToSdI"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -1418,16 +1557,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           }
         >
           <div
-            className="sc-jXQZqI eyRUMp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-fjdhpX iPdpdv"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jzJRlG lgArNv"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-chPdSV egNpeK"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -1457,7 +1596,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               </div>
             </div>
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -1512,7 +1651,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               }
             >
               <h1
-                className="sc-fZwumE gpUNMp"
+                className="sc-iSDuPN jSvqTR"
               >
                 Weekly Sync Report
               </h1>
@@ -1537,12 +1676,12 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </span>
           </span>
           <form
-            className="sc-gZMcBi kniurN"
+            className="sc-iwsKbI mLnRN"
             onSubmit={[Function]}
           >
             <input
               autoFocus={true}
-              className="sc-gqjmRU gLjgwy"
+              className="sc-gZMcBi fpDrjl"
               onBlur={[Function]}
               onChange={[Function]}
               value="Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work."
@@ -1551,16 +1690,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -1752,13 +1891,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -1825,7 +1964,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -1838,7 +1977,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -1848,17 +1987,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -1878,7 +2017,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -1895,13 +2034,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -1924,7 +2063,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -1947,14 +2086,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -1974,7 +2113,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -1991,13 +2130,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2020,7 +2159,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2043,14 +2182,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2070,7 +2209,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2087,13 +2226,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2116,7 +2255,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2139,14 +2278,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2166,7 +2305,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2183,13 +2322,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2212,7 +2351,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2235,14 +2374,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2262,7 +2401,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2282,14 +2421,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2309,7 +2448,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2326,13 +2465,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2355,7 +2494,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2378,14 +2517,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2405,7 +2544,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2422,13 +2561,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2451,7 +2590,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2474,14 +2613,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2501,7 +2640,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2518,13 +2657,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2547,7 +2686,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2572,16 +2711,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -2773,13 +2912,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -2846,7 +2985,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -2859,7 +2998,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -2869,17 +3008,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2899,7 +3038,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2916,13 +3055,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2945,7 +3084,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2968,14 +3107,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2995,7 +3134,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3012,13 +3151,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3041,7 +3180,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3064,14 +3203,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3091,7 +3230,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3108,13 +3247,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3137,7 +3276,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3160,14 +3299,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3187,7 +3326,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3204,13 +3343,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3233,7 +3372,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3256,14 +3395,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3283,7 +3422,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3303,14 +3442,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3330,7 +3469,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3347,13 +3486,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3376,7 +3515,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3399,14 +3538,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3426,7 +3565,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3443,13 +3582,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3472,7 +3611,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3495,14 +3634,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3522,7 +3661,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3539,13 +3678,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3568,7 +3707,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3593,16 +3732,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -3794,13 +3933,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -3867,7 +4006,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -3880,7 +4019,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -3890,17 +4029,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3920,7 +4059,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3937,13 +4076,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3966,7 +4105,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3989,14 +4128,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4016,7 +4155,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4033,13 +4172,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4062,7 +4201,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4085,14 +4224,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4112,7 +4251,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4129,13 +4268,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4158,7 +4297,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4181,14 +4320,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4208,7 +4347,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4225,13 +4364,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4254,7 +4393,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4277,14 +4416,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4304,7 +4443,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4324,14 +4463,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4351,7 +4490,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4368,13 +4507,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4397,7 +4536,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4420,14 +4559,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4447,7 +4586,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4464,13 +4603,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4493,7 +4632,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4516,14 +4655,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4543,7 +4682,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4560,13 +4699,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4589,7 +4728,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4621,14 +4760,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
 exports[`Snapshots Report render in title edit mode 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-RcBXQ dhnDzi"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-iSDuPN cToSdI"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -4641,12 +4780,12 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           }
         >
           <form
-            className="sc-VigVT koZmyN"
+            className="sc-gqjmRU liZjsx"
             onSubmit={[Function]}
           >
             <input
               autoFocus={true}
-              className="sc-jTzLTM dqfOIL"
+              className="sc-VigVT leLWkf"
               onBlur={[Function]}
               onChange={[Function]}
               value="Weekly Sync Report"
@@ -4671,10 +4810,10 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </span>
           </span>
           <div
-            className="sc-etwtAo imoISm"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -4729,7 +4868,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               }
             >
               <h2
-                className="sc-fQejPQ dBmXUZ"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -4738,16 +4877,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -4939,13 +5078,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -5012,7 +5151,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -5025,7 +5164,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -5035,17 +5174,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5065,7 +5204,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5082,13 +5221,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5111,7 +5250,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5134,14 +5273,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5161,7 +5300,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5178,13 +5317,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5207,7 +5346,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5230,14 +5369,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5257,7 +5396,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5274,13 +5413,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5303,7 +5442,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5326,14 +5465,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5353,7 +5492,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5370,13 +5509,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5399,7 +5538,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5422,14 +5561,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5449,7 +5588,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5469,14 +5608,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5496,7 +5635,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5513,13 +5652,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5542,7 +5681,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5565,14 +5704,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5592,7 +5731,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5609,13 +5748,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5638,7 +5777,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5661,14 +5800,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5688,7 +5827,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5705,13 +5844,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5734,7 +5873,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5759,16 +5898,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -5960,13 +6099,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -6033,7 +6172,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -6046,7 +6185,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -6056,17 +6195,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6086,7 +6225,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6103,13 +6242,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6132,7 +6271,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6155,14 +6294,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6182,7 +6321,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6199,13 +6338,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6228,7 +6367,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6251,14 +6390,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6278,7 +6417,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6295,13 +6434,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6324,7 +6463,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6347,14 +6486,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6374,7 +6513,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6391,13 +6530,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6420,7 +6559,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6443,14 +6582,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6470,7 +6609,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6490,14 +6629,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6517,7 +6656,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6534,13 +6673,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6563,7 +6702,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6586,14 +6725,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6613,7 +6752,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6630,13 +6769,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6659,7 +6798,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6682,14 +6821,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6709,7 +6848,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6726,13 +6865,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6755,7 +6894,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6780,16 +6919,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -6981,13 +7120,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -7054,7 +7193,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -7067,7 +7206,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -7077,17 +7216,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7107,7 +7246,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7124,13 +7263,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7153,7 +7292,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7176,14 +7315,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7203,7 +7342,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7220,13 +7359,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7249,7 +7388,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7272,14 +7411,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7299,7 +7438,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7316,13 +7455,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7345,7 +7484,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7368,14 +7507,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7395,7 +7534,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7412,13 +7551,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7441,7 +7580,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7464,14 +7603,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7491,7 +7630,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7511,14 +7650,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7538,7 +7677,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7555,13 +7694,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7584,7 +7723,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7607,14 +7746,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7634,7 +7773,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7651,13 +7790,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7680,7 +7819,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7703,14 +7842,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7730,7 +7869,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7747,13 +7886,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7776,7 +7915,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7808,16 +7947,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
 exports[`Snapshots Report render loading 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-kasBVs fyXeDD"
+      className="sc-iGPElx hIwNUa"
     >
       <div
-        className="sc-dxgOiQ fYkxwK"
+        className="sc-kpOJdX dpBkoP"
       >
         <div
-          className="sc-kpOJdX hBXaqU"
+          className="sc-kGXeez jgBcBL"
         >
           <div
             style={
@@ -7899,14 +8038,14 @@ exports[`Snapshots Report render loading 1`] = `
 exports[`Snapshots Report render only the multi-profile legend if that is available 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-RcBXQ dhnDzi"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-iSDuPN cToSdI"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -7919,16 +8058,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           }
         >
           <div
-            className="sc-jXQZqI eyRUMp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-fjdhpX iPdpdv"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jzJRlG lgArNv"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-chPdSV egNpeK"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -7958,7 +8097,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               </div>
             </div>
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -8013,7 +8152,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-fZwumE gpUNMp"
+                className="sc-iSDuPN jSvqTR"
               >
                 Weekly Sync Report
               </h1>
@@ -8038,10 +8177,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             </span>
           </span>
           <div
-            className="sc-etwtAo imoISm"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -8096,7 +8235,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h2
-                className="sc-fQejPQ dBmXUZ"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
               </h2>
@@ -8105,16 +8244,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </span>
       </div>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -8307,16 +8446,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <div
-              className="sc-kjoXOD hlUEhm"
+              className="sc-gisBJw cCWpwM"
             >
               <span
-                className="sc-caSCKo mUdMp"
+                className="sc-fAjcbJ fclNrM"
               >
                 <div
-                  className="sc-jlyJG jGwGPa"
+                  className="sc-iRbamj kNGkEx"
                   size="16px"
                 >
                   <img
@@ -8383,7 +8522,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-gisBJw feZXCW"
+                  className="sc-caSCKo dBUfBz"
                 >
                   <span
                     style={
@@ -8396,7 +8535,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-fAjcbJ kjdNkf"
+                      className="sc-eqIVtm ecxnvs"
                     >
                       @buffer
                     </span>
@@ -8404,10 +8543,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </span>
               <span
-                className="sc-caSCKo mUdMp"
+                className="sc-fAjcbJ fclNrM"
               >
                 <div
-                  className="sc-jlyJG jGwGPa"
+                  className="sc-iRbamj kNGkEx"
                   size="16px"
                 >
                   <img
@@ -8489,7 +8628,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-gisBJw feZXCW"
+                  className="sc-caSCKo dBUfBz"
                 >
                   <span
                     style={
@@ -8502,7 +8641,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-fAjcbJ kjdNkf"
+                      className="sc-eqIVtm ecxnvs"
                     >
                       buffer
                     </span>
@@ -8513,16 +8652,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </div>
         </div>
         <div
-          className="sc-ckVGcZ cmZATi"
+          className="sc-dxgOiQ ckNOOu"
         >
           <div
-            className="sc-jKJlTe iKZKYB"
+            className="sc-ckVGcZ YJXtP"
           >
             <div
-              className="sc-eNQAEJ jsaNIU"
+              className="sc-jKJlTe bWRyvh"
             />
             <h1
-              className="sc-hMqMXs hprcVs"
+              className="sc-eNQAEJ dYjNXW"
             >
               <span
                 style={
@@ -8548,20 +8687,18 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render only the multi-profile legend if that is available whilst exporting 1`] = `
 <span>
   <div
-    className="sc-RcBXQ dhnDzi"
+    className="sc-kZmsYB exKuiO"
     id="report-page"
   >
     <article
-      className="sc-bxivhb cEKEIA"
+      className="sc-bxivhb csPkxY"
     >
       <div
-        className="sc-ifAKCX kNbSqy"
+        className="sc-ifAKCX ieKocY"
       >
-        <div
-          className="sc-EHOje jvzENE"
-        >
+        <div>
           <div
-            className="sc-bZQynM kUBhSG"
+            className="sc-EHOje dClLkx"
           >
             <span
               style={
@@ -8574,7 +8711,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-gzVnrw jABNwW"
+                className="sc-bZQynM lckfgS"
               >
                 Weekly Sync Report
               </h1>
@@ -8583,7 +8720,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
+                    "fontSize": "1rem",
                     "fontWeight": 700,
                   }
                 }
@@ -8596,27 +8733,38 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   February 25, 2018
                 </span>
               </span>
-              <h2
-                className="sc-htoDjs eoFwiH"
-              >
-                Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
-              </h2>
             </span>
           </div>
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            <h2
+              className="sc-gzVnrw dkdfDA"
+            >
+              Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
+            </h2>
+          </span>
         </div>
       </div>
     </article>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -8634,16 +8782,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <div
-            className="sc-kjoXOD hlUEhm"
+            className="sc-gisBJw cCWpwM"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -8710,7 +8858,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -8723,7 +8871,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     @buffer
                   </span>
@@ -8731,10 +8879,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               </div>
             </span>
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -8816,7 +8964,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -8829,7 +8977,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     buffer
                   </span>
@@ -8840,16 +8988,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </div>
       </div>
       <div
-        className="sc-ckVGcZ cmZATi"
+        className="sc-dxgOiQ ckNOOu"
       >
         <div
-          className="sc-jKJlTe iKZKYB"
+          className="sc-ckVGcZ YJXtP"
         >
           <div
-            className="sc-eNQAEJ jsaNIU"
+            className="sc-jKJlTe bWRyvh"
           />
           <h1
-            className="sc-hMqMXs hprcVs"
+            className="sc-eNQAEJ dYjNXW"
           >
             <span
               style={
@@ -8868,7 +9016,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
       </div>
     </section>
     <div
-      className="sc-hgHYgh dnbQMm"
+      className="sc-kasBVs bedwKD"
     />
   </div>
 </span>
@@ -8877,14 +9025,14 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render with summary table and logo 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-RcBXQ dhnDzi"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-iSDuPN cToSdI"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -8897,10 +9045,10 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           }
         >
           <div
-            className="sc-jXQZqI eyRUMp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-fjdhpX iPdpdv"
+              className="sc-jTzLTM fXZkZI"
             >
               <button
                 aria-label={null}
@@ -8931,7 +9079,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 }
               >
                 <span
-                  className="sc-kGXeez cqGbwk"
+                  className="sc-kgoBCf byUlgs"
                 >
                   <svg
                     height="100%"
@@ -8961,7 +9109,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               </button>
             </div>
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -9016,7 +9164,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h1
-                className="sc-fZwumE gpUNMp"
+                className="sc-iSDuPN jSvqTR"
               >
                 Weekly Sync Report
               </h1>
@@ -9041,10 +9189,10 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </span>
           </span>
           <div
-            className="sc-etwtAo imoISm"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -9099,7 +9247,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h2
-                className="sc-fQejPQ dBmXUZ"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -9108,16 +9256,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -9309,13 +9457,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -9382,7 +9530,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -9395,7 +9543,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -9405,17 +9553,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9435,7 +9583,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9452,13 +9600,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9481,7 +9629,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9504,14 +9652,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9531,7 +9679,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9548,13 +9696,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9577,7 +9725,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9600,14 +9748,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9627,7 +9775,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9644,13 +9792,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9673,7 +9821,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9696,14 +9844,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9723,7 +9871,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9740,13 +9888,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9769,7 +9917,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9792,14 +9940,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9819,7 +9967,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9839,14 +9987,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9866,7 +10014,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9883,13 +10031,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9912,7 +10060,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9935,14 +10083,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9962,7 +10110,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9979,13 +10127,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10008,7 +10156,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10031,14 +10179,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10058,7 +10206,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10075,13 +10223,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10104,7 +10252,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10129,16 +10277,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -10330,13 +10478,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -10403,7 +10551,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -10416,7 +10564,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -10426,17 +10574,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10456,7 +10604,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10473,13 +10621,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10502,7 +10650,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10525,14 +10673,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10552,7 +10700,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10569,13 +10717,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10598,7 +10746,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10621,14 +10769,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10648,7 +10796,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10665,13 +10813,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10694,7 +10842,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10717,14 +10865,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10744,7 +10892,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10761,13 +10909,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10790,7 +10938,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10813,14 +10961,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10840,7 +10988,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10860,14 +11008,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10887,7 +11035,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10904,13 +11052,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10933,7 +11081,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10956,14 +11104,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10983,7 +11131,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11000,13 +11148,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11029,7 +11177,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11052,14 +11200,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11079,7 +11227,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11096,13 +11244,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11125,7 +11273,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11150,16 +11298,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -11351,13 +11499,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -11424,7 +11572,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -11437,7 +11585,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -11447,17 +11595,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11477,7 +11625,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11494,13 +11642,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11523,7 +11671,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11546,14 +11694,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11573,7 +11721,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11590,13 +11738,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11619,7 +11767,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11642,14 +11790,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11669,7 +11817,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11686,13 +11834,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11715,7 +11863,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11738,14 +11886,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11765,7 +11913,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11782,13 +11930,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11811,7 +11959,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11834,14 +11982,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11861,7 +12009,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11881,14 +12029,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11908,7 +12056,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11925,13 +12073,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11954,7 +12102,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11977,14 +12125,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -12004,7 +12152,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -12021,13 +12169,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -12050,7 +12198,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -12073,14 +12221,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -12100,7 +12248,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -12117,13 +12265,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -12146,7 +12294,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -12178,20 +12326,18 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
 exports[`Snapshots Report render with summary table and logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-RcBXQ dhnDzi"
+    className="sc-kZmsYB exKuiO"
     id="report-page"
   >
     <article
-      className="sc-bxivhb cEKEIA"
+      className="sc-bxivhb csPkxY"
     >
       <div
-        className="sc-ifAKCX kNbSqy"
+        className="sc-ifAKCX ieKocY"
       >
-        <div
-          className="sc-EHOje jvzENE"
-        >
+        <div>
           <div
-            className="sc-bZQynM kUBhSG"
+            className="sc-EHOje dClLkx"
           >
             <span
               style={
@@ -12203,8 +12349,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               }
             >
+              <img
+                alt="Weekly Sync Report"
+                className="sc-htoDjs hYowVK"
+                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+              />
               <h1
-                className="sc-gzVnrw jABNwW"
+                className="sc-bZQynM lckfgS"
               >
                 Weekly Sync Report
               </h1>
@@ -12213,7 +12364,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
+                    "fontSize": "1rem",
                     "fontWeight": 700,
                   }
                 }
@@ -12226,32 +12377,38 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   February 25, 2018
                 </span>
               </span>
-              <h2
-                className="sc-htoDjs eoFwiH"
-              >
-                Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
-              </h2>
             </span>
           </div>
-          <img
-            alt="Weekly Sync Report"
-            className="sc-dnqmqq bomrRH"
-            src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
-          />
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            <h2
+              className="sc-gzVnrw dkdfDA"
+            >
+              Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
+            </h2>
+          </span>
         </div>
       </div>
     </article>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -12268,13 +12425,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-caSCKo mUdMp"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-jlyJG jGwGPa"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -12341,7 +12498,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-gisBJw feZXCW"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -12354,7 +12511,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-fAjcbJ kjdNkf"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -12364,17 +12521,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-esjQYD edlJEc"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12394,7 +12551,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12411,13 +12568,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12440,7 +12597,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12463,14 +12620,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12490,7 +12647,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12507,13 +12664,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12536,7 +12693,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12559,14 +12716,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12586,7 +12743,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12603,13 +12760,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12632,7 +12789,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12655,14 +12812,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12682,7 +12839,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12699,13 +12856,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12728,7 +12885,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12751,14 +12908,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12778,7 +12935,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12798,14 +12955,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12825,7 +12982,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12842,13 +12999,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12871,7 +13028,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12894,14 +13051,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12921,7 +13078,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12938,13 +13095,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12967,7 +13124,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12990,14 +13147,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13017,7 +13174,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13034,13 +13191,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13063,7 +13220,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13088,16 +13245,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -13114,13 +13271,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-caSCKo mUdMp"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-jlyJG jGwGPa"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -13187,7 +13344,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-gisBJw feZXCW"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -13200,7 +13357,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-fAjcbJ kjdNkf"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -13210,17 +13367,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-esjQYD edlJEc"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13240,7 +13397,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13257,13 +13414,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13286,7 +13443,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13309,14 +13466,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13336,7 +13493,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13353,13 +13510,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13382,7 +13539,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13405,14 +13562,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13432,7 +13589,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13449,13 +13606,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13478,7 +13635,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13501,14 +13658,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13528,7 +13685,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13545,13 +13702,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13574,7 +13731,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13597,14 +13754,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13624,7 +13781,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13644,14 +13801,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13671,7 +13828,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13688,13 +13845,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13717,7 +13874,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13740,14 +13897,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13767,7 +13924,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13784,13 +13941,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13813,7 +13970,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13836,14 +13993,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13863,7 +14020,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13880,13 +14037,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13909,7 +14066,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13934,16 +14091,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -13960,13 +14117,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-caSCKo mUdMp"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-jlyJG jGwGPa"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -14033,7 +14190,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-gisBJw feZXCW"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -14046,7 +14203,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-fAjcbJ kjdNkf"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -14056,17 +14213,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-esjQYD edlJEc"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14086,7 +14243,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14103,13 +14260,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14132,7 +14289,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14155,14 +14312,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14182,7 +14339,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14199,13 +14356,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14228,7 +14385,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14251,14 +14408,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14278,7 +14435,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14295,13 +14452,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14324,7 +14481,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14347,14 +14504,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14374,7 +14531,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14391,13 +14548,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14420,7 +14577,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14443,14 +14600,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14470,7 +14627,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14490,14 +14647,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14517,7 +14674,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14534,13 +14691,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14563,7 +14720,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14586,14 +14743,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14613,7 +14770,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14630,13 +14787,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14659,7 +14816,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14682,14 +14839,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14709,7 +14866,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14726,13 +14883,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14755,7 +14912,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14780,7 +14937,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <div
-      className="sc-hgHYgh dnbQMm"
+      className="sc-kasBVs bedwKD"
     />
   </div>
 </span>
@@ -14789,14 +14946,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
 exports[`Snapshots Report render with summary table and no logo 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-RcBXQ dhnDzi"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-iSDuPN cToSdI"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -14809,16 +14966,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           }
         >
           <div
-            className="sc-jXQZqI eyRUMp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-fjdhpX iPdpdv"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jzJRlG lgArNv"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-chPdSV egNpeK"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -14848,7 +15005,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               </div>
             </div>
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -14903,7 +15060,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h1
-                className="sc-fZwumE gpUNMp"
+                className="sc-iSDuPN jSvqTR"
               >
                 Weekly Sync Report
               </h1>
@@ -14928,10 +15085,10 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </span>
           </span>
           <div
-            className="sc-etwtAo imoISm"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -14986,7 +15143,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h2
-                className="sc-fQejPQ dBmXUZ"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -14995,16 +15152,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -15196,13 +15353,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -15269,7 +15426,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -15282,7 +15439,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -15292,17 +15449,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15322,7 +15479,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15339,13 +15496,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15368,7 +15525,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15391,14 +15548,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15418,7 +15575,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15435,13 +15592,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15464,7 +15621,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15487,14 +15644,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15514,7 +15671,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15531,13 +15688,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15560,7 +15717,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15583,14 +15740,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15610,7 +15767,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15627,13 +15784,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15656,7 +15813,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15679,14 +15836,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15706,7 +15863,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15726,14 +15883,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15753,7 +15910,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15770,13 +15927,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15799,7 +15956,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15822,14 +15979,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15849,7 +16006,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15866,13 +16023,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15895,7 +16052,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15918,14 +16075,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15945,7 +16102,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15962,13 +16119,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15991,7 +16148,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16016,16 +16173,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -16217,13 +16374,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -16290,7 +16447,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -16303,7 +16460,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -16313,17 +16470,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16343,7 +16500,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16360,13 +16517,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16389,7 +16546,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16412,14 +16569,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16439,7 +16596,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16456,13 +16613,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16485,7 +16642,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16508,14 +16665,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16535,7 +16692,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16552,13 +16709,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16581,7 +16738,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16604,14 +16761,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16631,7 +16788,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16648,13 +16805,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16677,7 +16834,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16700,14 +16857,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16727,7 +16884,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16747,14 +16904,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16774,7 +16931,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16791,13 +16948,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16820,7 +16977,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16843,14 +17000,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16870,7 +17027,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16887,13 +17044,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16916,7 +17073,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16939,14 +17096,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16966,7 +17123,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16983,13 +17140,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17012,7 +17169,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17037,16 +17194,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -17238,13 +17395,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -17311,7 +17468,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -17324,7 +17481,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -17334,17 +17491,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17364,7 +17521,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17381,13 +17538,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17410,7 +17567,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17433,14 +17590,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17460,7 +17617,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17477,13 +17634,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17506,7 +17663,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17529,14 +17686,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17556,7 +17713,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17573,13 +17730,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17602,7 +17759,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17625,14 +17782,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17652,7 +17809,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17669,13 +17826,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17698,7 +17855,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17721,14 +17878,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17748,7 +17905,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17768,14 +17925,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17795,7 +17952,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17812,13 +17969,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17841,7 +17998,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17864,14 +18021,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17891,7 +18048,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17908,13 +18065,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17937,7 +18094,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17960,14 +18117,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17987,7 +18144,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -18004,13 +18161,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -18033,7 +18190,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -18065,20 +18222,18 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
 exports[`Snapshots Report render with summary table and no logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-RcBXQ dhnDzi"
+    className="sc-kZmsYB exKuiO"
     id="report-page"
   >
     <article
-      className="sc-bxivhb cEKEIA"
+      className="sc-bxivhb csPkxY"
     >
       <div
-        className="sc-ifAKCX kNbSqy"
+        className="sc-ifAKCX ieKocY"
       >
-        <div
-          className="sc-EHOje jvzENE"
-        >
+        <div>
           <div
-            className="sc-bZQynM kUBhSG"
+            className="sc-EHOje dClLkx"
           >
             <span
               style={
@@ -18091,7 +18246,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               }
             >
               <h1
-                className="sc-gzVnrw jABNwW"
+                className="sc-bZQynM lckfgS"
               >
                 Weekly Sync Report
               </h1>
@@ -18100,7 +18255,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   Object {
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
-                    "fontSize": "1.5rem",
+                    "fontSize": "1rem",
                     "fontWeight": 700,
                   }
                 }
@@ -18113,27 +18268,38 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   February 25, 2018
                 </span>
               </span>
-              <h2
-                className="sc-htoDjs eoFwiH"
-              >
-                Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
-              </h2>
             </span>
           </div>
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            <h2
+              className="sc-gzVnrw dkdfDA"
+            >
+              Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
+            </h2>
+          </span>
         </div>
       </div>
     </article>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -18150,13 +18316,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-caSCKo mUdMp"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-jlyJG jGwGPa"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -18223,7 +18389,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-gisBJw feZXCW"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -18236,7 +18402,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-fAjcbJ kjdNkf"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -18246,17 +18412,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-esjQYD edlJEc"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18276,7 +18442,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18293,13 +18459,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18322,7 +18488,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18345,14 +18511,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18372,7 +18538,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18389,13 +18555,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18418,7 +18584,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18441,14 +18607,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18468,7 +18634,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18485,13 +18651,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18514,7 +18680,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18537,14 +18703,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18564,7 +18730,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18581,13 +18747,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18610,7 +18776,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18633,14 +18799,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18660,7 +18826,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18680,14 +18846,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18707,7 +18873,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18724,13 +18890,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18753,7 +18919,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18776,14 +18942,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18803,7 +18969,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18820,13 +18986,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18849,7 +19015,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18872,14 +19038,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18899,7 +19065,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18916,13 +19082,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18945,7 +19111,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18970,16 +19136,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -18996,13 +19162,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-caSCKo mUdMp"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-jlyJG jGwGPa"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -19069,7 +19235,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-gisBJw feZXCW"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -19082,7 +19248,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-fAjcbJ kjdNkf"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -19092,17 +19258,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-esjQYD edlJEc"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19122,7 +19288,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19139,13 +19305,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19168,7 +19334,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19191,14 +19357,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19218,7 +19384,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19235,13 +19401,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19264,7 +19430,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19287,14 +19453,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19314,7 +19480,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19331,13 +19497,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19360,7 +19526,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19383,14 +19549,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19410,7 +19576,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19427,13 +19593,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19456,7 +19622,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19479,14 +19645,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19506,7 +19672,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19526,14 +19692,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19553,7 +19719,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19570,13 +19736,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19599,7 +19765,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19622,14 +19788,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19649,7 +19815,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19666,13 +19832,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19695,7 +19861,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19718,14 +19884,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19745,7 +19911,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19762,13 +19928,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19791,7 +19957,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19816,16 +19982,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-cooIXK kpIZvP"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-kZmsYB gzISiG"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-fcdeBU kOrOHM"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-bRBYWo loIEUc"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -19842,13 +20008,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-gmeYpB danrEB"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-caSCKo mUdMp"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-jlyJG jGwGPa"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -19915,7 +20081,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-gisBJw feZXCW"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -19928,7 +20094,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-fAjcbJ kjdNkf"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -19938,17 +20104,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-esjQYD edlJEc"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19968,7 +20134,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19985,13 +20151,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20014,7 +20180,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20037,14 +20203,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20064,7 +20230,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20081,13 +20247,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20110,7 +20276,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20133,14 +20299,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20160,7 +20326,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20177,13 +20343,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20206,7 +20372,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20229,14 +20395,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20256,7 +20422,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20273,13 +20439,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20302,7 +20468,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20325,14 +20491,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20352,7 +20518,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20372,14 +20538,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20399,7 +20565,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20416,13 +20582,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20445,7 +20611,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20468,14 +20634,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20495,7 +20661,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20512,13 +20678,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20541,7 +20707,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20564,14 +20730,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-cvbbAY ctiTdI"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-brqgnP gQlgjS"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-eHgmQL kfCLXo"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20591,7 +20757,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-cMljjf eoqHoj"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20608,13 +20774,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kkGfuU hPRlqQ"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-iAyFgw eDsNSv"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-kEYyzF hLqtyz"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20637,7 +20803,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-hSdWYo kVzqVH"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20662,7 +20828,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <div
-      className="sc-hgHYgh dnbQMm"
+      className="sc-kasBVs bedwKD"
     />
   </div>
 </span>
@@ -20671,14 +20837,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
 exports[`Snapshots Report render with summary table, no logo and no description 1`] = `
 <span>
   <section
-    className="sc-eInJlc cGRvgw"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-RcBXQ dhnDzi"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-iSDuPN cToSdI"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -20691,16 +20857,16 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           }
         >
           <div
-            className="sc-jXQZqI eyRUMp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-fjdhpX iPdpdv"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jzJRlG lgArNv"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-chPdSV egNpeK"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -20730,7 +20896,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               </div>
             </div>
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -20785,7 +20951,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               }
             >
               <h1
-                className="sc-fZwumE gpUNMp"
+                className="sc-iSDuPN jSvqTR"
               >
                 Weekly Sync Report New
               </h1>
@@ -20810,10 +20976,10 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </span>
           </span>
           <div
-            className="sc-etwtAo imoISm"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-iGPElx ekHhUl"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -20869,7 +21035,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             >
               
               <h2
-                className="sc-clNaTc bOojmx"
+                className="sc-fQejPQ gXGPsM"
               >
                 Add report description
               </h2>
@@ -20878,16 +21044,16 @@ exports[`Snapshots Report render with summary table, no logo and no description 
         </span>
       </div>
       <section
-        className="sc-cooIXK vBgCb"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-kZmsYB gzISiG"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-fcdeBU kOrOHM"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-bRBYWo loIEUc"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -21079,13 +21245,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </aside>
           </div>
           <div
-            className="sc-gmeYpB danrEB"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-caSCKo mUdMp"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-jlyJG jGwGPa"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -21152,7 +21318,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </div>
               </div>
               <div
-                className="sc-gisBJw feZXCW"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -21165,7 +21331,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   }
                 >
                   <span
-                    className="sc-fAjcbJ kjdNkf"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -21175,17 +21341,17 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           </div>
         </div>
         <ul
-          className="sc-esjQYD edlJEc"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21205,7 +21371,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21222,13 +21388,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21251,7 +21417,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21274,14 +21440,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21301,7 +21467,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21318,13 +21484,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21347,7 +21513,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21370,14 +21536,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21397,7 +21563,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21414,13 +21580,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21443,7 +21609,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21466,14 +21632,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21493,7 +21659,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21510,13 +21676,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21539,7 +21705,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21562,14 +21728,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21589,7 +21755,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21609,14 +21775,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21636,7 +21802,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21653,13 +21819,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21682,7 +21848,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21705,14 +21871,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21732,7 +21898,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21749,13 +21915,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21778,7 +21944,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21801,14 +21967,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-cvbbAY ctiTdI"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-brqgnP gQlgjS"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-eHgmQL kfCLXo"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21828,7 +21994,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-cMljjf eoqHoj"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21845,13 +22011,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kkGfuU hPRlqQ"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-iAyFgw eDsNSv"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-kEYyzF hLqtyz"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21874,7 +22040,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-hSdWYo kVzqVH"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21906,13 +22072,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
 exports[`Snapshots Report renders loading whilst exporting 1`] = `
 <span>
   <div
-    className="sc-kasBVs fyXeDD"
+    className="sc-iGPElx hIwNUa"
   >
     <div
-      className="sc-dxgOiQ fYkxwK"
+      className="sc-kpOJdX dpBkoP"
     >
       <div
-        className="sc-kpOJdX hBXaqU"
+        className="sc-kGXeez jgBcBL"
       >
         <div
           style={

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -543,13 +543,13 @@ exports[`Snapshots ChartEditButtons they render 1`] = `
 exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
 <span>
   <section
-    className="sc-htoDjs jNHMKJ"
+    className="sc-dnqmqq gjnmZE"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -565,11 +565,6 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
                 }
               }
             >
-              <img
-                alt="Weekly Sync Report"
-                className="sc-gzVnrw fIxqHo"
-                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
-              />
               <h1
                 className="sc-EHOje jrTCNW"
               >
@@ -581,7 +576,7 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -589,9 +584,18 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
                  to 
                 February 25, 2018
               </span>
+              
             </span>
           </div>
-          
+          <div
+            className="sc-gzVnrw FpkGo"
+          >
+            <img
+              alt="Weekly Sync Report"
+              className="sc-htoDjs syfgG"
+              src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
+            />
+          </div>
         </div>
       </div>
     </article>
@@ -602,13 +606,13 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
 exports[`Snapshots Cover renders a cover with logo, name, date and description 1`] = `
 <span>
   <section
-    className="sc-htoDjs jNHMKJ"
+    className="sc-dnqmqq gjnmZE"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -624,11 +628,6 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                 }
               }
             >
-              <img
-                alt="Weekly Sync Report"
-                className="sc-gzVnrw fIxqHo"
-                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
-              />
               <h1
                 className="sc-EHOje jrTCNW"
               >
@@ -640,7 +639,7 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -648,24 +647,22 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                  to 
                 February 25, 2018
               </span>
+              <h2
+                className="sc-bZQynM dTUqdE"
+              >
+                This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
+              </h2>
             </span>
           </div>
-          <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "1rem",
-                "fontWeight": 400,
-              }
-            }
+          <div
+            className="sc-gzVnrw FpkGo"
           >
-            <h2
-              className="sc-bZQynM hlVgYy"
-            >
-              This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
-            </h2>
-          </span>
+            <img
+              alt="Weekly Sync Report"
+              className="sc-htoDjs syfgG"
+              src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
+            />
+          </div>
         </div>
       </div>
     </article>
@@ -676,13 +673,13 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
 exports[`Snapshots Cover renders a cover with name and date 1`] = `
 <span>
   <section
-    className="sc-htoDjs jNHMKJ"
+    className="sc-dnqmqq gjnmZE"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -709,7 +706,7 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -717,9 +714,9 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
                  to 
                 February 25, 2018
               </span>
+              
             </span>
           </div>
-          
         </div>
       </div>
     </article>
@@ -730,13 +727,13 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
 exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
 <span>
   <section
-    className="sc-htoDjs jNHMKJ"
+    className="sc-dnqmqq gjnmZE"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -763,7 +760,7 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -771,24 +768,13 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
                  to 
                 February 25, 2018
               </span>
+              <h2
+                className="sc-bZQynM dTUqdE"
+              >
+                This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
+              </h2>
             </span>
           </div>
-          <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "1rem",
-                "fontWeight": 400,
-              }
-            }
-          >
-            <h2
-              className="sc-bZQynM hlVgYy"
-            >
-              This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
-            </h2>
-          </span>
         </div>
       </div>
     </article>
@@ -804,7 +790,7 @@ exports[`Snapshots DateRange renders the date range 1`] = `
         "color": "#000",
         "fontFamily": "\\"Roboto\\", sans-serif",
         "fontSize": "1rem",
-        "fontWeight": 500,
+        "fontWeight": 600,
       }
     }
   >
@@ -823,7 +809,7 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
         "color": "#000",
         "fontFamily": "\\"Roboto\\", sans-serif",
         "fontSize": "1rem",
-        "fontWeight": 500,
+        "fontWeight": 600,
       }
     }
   >
@@ -837,12 +823,12 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
 exports[`Snapshots EditDescription renders the edit description text box 1`] = `
 <span>
   <form
-    className="sc-dnqmqq hGddsQ"
+    className="sc-iwsKbI mLnRN"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-iwsKbI jYSBRk"
+      className="sc-gZMcBi fpDrjl"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test report description"
@@ -854,12 +840,12 @@ exports[`Snapshots EditDescription renders the edit description text box 1`] = `
 exports[`Snapshots EditTitle renders the edit title text box 1`] = `
 <span>
   <form
-    className="sc-gZMcBi dSqFpM"
+    className="sc-gqjmRU liZjsx"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-gqjmRU hieDIv"
+      className="sc-VigVT iPxSok"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test Report"
@@ -896,7 +882,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
     }
   >
     <div
-      className="sc-VigVT hcpnyU"
+      className="sc-jTzLTM fXZkZI"
     >
       <button
         aria-label={null}
@@ -927,7 +913,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
         }
       >
         <span
-          className="sc-chPdSV fOLfpE"
+          className="sc-kgoBCf byUlgs"
         >
           <svg
             height="100%"
@@ -973,7 +959,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
     }
   >
     <div
-      className="sc-VigVT hcpnyU"
+      className="sc-jTzLTM fXZkZI"
     >
       <button
         aria-label={null}
@@ -1004,7 +990,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
         }
       >
         <span
-          className="sc-chPdSV fOLfpE"
+          className="sc-kgoBCf byUlgs"
         >
           <svg
             height="100%"
@@ -1050,13 +1036,13 @@ exports[`Snapshots LogoUpload renders no logo image upload box 1`] = `
     }
   >
     <div
-      className="sc-VigVT hcpnyU"
+      className="sc-jTzLTM fXZkZI"
     >
       <div
-        className="sc-jTzLTM kEHBFa"
+        className="sc-fjdhpX LgDyd"
       >
         <span
-          className="sc-cSHVUG dcBfFr"
+          className="sc-kAzzGY gMJrTE"
         >
           <span
             style={
@@ -1102,16 +1088,16 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
     }
   >
     <div
-      className="sc-VigVT hcpnyU"
+      className="sc-jTzLTM fXZkZI"
     >
       <div
-        className="sc-jTzLTM kEHBFa"
+        className="sc-fjdhpX LgDyd"
       >
         <span
-          className="sc-cSHVUG dcBfFr"
+          className="sc-kAzzGY gMJrTE"
         />
         <span
-          className="sc-kAzzGY egQMhq"
+          className="sc-chPdSV gccHCf"
         >
           <span
             style={
@@ -1135,13 +1121,13 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
 exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 <span>
   <div
-    className="sc-caSCKo lZocL"
+    className="sc-gisBJw cCWpwM"
   >
     <span
-      className="sc-eqIVtm ixzlzR"
+      className="sc-fAjcbJ fclNrM"
     >
       <div
-        className="sc-gPEVay eFShNV"
+        className="sc-iRbamj kNGkEx"
         size="16px"
       >
         <img
@@ -1208,7 +1194,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-fAjcbJ jYwFjC"
+        className="sc-caSCKo dBUfBz"
       >
         <span
           style={
@@ -1221,7 +1207,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-dVhcbM KPvEY"
+            className="sc-eqIVtm ecxnvs"
           >
             @moreofmorris
           </span>
@@ -1229,10 +1215,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-eqIVtm ixzlzR"
+      className="sc-fAjcbJ fclNrM"
     >
       <div
-        className="sc-gPEVay eFShNV"
+        className="sc-iRbamj kNGkEx"
         size="16px"
       >
         <img
@@ -1299,7 +1285,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-fAjcbJ jYwFjC"
+        className="sc-caSCKo dBUfBz"
       >
         <span
           style={
@@ -1312,7 +1298,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-dVhcbM KPvEY"
+            className="sc-eqIVtm ecxnvs"
           >
             @roughquest
           </span>
@@ -1320,10 +1306,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-eqIVtm ixzlzR"
+      className="sc-fAjcbJ fclNrM"
     >
       <div
-        className="sc-gPEVay eFShNV"
+        className="sc-iRbamj kNGkEx"
         size="16px"
       >
         <img
@@ -1390,7 +1376,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-fAjcbJ jYwFjC"
+        className="sc-caSCKo dBUfBz"
       >
         <span
           style={
@@ -1403,7 +1389,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-dVhcbM KPvEY"
+            className="sc-eqIVtm ecxnvs"
           >
             Roughquest
           </span>
@@ -1417,10 +1403,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 <span>
   <span
-    className="sc-eqIVtm ixzlzR"
+    className="sc-fAjcbJ fclNrM"
   >
     <div
-      className="sc-gPEVay eFShNV"
+      className="sc-iRbamj kNGkEx"
       size="16px"
     >
       <img
@@ -1487,7 +1473,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
       </div>
     </div>
     <div
-      className="sc-fAjcbJ jYwFjC"
+      className="sc-caSCKo dBUfBz"
     >
       <span
         style={
@@ -1500,7 +1486,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
         }
       >
         <span
-          className="sc-dVhcbM KPvEY"
+          className="sc-eqIVtm ecxnvs"
         >
           @moreofmorris
         </span>
@@ -1513,14 +1499,14 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 exports[`Snapshots Report render in description edit mode 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-gmeYpB hETgOf"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-kZmsYB putUk"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -1533,16 +1519,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           }
         >
           <div
-            className="sc-clNaTc fkjCIp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-VigVT hcpnyU"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jTzLTM kEHBFa"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-cSHVUG dcBfFr"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -1572,7 +1558,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               </div>
             </div>
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -1627,7 +1613,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               }
             >
               <h1
-                className="sc-RcBXQ ljXeou"
+                className="sc-iSDuPN hvxUgq"
               >
                 Weekly Sync Report
               </h1>
@@ -1639,7 +1625,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 500,
+                "fontWeight": 600,
               }
             }
           >
@@ -1648,12 +1634,12 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             February 25, 2018
           </span>
           <form
-            className="sc-dnqmqq hGddsQ"
+            className="sc-iwsKbI mLnRN"
             onSubmit={[Function]}
           >
             <input
               autoFocus={true}
-              className="sc-iwsKbI jYSBRk"
+              className="sc-gZMcBi fpDrjl"
               onBlur={[Function]}
               onChange={[Function]}
               value="Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work."
@@ -1662,16 +1648,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -1863,13 +1849,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -1936,7 +1922,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -1949,7 +1935,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -1959,17 +1945,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -1989,7 +1975,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2006,13 +1992,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2035,7 +2021,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2058,14 +2044,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2085,7 +2071,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2102,13 +2088,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2131,7 +2117,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2154,14 +2140,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2181,7 +2167,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2198,13 +2184,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2227,7 +2213,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2250,14 +2236,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2277,7 +2263,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2294,13 +2280,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2323,7 +2309,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2346,14 +2332,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2373,7 +2359,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2393,14 +2379,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2420,7 +2406,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2437,13 +2423,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2466,7 +2452,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2489,14 +2475,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2516,7 +2502,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2533,13 +2519,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2562,7 +2548,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2585,14 +2571,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -2612,7 +2598,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -2629,13 +2615,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -2658,7 +2644,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -2683,16 +2669,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -2884,13 +2870,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -2957,7 +2943,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -2970,7 +2956,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -2980,17 +2966,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3010,7 +2996,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3027,13 +3013,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3056,7 +3042,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3079,14 +3065,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3106,7 +3092,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3123,13 +3109,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3152,7 +3138,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3175,14 +3161,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3202,7 +3188,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3219,13 +3205,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3248,7 +3234,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3271,14 +3257,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3298,7 +3284,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3315,13 +3301,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3344,7 +3330,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3367,14 +3353,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3394,7 +3380,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3414,14 +3400,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3441,7 +3427,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3458,13 +3444,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3487,7 +3473,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3510,14 +3496,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3537,7 +3523,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3554,13 +3540,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3583,7 +3569,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3606,14 +3592,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -3633,7 +3619,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -3650,13 +3636,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -3679,7 +3665,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -3704,16 +3690,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -3905,13 +3891,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -3978,7 +3964,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -3991,7 +3977,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -4001,17 +3987,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4031,7 +4017,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4048,13 +4034,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4077,7 +4063,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4100,14 +4086,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4127,7 +4113,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4144,13 +4130,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4173,7 +4159,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4196,14 +4182,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4223,7 +4209,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4240,13 +4226,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4269,7 +4255,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4292,14 +4278,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4319,7 +4305,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4336,13 +4322,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4365,7 +4351,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4388,14 +4374,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4415,7 +4401,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4435,14 +4421,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4462,7 +4448,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4479,13 +4465,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4508,7 +4494,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4531,14 +4517,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4558,7 +4544,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4575,13 +4561,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4604,7 +4590,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4627,14 +4613,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -4654,7 +4640,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -4671,13 +4657,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -4700,7 +4686,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -4732,14 +4718,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
 exports[`Snapshots Report render in title edit mode 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-gmeYpB hETgOf"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-kZmsYB putUk"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -4752,12 +4738,12 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           }
         >
           <form
-            className="sc-gZMcBi dSqFpM"
+            className="sc-gqjmRU liZjsx"
             onSubmit={[Function]}
           >
             <input
               autoFocus={true}
-              className="sc-gqjmRU hieDIv"
+              className="sc-VigVT iPxSok"
               onBlur={[Function]}
               onChange={[Function]}
               value="Weekly Sync Report"
@@ -4769,7 +4755,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 500,
+                "fontWeight": 600,
               }
             }
           >
@@ -4778,10 +4764,10 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             February 25, 2018
           </span>
           <div
-            className="sc-fQejPQ iHNcjH"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -4836,7 +4822,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               }
             >
               <h2
-                className="sc-iSDuPN hbyslV"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -4845,16 +4831,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -5046,13 +5032,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -5119,7 +5105,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -5132,7 +5118,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -5142,17 +5128,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5172,7 +5158,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5189,13 +5175,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5218,7 +5204,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5241,14 +5227,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5268,7 +5254,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5285,13 +5271,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5314,7 +5300,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5337,14 +5323,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5364,7 +5350,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5381,13 +5367,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5410,7 +5396,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5433,14 +5419,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5460,7 +5446,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5477,13 +5463,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5506,7 +5492,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5529,14 +5515,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5556,7 +5542,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5576,14 +5562,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5603,7 +5589,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5620,13 +5606,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5649,7 +5635,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5672,14 +5658,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5699,7 +5685,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5716,13 +5702,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5745,7 +5731,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5768,14 +5754,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -5795,7 +5781,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -5812,13 +5798,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -5841,7 +5827,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -5866,16 +5852,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -6067,13 +6053,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -6140,7 +6126,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -6153,7 +6139,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -6163,17 +6149,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6193,7 +6179,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6210,13 +6196,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6239,7 +6225,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6262,14 +6248,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6289,7 +6275,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6306,13 +6292,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6335,7 +6321,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6358,14 +6344,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6385,7 +6371,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6402,13 +6388,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6431,7 +6417,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6454,14 +6440,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6481,7 +6467,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6498,13 +6484,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6527,7 +6513,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6550,14 +6536,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6577,7 +6563,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6597,14 +6583,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6624,7 +6610,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6641,13 +6627,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6670,7 +6656,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6693,14 +6679,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6720,7 +6706,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6737,13 +6723,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6766,7 +6752,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6789,14 +6775,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -6816,7 +6802,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -6833,13 +6819,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -6862,7 +6848,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -6887,16 +6873,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -7088,13 +7074,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -7161,7 +7147,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -7174,7 +7160,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -7184,17 +7170,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7214,7 +7200,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7231,13 +7217,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7260,7 +7246,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7283,14 +7269,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7310,7 +7296,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7327,13 +7313,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7356,7 +7342,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7379,14 +7365,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7406,7 +7392,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7423,13 +7409,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7452,7 +7438,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7475,14 +7461,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7502,7 +7488,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7519,13 +7505,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7548,7 +7534,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7571,14 +7557,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7598,7 +7584,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7618,14 +7604,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7645,7 +7631,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7662,13 +7648,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7691,7 +7677,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7714,14 +7700,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7741,7 +7727,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7758,13 +7744,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7787,7 +7773,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7810,14 +7796,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -7837,7 +7823,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -7854,13 +7840,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -7883,7 +7869,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -7915,16 +7901,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
 exports[`Snapshots Report render loading 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-jXQZqI fPoiYy"
+      className="sc-iGPElx hIwNUa"
     >
       <div
-        className="sc-kGXeez iJENgK"
+        className="sc-kpOJdX dpBkoP"
       >
         <div
-          className="sc-kgoBCf fEHafe"
+          className="sc-kGXeez jgBcBL"
         >
           <div
             style={
@@ -8006,14 +7992,14 @@ exports[`Snapshots Report render loading 1`] = `
 exports[`Snapshots Report render only the multi-profile legend if that is available 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-gmeYpB hETgOf"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-kZmsYB putUk"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -8026,16 +8012,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           }
         >
           <div
-            className="sc-clNaTc fkjCIp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-VigVT hcpnyU"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jTzLTM kEHBFa"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-cSHVUG dcBfFr"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -8065,7 +8051,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               </div>
             </div>
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -8120,7 +8106,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-RcBXQ ljXeou"
+                className="sc-iSDuPN hvxUgq"
               >
                 Weekly Sync Report
               </h1>
@@ -8132,7 +8118,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 500,
+                "fontWeight": 600,
               }
             }
           >
@@ -8141,10 +8127,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             February 25, 2018
           </span>
           <div
-            className="sc-fQejPQ iHNcjH"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -8199,7 +8185,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h2
-                className="sc-iSDuPN hbyslV"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
               </h2>
@@ -8208,16 +8194,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </span>
       </div>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -8410,16 +8396,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <div
-              className="sc-caSCKo lZocL"
+              className="sc-gisBJw cCWpwM"
             >
               <span
-                className="sc-eqIVtm ixzlzR"
+                className="sc-fAjcbJ fclNrM"
               >
                 <div
-                  className="sc-gPEVay eFShNV"
+                  className="sc-iRbamj kNGkEx"
                   size="16px"
                 >
                   <img
@@ -8486,7 +8472,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-fAjcbJ jYwFjC"
+                  className="sc-caSCKo dBUfBz"
                 >
                   <span
                     style={
@@ -8499,7 +8485,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-dVhcbM KPvEY"
+                      className="sc-eqIVtm ecxnvs"
                     >
                       @buffer
                     </span>
@@ -8507,10 +8493,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </span>
               <span
-                className="sc-eqIVtm ixzlzR"
+                className="sc-fAjcbJ fclNrM"
               >
                 <div
-                  className="sc-gPEVay eFShNV"
+                  className="sc-iRbamj kNGkEx"
                   size="16px"
                 >
                   <img
@@ -8592,7 +8578,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-fAjcbJ jYwFjC"
+                  className="sc-caSCKo dBUfBz"
                 >
                   <span
                     style={
@@ -8605,7 +8591,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-dVhcbM KPvEY"
+                      className="sc-eqIVtm ecxnvs"
                     >
                       buffer
                     </span>
@@ -8616,16 +8602,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </div>
         </div>
         <div
-          className="sc-kpOJdX dNTKpM"
+          className="sc-dxgOiQ ckNOOu"
         >
           <div
-            className="sc-dxgOiQ cJLLMr"
+            className="sc-ckVGcZ YJXtP"
           >
             <div
-              className="sc-ckVGcZ hoOcak"
+              className="sc-jKJlTe bWRyvh"
             />
             <h1
-              className="sc-jKJlTe cVHNsT"
+              className="sc-eNQAEJ dYjNXW"
             >
               <span
                 style={
@@ -8651,14 +8637,14 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render only the multi-profile legend if that is available whilst exporting 1`] = `
 <span>
   <div
-    className="sc-gmeYpB hETgOf"
+    className="sc-kZmsYB exKuiO"
     id="report-page"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -8685,7 +8671,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -8693,38 +8679,27 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                  to 
                 February 25, 2018
               </span>
+              <h2
+                className="sc-bZQynM dTUqdE"
+              >
+                Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
+              </h2>
             </span>
           </div>
-          <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "1rem",
-                "fontWeight": 400,
-              }
-            }
-          >
-            <h2
-              className="sc-bZQynM hlVgYy"
-            >
-              Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
-            </h2>
-          </span>
         </div>
       </div>
     </article>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -8742,16 +8717,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <div
-            className="sc-caSCKo lZocL"
+            className="sc-gisBJw cCWpwM"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -8818,7 +8793,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -8831,7 +8806,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     @buffer
                   </span>
@@ -8839,10 +8814,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               </div>
             </span>
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -8924,7 +8899,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -8937,7 +8912,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     buffer
                   </span>
@@ -8948,16 +8923,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </div>
       </div>
       <div
-        className="sc-kpOJdX dNTKpM"
+        className="sc-dxgOiQ ckNOOu"
       >
         <div
-          className="sc-dxgOiQ cJLLMr"
+          className="sc-ckVGcZ YJXtP"
         >
           <div
-            className="sc-ckVGcZ hoOcak"
+            className="sc-jKJlTe bWRyvh"
           />
           <h1
-            className="sc-jKJlTe cVHNsT"
+            className="sc-eNQAEJ dYjNXW"
           >
             <span
               style={
@@ -8976,7 +8951,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
       </div>
     </section>
     <div
-      className="sc-iGPElx eSNuwW"
+      className="sc-kasBVs bedwKD"
     />
   </div>
 </span>
@@ -8985,14 +8960,14 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render with summary table and logo 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-gmeYpB hETgOf"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-kZmsYB putUk"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -9005,10 +8980,10 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           }
         >
           <div
-            className="sc-clNaTc fkjCIp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-VigVT hcpnyU"
+              className="sc-jTzLTM fXZkZI"
             >
               <button
                 aria-label={null}
@@ -9039,7 +9014,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 }
               >
                 <span
-                  className="sc-chPdSV fOLfpE"
+                  className="sc-kgoBCf byUlgs"
                 >
                   <svg
                     height="100%"
@@ -9069,7 +9044,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               </button>
             </div>
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -9124,7 +9099,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h1
-                className="sc-RcBXQ ljXeou"
+                className="sc-iSDuPN hvxUgq"
               >
                 Weekly Sync Report
               </h1>
@@ -9136,7 +9111,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 500,
+                "fontWeight": 600,
               }
             }
           >
@@ -9145,10 +9120,10 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             February 25, 2018
           </span>
           <div
-            className="sc-fQejPQ iHNcjH"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -9203,7 +9178,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h2
-                className="sc-iSDuPN hbyslV"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -9212,16 +9187,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -9413,13 +9388,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -9486,7 +9461,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -9499,7 +9474,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -9509,17 +9484,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9539,7 +9514,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9556,13 +9531,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9585,7 +9560,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9608,14 +9583,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9635,7 +9610,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9652,13 +9627,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9681,7 +9656,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9704,14 +9679,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9731,7 +9706,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9748,13 +9723,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9777,7 +9752,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9800,14 +9775,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9827,7 +9802,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9844,13 +9819,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -9873,7 +9848,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -9896,14 +9871,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9923,7 +9898,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9943,14 +9918,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -9970,7 +9945,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -9987,13 +9962,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10016,7 +9991,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10039,14 +10014,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10066,7 +10041,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10083,13 +10058,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10112,7 +10087,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10135,14 +10110,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10162,7 +10137,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10179,13 +10154,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10208,7 +10183,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10233,16 +10208,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -10434,13 +10409,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -10507,7 +10482,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -10520,7 +10495,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -10530,17 +10505,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10560,7 +10535,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10577,13 +10552,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10606,7 +10581,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10629,14 +10604,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10656,7 +10631,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10673,13 +10648,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10702,7 +10677,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10725,14 +10700,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10752,7 +10727,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10769,13 +10744,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10798,7 +10773,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10821,14 +10796,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10848,7 +10823,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10865,13 +10840,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -10894,7 +10869,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -10917,14 +10892,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10944,7 +10919,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -10964,14 +10939,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -10991,7 +10966,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11008,13 +10983,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11037,7 +11012,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11060,14 +11035,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11087,7 +11062,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11104,13 +11079,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11133,7 +11108,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11156,14 +11131,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11183,7 +11158,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11200,13 +11175,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11229,7 +11204,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11254,16 +11229,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -11455,13 +11430,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -11528,7 +11503,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -11541,7 +11516,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -11551,17 +11526,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11581,7 +11556,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11598,13 +11573,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11627,7 +11602,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11650,14 +11625,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11677,7 +11652,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11694,13 +11669,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11723,7 +11698,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11746,14 +11721,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11773,7 +11748,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11790,13 +11765,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11819,7 +11794,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11842,14 +11817,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11869,7 +11844,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11886,13 +11861,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -11915,7 +11890,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -11938,14 +11913,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -11965,7 +11940,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -11985,14 +11960,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -12012,7 +11987,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -12029,13 +12004,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -12058,7 +12033,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -12081,14 +12056,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -12108,7 +12083,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -12125,13 +12100,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -12154,7 +12129,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -12177,14 +12152,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -12204,7 +12179,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -12221,13 +12196,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -12250,7 +12225,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -12282,14 +12257,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
 exports[`Snapshots Report render with summary table and logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-gmeYpB hETgOf"
+    className="sc-kZmsYB exKuiO"
     id="report-page"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -12305,11 +12280,6 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               }
             >
-              <img
-                alt="Weekly Sync Report"
-                className="sc-gzVnrw fIxqHo"
-                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
-              />
               <h1
                 className="sc-EHOje jrTCNW"
               >
@@ -12321,7 +12291,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -12329,38 +12299,36 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                  to 
                 February 25, 2018
               </span>
+              <h2
+                className="sc-bZQynM dTUqdE"
+              >
+                Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
+              </h2>
             </span>
           </div>
-          <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "1rem",
-                "fontWeight": 400,
-              }
-            }
+          <div
+            className="sc-gzVnrw FpkGo"
           >
-            <h2
-              className="sc-bZQynM hlVgYy"
-            >
-              Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
-            </h2>
-          </span>
+            <img
+              alt="Weekly Sync Report"
+              className="sc-htoDjs syfgG"
+              src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+            />
+          </div>
         </div>
       </div>
     </article>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -12377,13 +12345,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-eqIVtm ixzlzR"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-gPEVay eFShNV"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -12450,7 +12418,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-fAjcbJ jYwFjC"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -12463,7 +12431,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-dVhcbM KPvEY"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -12473,17 +12441,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-kPVwWT ksBtpo"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12503,7 +12471,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12520,13 +12488,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12549,7 +12517,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12572,14 +12540,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12599,7 +12567,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12616,13 +12584,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12645,7 +12613,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12668,14 +12636,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12695,7 +12663,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12712,13 +12680,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12741,7 +12709,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12764,14 +12732,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12791,7 +12759,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12808,13 +12776,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12837,7 +12805,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -12860,14 +12828,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12887,7 +12855,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12907,14 +12875,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -12934,7 +12902,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -12951,13 +12919,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -12980,7 +12948,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13003,14 +12971,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13030,7 +12998,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13047,13 +13015,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13076,7 +13044,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13099,14 +13067,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13126,7 +13094,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13143,13 +13111,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13172,7 +13140,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13197,16 +13165,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -13223,13 +13191,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-eqIVtm ixzlzR"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-gPEVay eFShNV"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -13296,7 +13264,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-fAjcbJ jYwFjC"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -13309,7 +13277,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-dVhcbM KPvEY"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -13319,17 +13287,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-kPVwWT ksBtpo"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13349,7 +13317,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13366,13 +13334,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13395,7 +13363,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13418,14 +13386,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13445,7 +13413,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13462,13 +13430,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13491,7 +13459,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13514,14 +13482,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13541,7 +13509,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13558,13 +13526,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13587,7 +13555,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13610,14 +13578,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13637,7 +13605,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13654,13 +13622,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13683,7 +13651,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13706,14 +13674,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13733,7 +13701,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13753,14 +13721,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13780,7 +13748,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13797,13 +13765,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13826,7 +13794,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13849,14 +13817,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13876,7 +13844,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13893,13 +13861,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -13922,7 +13890,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -13945,14 +13913,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -13972,7 +13940,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -13989,13 +13957,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14018,7 +13986,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14043,16 +14011,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -14069,13 +14037,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-eqIVtm ixzlzR"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-gPEVay eFShNV"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -14142,7 +14110,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-fAjcbJ jYwFjC"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -14155,7 +14123,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-dVhcbM KPvEY"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -14165,17 +14133,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-kPVwWT ksBtpo"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14195,7 +14163,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14212,13 +14180,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14241,7 +14209,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14264,14 +14232,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14291,7 +14259,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14308,13 +14276,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14337,7 +14305,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14360,14 +14328,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14387,7 +14355,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14404,13 +14372,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14433,7 +14401,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14456,14 +14424,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14483,7 +14451,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14500,13 +14468,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14529,7 +14497,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14552,14 +14520,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14579,7 +14547,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14599,14 +14567,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14626,7 +14594,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14643,13 +14611,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14672,7 +14640,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14695,14 +14663,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14722,7 +14690,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14739,13 +14707,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14768,7 +14736,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14791,14 +14759,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -14818,7 +14786,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -14835,13 +14803,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -14864,7 +14832,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -14889,7 +14857,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <div
-      className="sc-iGPElx eSNuwW"
+      className="sc-kasBVs bedwKD"
     />
   </div>
 </span>
@@ -14898,14 +14866,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
 exports[`Snapshots Report render with summary table and no logo 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-gmeYpB hETgOf"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-kZmsYB putUk"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -14918,16 +14886,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           }
         >
           <div
-            className="sc-clNaTc fkjCIp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-VigVT hcpnyU"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jTzLTM kEHBFa"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-cSHVUG dcBfFr"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -14957,7 +14925,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               </div>
             </div>
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -15012,7 +14980,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h1
-                className="sc-RcBXQ ljXeou"
+                className="sc-iSDuPN hvxUgq"
               >
                 Weekly Sync Report
               </h1>
@@ -15024,7 +14992,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 500,
+                "fontWeight": 600,
               }
             }
           >
@@ -15033,10 +15001,10 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             February 25, 2018
           </span>
           <div
-            className="sc-fQejPQ iHNcjH"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -15091,7 +15059,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h2
-                className="sc-iSDuPN hbyslV"
+                className="sc-fZwumE kMgtlM"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -15100,16 +15068,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -15301,13 +15269,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -15374,7 +15342,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -15387,7 +15355,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -15397,17 +15365,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15427,7 +15395,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15444,13 +15412,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15473,7 +15441,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15496,14 +15464,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15523,7 +15491,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15540,13 +15508,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15569,7 +15537,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15592,14 +15560,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15619,7 +15587,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15636,13 +15604,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15665,7 +15633,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15688,14 +15656,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15715,7 +15683,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15732,13 +15700,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15761,7 +15729,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15784,14 +15752,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15811,7 +15779,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15831,14 +15799,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15858,7 +15826,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15875,13 +15843,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -15904,7 +15872,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -15927,14 +15895,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -15954,7 +15922,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -15971,13 +15939,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16000,7 +15968,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16023,14 +15991,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16050,7 +16018,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16067,13 +16035,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16096,7 +16064,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16121,16 +16089,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -16322,13 +16290,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -16395,7 +16363,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -16408,7 +16376,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -16418,17 +16386,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16448,7 +16416,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16465,13 +16433,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16494,7 +16462,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16517,14 +16485,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16544,7 +16512,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16561,13 +16529,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16590,7 +16558,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16613,14 +16581,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16640,7 +16608,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16657,13 +16625,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16686,7 +16654,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16709,14 +16677,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16736,7 +16704,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16753,13 +16721,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16782,7 +16750,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16805,14 +16773,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16832,7 +16800,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16852,14 +16820,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16879,7 +16847,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16896,13 +16864,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -16925,7 +16893,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -16948,14 +16916,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -16975,7 +16943,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -16992,13 +16960,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17021,7 +16989,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17044,14 +17012,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17071,7 +17039,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17088,13 +17056,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17117,7 +17085,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17142,16 +17110,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -17343,13 +17311,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -17416,7 +17384,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -17429,7 +17397,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -17439,17 +17407,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17469,7 +17437,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17486,13 +17454,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17515,7 +17483,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17538,14 +17506,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17565,7 +17533,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17582,13 +17550,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17611,7 +17579,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17634,14 +17602,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17661,7 +17629,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17678,13 +17646,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17707,7 +17675,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17730,14 +17698,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17757,7 +17725,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17774,13 +17742,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17803,7 +17771,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17826,14 +17794,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17853,7 +17821,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17873,14 +17841,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17900,7 +17868,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -17917,13 +17885,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -17946,7 +17914,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -17969,14 +17937,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -17996,7 +17964,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -18013,13 +17981,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -18042,7 +18010,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -18065,14 +18033,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -18092,7 +18060,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -18109,13 +18077,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -18138,7 +18106,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -18170,14 +18138,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
 exports[`Snapshots Report render with summary table and no logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-gmeYpB hETgOf"
+    className="sc-kZmsYB exKuiO"
     id="report-page"
   >
     <article
       className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-bxivhb iizGgK"
+        className="sc-bxivhb YPjRx"
       >
         <div>
           <div
@@ -18204,7 +18172,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                     "color": "#000",
                     "fontFamily": "\\"Roboto\\", sans-serif",
                     "fontSize": "1rem",
-                    "fontWeight": 500,
+                    "fontWeight": 600,
                   }
                 }
               >
@@ -18212,38 +18180,27 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                  to 
                 February 25, 2018
               </span>
+              <h2
+                className="sc-bZQynM dTUqdE"
+              >
+                Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
+              </h2>
             </span>
           </div>
-          <span
-            style={
-              Object {
-                "color": "#59626a",
-                "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "1rem",
-                "fontWeight": 400,
-              }
-            }
-          >
-            <h2
-              className="sc-bZQynM hlVgYy"
-            >
-              Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
-            </h2>
-          </span>
         </div>
       </div>
     </article>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -18260,13 +18217,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-eqIVtm ixzlzR"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-gPEVay eFShNV"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -18333,7 +18290,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-fAjcbJ jYwFjC"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -18346,7 +18303,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-dVhcbM KPvEY"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -18356,17 +18313,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-kPVwWT ksBtpo"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18386,7 +18343,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18403,13 +18360,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18432,7 +18389,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18455,14 +18412,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18482,7 +18439,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18499,13 +18456,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18528,7 +18485,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18551,14 +18508,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18578,7 +18535,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18595,13 +18552,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18624,7 +18581,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18647,14 +18604,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18674,7 +18631,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18691,13 +18648,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18720,7 +18677,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18743,14 +18700,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18770,7 +18727,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18790,14 +18747,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18817,7 +18774,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18834,13 +18791,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18863,7 +18820,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18886,14 +18843,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -18913,7 +18870,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -18930,13 +18887,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -18959,7 +18916,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -18982,14 +18939,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19009,7 +18966,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19026,13 +18983,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19055,7 +19012,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19080,16 +19037,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -19106,13 +19063,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-eqIVtm ixzlzR"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-gPEVay eFShNV"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -19179,7 +19136,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-fAjcbJ jYwFjC"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -19192,7 +19149,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-dVhcbM KPvEY"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -19202,17 +19159,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-kPVwWT ksBtpo"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19232,7 +19189,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19249,13 +19206,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19278,7 +19235,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19301,14 +19258,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19328,7 +19285,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19345,13 +19302,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19374,7 +19331,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19397,14 +19354,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19424,7 +19381,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19441,13 +19398,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19470,7 +19427,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19493,14 +19450,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19520,7 +19477,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19537,13 +19494,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19566,7 +19523,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19589,14 +19546,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19616,7 +19573,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19636,14 +19593,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19663,7 +19620,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19680,13 +19637,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19709,7 +19666,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19732,14 +19689,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19759,7 +19716,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19776,13 +19733,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19805,7 +19762,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19828,14 +19785,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -19855,7 +19812,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -19872,13 +19829,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -19901,7 +19858,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -19926,16 +19883,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-chbbiW cEsOfO"
+      className="sc-kxynE hggGNg"
     >
       <div
-        className="sc-fcdeBU iNVTGA"
+        className="sc-gmeYpB iEJOnV"
       >
         <div
-          className="sc-kxynE Vtclv"
+          className="sc-cooIXK cYHYkl"
         >
           <h2
-            className="sc-csuQGl cMenPN"
+            className="sc-Rmtcm dMAMwK"
           >
             <span
               style={
@@ -19952,13 +19909,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-cooIXK bOVWWn"
+          className="sc-fcdeBU iOEEra"
         >
           <span
-            className="sc-eqIVtm ixzlzR"
+            className="sc-fAjcbJ fclNrM"
           >
             <div
-              className="sc-gPEVay eFShNV"
+              className="sc-iRbamj kNGkEx"
               size="16px"
             >
               <img
@@ -20025,7 +19982,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-fAjcbJ jYwFjC"
+              className="sc-caSCKo dBUfBz"
             >
               <span
                 style={
@@ -20038,7 +19995,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-dVhcbM KPvEY"
+                  className="sc-eqIVtm ecxnvs"
                 >
                   Buffer
                 </span>
@@ -20048,17 +20005,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-kPVwWT ksBtpo"
+        className="sc-kfGgVZ gNGxgR"
       >
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20078,7 +20035,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20095,13 +20052,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20124,7 +20081,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20147,14 +20104,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20174,7 +20131,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20191,13 +20148,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20220,7 +20177,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20243,14 +20200,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20270,7 +20227,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20287,13 +20244,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20316,7 +20273,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20339,14 +20296,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20366,7 +20323,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20383,13 +20340,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20412,7 +20369,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20435,14 +20392,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20462,7 +20419,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20482,14 +20439,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20509,7 +20466,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20526,13 +20483,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20555,7 +20512,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20578,14 +20535,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20605,7 +20562,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20622,13 +20579,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20651,7 +20608,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20674,14 +20631,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-hSdWYo hbZqqh"
+          className="sc-eHgmQL hUstPo"
           width="25%"
         >
           <div
-            className="sc-cvbbAY FpcGm"
+            className="sc-jWBwVP eBgsec"
           >
             <span
-              className="sc-iAyFgw acaZS"
+              className="sc-hSdWYo bpLJPs"
             >
               <span
                 data-tip={null}
@@ -20701,7 +20658,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-jWBwVP jFdhvt"
+              className="sc-brqgnP bPJvMT"
             >
               <span
                 style={
@@ -20718,13 +20675,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-hMqMXs idyYAP"
+                className="sc-kEYyzF cNZdMg"
               >
                 <div
-                  className="sc-kEYyzF cPIOVY"
+                  className="sc-kkGfuU hxFSCl"
                 >
                   <div
-                    className="sc-eNQAEJ uiKxp"
+                    className="sc-hMqMXs hwVpmX"
                   >
                     <svg
                       fill="none"
@@ -20747,7 +20704,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-kkGfuU dpSiAT"
+                  className="sc-iAyFgw kWLHyT"
                 >
                   <span
                     style={
@@ -20772,7 +20729,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <div
-      className="sc-iGPElx eSNuwW"
+      className="sc-kasBVs bedwKD"
     />
   </div>
 </span>
@@ -20781,14 +20738,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
 exports[`Snapshots Report render with summary table, no logo and no description 1`] = `
 <span>
   <section
-    className="sc-kasBVs hPMNkS"
+    className="sc-hgHYgh huVFeC"
   >
     <div
-      className="sc-gmeYpB hETgOf"
+      className="sc-kZmsYB exKuiO"
       id="report-page"
     >
       <div
-        className="sc-kZmsYB putUk"
+        className="sc-RcBXQ IZhjJ"
       >
         <span
           style={
@@ -20801,16 +20758,16 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           }
         >
           <div
-            className="sc-clNaTc fkjCIp"
+            className="sc-etwtAo eLnpad"
           >
             <div
-              className="sc-VigVT hcpnyU"
+              className="sc-jTzLTM fXZkZI"
             >
               <div
-                className="sc-jTzLTM kEHBFa"
+                className="sc-fjdhpX LgDyd"
               >
                 <span
-                  className="sc-cSHVUG dcBfFr"
+                  className="sc-kAzzGY gMJrTE"
                 >
                   <span
                     style={
@@ -20840,7 +20797,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               </div>
             </div>
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -20895,7 +20852,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               }
             >
               <h1
-                className="sc-RcBXQ ljXeou"
+                className="sc-iSDuPN hvxUgq"
               >
                 Weekly Sync Report New
               </h1>
@@ -20907,7 +20864,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 "color": "#000",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 500,
+                "fontWeight": 600,
               }
             }
           >
@@ -20916,10 +20873,10 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             February 25, 2018
           </span>
           <div
-            className="sc-fQejPQ iHNcjH"
+            className="sc-clNaTc iLQykU"
           >
             <div
-              className="sc-etwtAo kdVRkA"
+              className="sc-jXQZqI iBWNXq"
             >
               <svg
                 height="100%"
@@ -20975,7 +20932,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             >
               
               <h2
-                className="sc-fZwumE yKUcC"
+                className="sc-fQejPQ gXGPsM"
               >
                 Add report description
               </h2>
@@ -20984,16 +20941,16 @@ exports[`Snapshots Report render with summary table, no logo and no description 
         </span>
       </div>
       <section
-        className="sc-chbbiW gtGkqp"
+        className="sc-kxynE beYkXW"
       >
         <div
-          className="sc-fcdeBU iNVTGA"
+          className="sc-gmeYpB iEJOnV"
         >
           <div
-            className="sc-kxynE Vtclv"
+            className="sc-cooIXK cYHYkl"
           >
             <h2
-              className="sc-csuQGl cMenPN"
+              className="sc-Rmtcm dMAMwK"
             >
               <span
                 style={
@@ -21185,13 +21142,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </aside>
           </div>
           <div
-            className="sc-cooIXK bOVWWn"
+            className="sc-fcdeBU iOEEra"
           >
             <span
-              className="sc-eqIVtm ixzlzR"
+              className="sc-fAjcbJ fclNrM"
             >
               <div
-                className="sc-gPEVay eFShNV"
+                className="sc-iRbamj kNGkEx"
                 size="16px"
               >
                 <img
@@ -21258,7 +21215,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </div>
               </div>
               <div
-                className="sc-fAjcbJ jYwFjC"
+                className="sc-caSCKo dBUfBz"
               >
                 <span
                   style={
@@ -21271,7 +21228,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   }
                 >
                   <span
-                    className="sc-dVhcbM KPvEY"
+                    className="sc-eqIVtm ecxnvs"
                   >
                     Buffer
                   </span>
@@ -21281,17 +21238,17 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           </div>
         </div>
         <ul
-          className="sc-kPVwWT ksBtpo"
+          className="sc-kfGgVZ gNGxgR"
         >
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21311,7 +21268,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21328,13 +21285,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21357,7 +21314,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21380,14 +21337,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21407,7 +21364,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21424,13 +21381,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21453,7 +21410,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21476,14 +21433,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21503,7 +21460,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21520,13 +21477,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21549,7 +21506,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21572,14 +21529,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21599,7 +21556,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21616,13 +21573,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21645,7 +21602,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21668,14 +21625,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21695,7 +21652,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21715,14 +21672,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21742,7 +21699,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21759,13 +21716,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21788,7 +21745,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21811,14 +21768,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21838,7 +21795,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21855,13 +21812,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21884,7 +21841,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -21907,14 +21864,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-hSdWYo hbZqqh"
+            className="sc-eHgmQL hUstPo"
             width="25%"
           >
             <div
-              className="sc-cvbbAY FpcGm"
+              className="sc-jWBwVP eBgsec"
             >
               <span
-                className="sc-iAyFgw acaZS"
+                className="sc-hSdWYo bpLJPs"
               >
                 <span
                   data-tip={null}
@@ -21934,7 +21891,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-jWBwVP jFdhvt"
+                className="sc-brqgnP bPJvMT"
               >
                 <span
                   style={
@@ -21951,13 +21908,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-hMqMXs idyYAP"
+                  className="sc-kEYyzF cNZdMg"
                 >
                   <div
-                    className="sc-kEYyzF cPIOVY"
+                    className="sc-kkGfuU hxFSCl"
                   >
                     <div
-                      className="sc-eNQAEJ uiKxp"
+                      className="sc-hMqMXs hwVpmX"
                     >
                       <svg
                         fill="none"
@@ -21980,7 +21937,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-kkGfuU dpSiAT"
+                    className="sc-iAyFgw kWLHyT"
                   >
                     <span
                       style={
@@ -22012,13 +21969,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
 exports[`Snapshots Report renders loading whilst exporting 1`] = `
 <span>
   <div
-    className="sc-jXQZqI fPoiYy"
+    className="sc-iGPElx hIwNUa"
   >
     <div
-      className="sc-kGXeez iJENgK"
+      className="sc-kpOJdX dpBkoP"
     >
       <div
-        className="sc-kgoBCf fEHafe"
+        className="sc-kGXeez jgBcBL"
       >
         <div
           style={

--- a/packages/report/__snapshots__/snapshot.test.js.snap
+++ b/packages/report/__snapshots__/snapshot.test.js.snap
@@ -543,17 +543,17 @@ exports[`Snapshots ChartEditButtons they render 1`] = `
 exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
 <span>
   <section
-    className="sc-dnqmqq gjnmZE"
+    className="sc-htoDjs jNHMKJ"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -567,11 +567,11 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
             >
               <img
                 alt="Weekly Sync Report"
-                className="sc-htoDjs hYowVK"
-                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+                className="sc-gzVnrw fIxqHo"
+                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
               />
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -585,13 +585,9 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -606,17 +602,17 @@ exports[`Snapshots Cover renders a cover with logo, name and date 1`] = `
 exports[`Snapshots Cover renders a cover with logo, name, date and description 1`] = `
 <span>
   <section
-    className="sc-dnqmqq gjnmZE"
+    className="sc-htoDjs jNHMKJ"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -630,11 +626,11 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
             >
               <img
                 alt="Weekly Sync Report"
-                className="sc-htoDjs hYowVK"
-                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
+                className="sc-gzVnrw fIxqHo"
+                src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg"
               />
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -648,13 +644,9 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -669,9 +661,9 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
             }
           >
             <h2
-              className="sc-gzVnrw dkdfDA"
+              className="sc-bZQynM hlVgYy"
             >
-              Weekly report of all the social account of Buffer. We only use organic posts in this report. It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.
+              This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
             </h2>
           </span>
         </div>
@@ -684,17 +676,17 @@ exports[`Snapshots Cover renders a cover with logo, name, date and description 1
 exports[`Snapshots Cover renders a cover with name and date 1`] = `
 <span>
   <section
-    className="sc-dnqmqq gjnmZE"
+    className="sc-htoDjs jNHMKJ"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -707,7 +699,7 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
               }
             >
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -721,13 +713,9 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -742,17 +730,17 @@ exports[`Snapshots Cover renders a cover with name and date 1`] = `
 exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
 <span>
   <section
-    className="sc-dnqmqq gjnmZE"
+    className="sc-htoDjs jNHMKJ"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -765,7 +753,7 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
               }
             >
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -779,13 +767,9 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -800,9 +784,9 @@ exports[`Snapshots Cover renders a cover with name, date and description 1`] = `
             }
           >
             <h2
-              className="sc-gzVnrw dkdfDA"
+              className="sc-bZQynM hlVgYy"
             >
-              Weekly report of all the social account of Buffer. We only use organic posts in this report. It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.
+              This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.
             </h2>
           </span>
         </div>
@@ -824,13 +808,9 @@ exports[`Snapshots DateRange renders the date range 1`] = `
       }
     }
   >
-    <span
-      className="sc-htpNat KtFsv"
-    >
-      February 20, 2018
-       to 
-      February 25, 2018
-    </span>
+    February 20, 2018
+     to 
+    February 25, 2018
   </span>
 </span>
 `;
@@ -842,18 +822,14 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
       Object {
         "color": "#000",
         "fontFamily": "\\"Roboto\\", sans-serif",
-        "fontSize": "1.5rem",
+        "fontSize": "1rem",
         "fontWeight": 700,
       }
     }
   >
-    <span
-      className="sc-htpNat KtFsv"
-    >
-      February 20, 2018
-       to 
-      February 25, 2018
-    </span>
+    February 20, 2018
+     to 
+    February 25, 2018
   </span>
 </span>
 `;
@@ -861,12 +837,12 @@ exports[`Snapshots DateRange renders the date range larger 1`] = `
 exports[`Snapshots EditDescription renders the edit description text box 1`] = `
 <span>
   <form
-    className="sc-iwsKbI mLnRN"
+    className="sc-dnqmqq hGddsQ"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-gZMcBi fpDrjl"
+      className="sc-iwsKbI jYSBRk"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test report description"
@@ -878,12 +854,12 @@ exports[`Snapshots EditDescription renders the edit description text box 1`] = `
 exports[`Snapshots EditTitle renders the edit title text box 1`] = `
 <span>
   <form
-    className="sc-gqjmRU liZjsx"
+    className="sc-gZMcBi dSqFpM"
     onSubmit={[Function]}
   >
     <input
       autoFocus={true}
-      className="sc-VigVT leLWkf"
+      className="sc-gqjmRU kZfPWj"
       onBlur={[Function]}
       onChange={[Function]}
       value="Test Report"
@@ -920,7 +896,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
     }
   >
     <div
-      className="sc-jTzLTM fXZkZI"
+      className="sc-VigVT hcpnyU"
     >
       <button
         aria-label={null}
@@ -951,7 +927,7 @@ exports[`Snapshots LogoUpload renders logo and disables the replacement of the l
         }
       >
         <span
-          className="sc-kgoBCf byUlgs"
+          className="sc-chPdSV fOLfpE"
         >
           <svg
             height="100%"
@@ -997,7 +973,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
     }
   >
     <div
-      className="sc-jTzLTM fXZkZI"
+      className="sc-VigVT hcpnyU"
     >
       <button
         aria-label={null}
@@ -1028,7 +1004,7 @@ exports[`Snapshots LogoUpload renders logo in the box with the delete icon on th
         }
       >
         <span
-          className="sc-kgoBCf byUlgs"
+          className="sc-chPdSV fOLfpE"
         >
           <svg
             height="100%"
@@ -1074,13 +1050,13 @@ exports[`Snapshots LogoUpload renders no logo image upload box 1`] = `
     }
   >
     <div
-      className="sc-jTzLTM fXZkZI"
+      className="sc-VigVT hcpnyU"
     >
       <div
-        className="sc-fjdhpX LgDyd"
+        className="sc-jTzLTM kEHBFa"
       >
         <span
-          className="sc-kAzzGY gMJrTE"
+          className="sc-cSHVUG dcBfFr"
         >
           <span
             style={
@@ -1126,16 +1102,16 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
     }
   >
     <div
-      className="sc-jTzLTM fXZkZI"
+      className="sc-VigVT hcpnyU"
     >
       <div
-        className="sc-fjdhpX LgDyd"
+        className="sc-jTzLTM kEHBFa"
       >
         <span
-          className="sc-kAzzGY gMJrTE"
+          className="sc-cSHVUG dcBfFr"
         />
         <span
-          className="sc-chPdSV gccHCf"
+          className="sc-kAzzGY egQMhq"
         >
           <span
             style={
@@ -1159,13 +1135,13 @@ exports[`Snapshots LogoUpload renders uploading state 1`] = `
 exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 <span>
   <div
-    className="sc-gisBJw cCWpwM"
+    className="sc-caSCKo lZocL"
   >
     <span
-      className="sc-fAjcbJ fclNrM"
+      className="sc-eqIVtm ixzlzR"
     >
       <div
-        className="sc-iRbamj kNGkEx"
+        className="sc-gPEVay eFShNV"
         size="16px"
       >
         <img
@@ -1232,7 +1208,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-caSCKo dBUfBz"
+        className="sc-fAjcbJ jYwFjC"
       >
         <span
           style={
@@ -1245,7 +1221,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-eqIVtm ecxnvs"
+            className="sc-dVhcbM KPvEY"
           >
             @moreofmorris
           </span>
@@ -1253,10 +1229,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-fAjcbJ fclNrM"
+      className="sc-eqIVtm ixzlzR"
     >
       <div
-        className="sc-iRbamj kNGkEx"
+        className="sc-gPEVay eFShNV"
         size="16px"
       >
         <img
@@ -1323,7 +1299,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-caSCKo dBUfBz"
+        className="sc-fAjcbJ jYwFjC"
       >
         <span
           style={
@@ -1336,7 +1312,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-eqIVtm ecxnvs"
+            className="sc-dVhcbM KPvEY"
           >
             @roughquest
           </span>
@@ -1344,10 +1320,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
       </div>
     </span>
     <span
-      className="sc-fAjcbJ fclNrM"
+      className="sc-eqIVtm ixzlzR"
     >
       <div
-        className="sc-iRbamj kNGkEx"
+        className="sc-gPEVay eFShNV"
         size="16px"
       >
         <img
@@ -1414,7 +1390,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
         </div>
       </div>
       <div
-        className="sc-caSCKo dBUfBz"
+        className="sc-fAjcbJ jYwFjC"
       >
         <span
           style={
@@ -1427,7 +1403,7 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
           }
         >
           <span
-            className="sc-eqIVtm ecxnvs"
+            className="sc-dVhcbM KPvEY"
           >
             Roughquest
           </span>
@@ -1441,10 +1417,10 @@ exports[`Snapshots MultiProfileLegends renders the multi profile legends 1`] = `
 exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 <span>
   <span
-    className="sc-fAjcbJ fclNrM"
+    className="sc-eqIVtm ixzlzR"
   >
     <div
-      className="sc-iRbamj kNGkEx"
+      className="sc-gPEVay eFShNV"
       size="16px"
     >
       <img
@@ -1511,7 +1487,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo dBUfBz"
+      className="sc-fAjcbJ jYwFjC"
     >
       <span
         style={
@@ -1524,7 +1500,7 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
         }
       >
         <span
-          className="sc-eqIVtm ecxnvs"
+          className="sc-dVhcbM KPvEY"
         >
           @moreofmorris
         </span>
@@ -1537,14 +1513,14 @@ exports[`Snapshots ProfileLegend renders the profile legend 1`] = `
 exports[`Snapshots Report render in description edit mode 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-kZmsYB exKuiO"
+      className="sc-gmeYpB hETgOf"
       id="report-page"
     >
       <div
-        className="sc-RcBXQ IZhjJ"
+        className="sc-kZmsYB putUk"
       >
         <span
           style={
@@ -1557,16 +1533,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           }
         >
           <div
-            className="sc-etwtAo eLnpad"
+            className="sc-clNaTc fkjCIp"
           >
             <div
-              className="sc-jTzLTM fXZkZI"
+              className="sc-VigVT hcpnyU"
             >
               <div
-                className="sc-fjdhpX LgDyd"
+                className="sc-jTzLTM kEHBFa"
               >
                 <span
-                  className="sc-kAzzGY gMJrTE"
+                  className="sc-cSHVUG dcBfFr"
                 >
                   <span
                     style={
@@ -1596,7 +1572,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               </div>
             </div>
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -1651,7 +1627,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               }
             >
               <h1
-                className="sc-iSDuPN jSvqTR"
+                className="sc-RcBXQ cdxqGl"
               >
                 Weekly Sync Report
               </h1>
@@ -1667,21 +1643,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
-            >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
           <form
-            className="sc-iwsKbI mLnRN"
+            className="sc-dnqmqq hGddsQ"
             onSubmit={[Function]}
           >
             <input
               autoFocus={true}
-              className="sc-gZMcBi fpDrjl"
+              className="sc-iwsKbI jYSBRk"
               onBlur={[Function]}
               onChange={[Function]}
               value="Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work."
@@ -1690,16 +1662,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -1891,13 +1863,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -1964,7 +1936,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -1977,7 +1949,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -1987,17 +1959,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2017,7 +1989,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2034,13 +2006,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2063,7 +2035,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2086,14 +2058,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2113,7 +2085,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2130,13 +2102,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2159,7 +2131,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2182,14 +2154,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2209,7 +2181,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2226,13 +2198,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2255,7 +2227,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2278,14 +2250,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2305,7 +2277,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2322,13 +2294,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2351,7 +2323,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2374,14 +2346,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2401,7 +2373,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2421,14 +2393,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2448,7 +2420,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2465,13 +2437,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2494,7 +2466,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2517,14 +2489,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2544,7 +2516,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2561,13 +2533,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2590,7 +2562,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2613,14 +2585,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -2640,7 +2612,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -2657,13 +2629,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -2686,7 +2658,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -2711,16 +2683,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -2912,13 +2884,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -2985,7 +2957,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -2998,7 +2970,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -3008,17 +2980,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3038,7 +3010,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3055,13 +3027,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3084,7 +3056,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3107,14 +3079,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3134,7 +3106,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3151,13 +3123,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3180,7 +3152,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3203,14 +3175,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3230,7 +3202,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3247,13 +3219,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3276,7 +3248,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3299,14 +3271,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3326,7 +3298,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3343,13 +3315,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3372,7 +3344,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3395,14 +3367,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3422,7 +3394,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3442,14 +3414,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3469,7 +3441,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3486,13 +3458,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3515,7 +3487,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3538,14 +3510,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3565,7 +3537,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3582,13 +3554,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3611,7 +3583,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3634,14 +3606,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -3661,7 +3633,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -3678,13 +3650,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -3707,7 +3679,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -3732,16 +3704,16 @@ exports[`Snapshots Report render in description edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -3933,13 +3905,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -4006,7 +3978,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -4019,7 +3991,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -4029,17 +4001,17 @@ exports[`Snapshots Report render in description edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4059,7 +4031,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4076,13 +4048,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4105,7 +4077,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4128,14 +4100,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4155,7 +4127,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4172,13 +4144,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4201,7 +4173,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4224,14 +4196,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4251,7 +4223,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4268,13 +4240,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4297,7 +4269,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4320,14 +4292,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4347,7 +4319,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4364,13 +4336,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4393,7 +4365,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4416,14 +4388,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4443,7 +4415,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4463,14 +4435,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4490,7 +4462,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4507,13 +4479,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4536,7 +4508,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4559,14 +4531,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4586,7 +4558,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4603,13 +4575,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4632,7 +4604,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4655,14 +4627,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -4682,7 +4654,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -4699,13 +4671,13 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -4728,7 +4700,7 @@ exports[`Snapshots Report render in description edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -4760,14 +4732,14 @@ exports[`Snapshots Report render in description edit mode 1`] = `
 exports[`Snapshots Report render in title edit mode 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-kZmsYB exKuiO"
+      className="sc-gmeYpB hETgOf"
       id="report-page"
     >
       <div
-        className="sc-RcBXQ IZhjJ"
+        className="sc-kZmsYB putUk"
       >
         <span
           style={
@@ -4780,12 +4752,12 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           }
         >
           <form
-            className="sc-gqjmRU liZjsx"
+            className="sc-gZMcBi dSqFpM"
             onSubmit={[Function]}
           >
             <input
               autoFocus={true}
-              className="sc-VigVT leLWkf"
+              className="sc-gqjmRU kZfPWj"
               onBlur={[Function]}
               onChange={[Function]}
               value="Weekly Sync Report"
@@ -4801,19 +4773,15 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
-            >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
           <div
-            className="sc-clNaTc iLQykU"
+            className="sc-fQejPQ iHNcjH"
           >
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -4868,7 +4836,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
               }
             >
               <h2
-                className="sc-fZwumE kMgtlM"
+                className="sc-iSDuPN hbyslV"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -4877,16 +4845,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </span>
       </div>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -5078,13 +5046,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -5151,7 +5119,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -5164,7 +5132,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -5174,17 +5142,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5204,7 +5172,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5221,13 +5189,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5250,7 +5218,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5273,14 +5241,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5300,7 +5268,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5317,13 +5285,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5346,7 +5314,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5369,14 +5337,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5396,7 +5364,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5413,13 +5381,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5442,7 +5410,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5465,14 +5433,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5492,7 +5460,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5509,13 +5477,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5538,7 +5506,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5561,14 +5529,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5588,7 +5556,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5608,14 +5576,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5635,7 +5603,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5652,13 +5620,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5681,7 +5649,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5704,14 +5672,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5731,7 +5699,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5748,13 +5716,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5777,7 +5745,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5800,14 +5768,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -5827,7 +5795,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -5844,13 +5812,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -5873,7 +5841,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -5898,16 +5866,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -6099,13 +6067,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -6172,7 +6140,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -6185,7 +6153,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -6195,17 +6163,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6225,7 +6193,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6242,13 +6210,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6271,7 +6239,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6294,14 +6262,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6321,7 +6289,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6338,13 +6306,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6367,7 +6335,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6390,14 +6358,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6417,7 +6385,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6434,13 +6402,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6463,7 +6431,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6486,14 +6454,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6513,7 +6481,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6530,13 +6498,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6559,7 +6527,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6582,14 +6550,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6609,7 +6577,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6629,14 +6597,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6656,7 +6624,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6673,13 +6641,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6702,7 +6670,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6725,14 +6693,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6752,7 +6720,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6769,13 +6737,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6798,7 +6766,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6821,14 +6789,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -6848,7 +6816,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -6865,13 +6833,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -6894,7 +6862,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -6919,16 +6887,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -7120,13 +7088,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -7193,7 +7161,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -7206,7 +7174,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -7216,17 +7184,17 @@ exports[`Snapshots Report render in title edit mode 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7246,7 +7214,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7263,13 +7231,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7292,7 +7260,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7315,14 +7283,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7342,7 +7310,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7359,13 +7327,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7388,7 +7356,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7411,14 +7379,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7438,7 +7406,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7455,13 +7423,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7484,7 +7452,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7507,14 +7475,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7534,7 +7502,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7551,13 +7519,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7580,7 +7548,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7603,14 +7571,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7630,7 +7598,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7650,14 +7618,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7677,7 +7645,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7694,13 +7662,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7723,7 +7691,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7746,14 +7714,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7773,7 +7741,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7790,13 +7758,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7819,7 +7787,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7842,14 +7810,14 @@ exports[`Snapshots Report render in title edit mode 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -7869,7 +7837,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -7886,13 +7854,13 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -7915,7 +7883,7 @@ exports[`Snapshots Report render in title edit mode 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -7947,16 +7915,16 @@ exports[`Snapshots Report render in title edit mode 1`] = `
 exports[`Snapshots Report render loading 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-iGPElx hIwNUa"
+      className="sc-jXQZqI fPoiYy"
     >
       <div
-        className="sc-kpOJdX dpBkoP"
+        className="sc-kGXeez iJENgK"
       >
         <div
-          className="sc-kGXeez jgBcBL"
+          className="sc-kgoBCf fEHafe"
         >
           <div
             style={
@@ -8038,14 +8006,14 @@ exports[`Snapshots Report render loading 1`] = `
 exports[`Snapshots Report render only the multi-profile legend if that is available 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-kZmsYB exKuiO"
+      className="sc-gmeYpB hETgOf"
       id="report-page"
     >
       <div
-        className="sc-RcBXQ IZhjJ"
+        className="sc-kZmsYB putUk"
       >
         <span
           style={
@@ -8058,16 +8026,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           }
         >
           <div
-            className="sc-etwtAo eLnpad"
+            className="sc-clNaTc fkjCIp"
           >
             <div
-              className="sc-jTzLTM fXZkZI"
+              className="sc-VigVT hcpnyU"
             >
               <div
-                className="sc-fjdhpX LgDyd"
+                className="sc-jTzLTM kEHBFa"
               >
                 <span
-                  className="sc-kAzzGY gMJrTE"
+                  className="sc-cSHVUG dcBfFr"
                 >
                   <span
                     style={
@@ -8097,7 +8065,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               </div>
             </div>
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -8152,7 +8120,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-iSDuPN jSvqTR"
+                className="sc-RcBXQ cdxqGl"
               >
                 Weekly Sync Report
               </h1>
@@ -8168,19 +8136,15 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
-            >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
           <div
-            className="sc-clNaTc iLQykU"
+            className="sc-fQejPQ iHNcjH"
           >
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -8235,7 +8199,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h2
-                className="sc-fZwumE kMgtlM"
+                className="sc-iSDuPN hbyslV"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
               </h2>
@@ -8244,16 +8208,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </span>
       </div>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -8446,16 +8410,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <div
-              className="sc-gisBJw cCWpwM"
+              className="sc-caSCKo lZocL"
             >
               <span
-                className="sc-fAjcbJ fclNrM"
+                className="sc-eqIVtm ixzlzR"
               >
                 <div
-                  className="sc-iRbamj kNGkEx"
+                  className="sc-gPEVay eFShNV"
                   size="16px"
                 >
                   <img
@@ -8522,7 +8486,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-caSCKo dBUfBz"
+                  className="sc-fAjcbJ jYwFjC"
                 >
                   <span
                     style={
@@ -8535,7 +8499,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-eqIVtm ecxnvs"
+                      className="sc-dVhcbM KPvEY"
                     >
                       @buffer
                     </span>
@@ -8543,10 +8507,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </span>
               <span
-                className="sc-fAjcbJ fclNrM"
+                className="sc-eqIVtm ixzlzR"
               >
                 <div
-                  className="sc-iRbamj kNGkEx"
+                  className="sc-gPEVay eFShNV"
                   size="16px"
                 >
                   <img
@@ -8628,7 +8592,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   </div>
                 </div>
                 <div
-                  className="sc-caSCKo dBUfBz"
+                  className="sc-fAjcbJ jYwFjC"
                 >
                   <span
                     style={
@@ -8641,7 +8605,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                     }
                   >
                     <span
-                      className="sc-eqIVtm ecxnvs"
+                      className="sc-dVhcbM KPvEY"
                     >
                       buffer
                     </span>
@@ -8652,16 +8616,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </div>
         </div>
         <div
-          className="sc-dxgOiQ ckNOOu"
+          className="sc-kpOJdX dNTKpM"
         >
           <div
-            className="sc-ckVGcZ YJXtP"
+            className="sc-dxgOiQ cJLLMr"
           >
             <div
-              className="sc-jKJlTe bWRyvh"
+              className="sc-ckVGcZ hoOcak"
             />
             <h1
-              className="sc-eNQAEJ dYjNXW"
+              className="sc-jKJlTe cVHNsT"
             >
               <span
                 style={
@@ -8687,18 +8651,18 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render only the multi-profile legend if that is available whilst exporting 1`] = `
 <span>
   <div
-    className="sc-kZmsYB exKuiO"
+    className="sc-gmeYpB hETgOf"
     id="report-page"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -8711,7 +8675,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               }
             >
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -8725,13 +8689,9 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -8746,7 +8706,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
             }
           >
             <h2
-              className="sc-gzVnrw dkdfDA"
+              className="sc-bZQynM hlVgYy"
             >
               Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts.
             </h2>
@@ -8755,16 +8715,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
       </div>
     </article>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -8782,16 +8742,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <div
-            className="sc-gisBJw cCWpwM"
+            className="sc-caSCKo lZocL"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -8858,7 +8818,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -8871,7 +8831,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     @buffer
                   </span>
@@ -8879,10 +8839,10 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
               </div>
             </span>
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -8964,7 +8924,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -8977,7 +8937,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     buffer
                   </span>
@@ -8988,16 +8948,16 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
         </div>
       </div>
       <div
-        className="sc-dxgOiQ ckNOOu"
+        className="sc-kpOJdX dNTKpM"
       >
         <div
-          className="sc-ckVGcZ YJXtP"
+          className="sc-dxgOiQ cJLLMr"
         >
           <div
-            className="sc-jKJlTe bWRyvh"
+            className="sc-ckVGcZ hoOcak"
           />
           <h1
-            className="sc-eNQAEJ dYjNXW"
+            className="sc-jKJlTe cVHNsT"
           >
             <span
               style={
@@ -9016,7 +8976,7 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
       </div>
     </section>
     <div
-      className="sc-kasBVs bedwKD"
+      className="sc-iGPElx eSNuwW"
     />
   </div>
 </span>
@@ -9025,14 +8985,14 @@ exports[`Snapshots Report render only the multi-profile legend if that is availa
 exports[`Snapshots Report render with summary table and logo 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-kZmsYB exKuiO"
+      className="sc-gmeYpB hETgOf"
       id="report-page"
     >
       <div
-        className="sc-RcBXQ IZhjJ"
+        className="sc-kZmsYB putUk"
       >
         <span
           style={
@@ -9045,10 +9005,10 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           }
         >
           <div
-            className="sc-etwtAo eLnpad"
+            className="sc-clNaTc fkjCIp"
           >
             <div
-              className="sc-jTzLTM fXZkZI"
+              className="sc-VigVT hcpnyU"
             >
               <button
                 aria-label={null}
@@ -9079,7 +9039,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 }
               >
                 <span
-                  className="sc-kgoBCf byUlgs"
+                  className="sc-chPdSV fOLfpE"
                 >
                   <svg
                     height="100%"
@@ -9109,7 +9069,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               </button>
             </div>
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -9164,7 +9124,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h1
-                className="sc-iSDuPN jSvqTR"
+                className="sc-RcBXQ cdxqGl"
               >
                 Weekly Sync Report
               </h1>
@@ -9180,19 +9140,15 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
-            >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
           <div
-            className="sc-clNaTc iLQykU"
+            className="sc-fQejPQ iHNcjH"
           >
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -9247,7 +9203,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
               }
             >
               <h2
-                className="sc-fZwumE kMgtlM"
+                className="sc-iSDuPN hbyslV"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -9256,16 +9212,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -9457,13 +9413,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -9530,7 +9486,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -9543,7 +9499,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -9553,17 +9509,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -9583,7 +9539,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -9600,13 +9556,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -9629,7 +9585,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -9652,14 +9608,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -9679,7 +9635,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -9696,13 +9652,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -9725,7 +9681,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -9748,14 +9704,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -9775,7 +9731,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -9792,13 +9748,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -9821,7 +9777,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -9844,14 +9800,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -9871,7 +9827,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -9888,13 +9844,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -9917,7 +9873,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -9940,14 +9896,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -9967,7 +9923,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -9987,14 +9943,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10014,7 +9970,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10031,13 +9987,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10060,7 +10016,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10083,14 +10039,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10110,7 +10066,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10127,13 +10083,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10156,7 +10112,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10179,14 +10135,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10206,7 +10162,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10223,13 +10179,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10252,7 +10208,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10277,16 +10233,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -10478,13 +10434,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -10551,7 +10507,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -10564,7 +10520,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -10574,17 +10530,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10604,7 +10560,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10621,13 +10577,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10650,7 +10606,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10673,14 +10629,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10700,7 +10656,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10717,13 +10673,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10746,7 +10702,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10769,14 +10725,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10796,7 +10752,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10813,13 +10769,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10842,7 +10798,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10865,14 +10821,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10892,7 +10848,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -10909,13 +10865,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -10938,7 +10894,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -10961,14 +10917,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -10988,7 +10944,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11008,14 +10964,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11035,7 +10991,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11052,13 +11008,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11081,7 +11037,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11104,14 +11060,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11131,7 +11087,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11148,13 +11104,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11177,7 +11133,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11200,14 +11156,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11227,7 +11183,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11244,13 +11200,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11273,7 +11229,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11298,16 +11254,16 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -11499,13 +11455,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -11572,7 +11528,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -11585,7 +11541,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -11595,17 +11551,17 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11625,7 +11581,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11642,13 +11598,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11671,7 +11627,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11694,14 +11650,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11721,7 +11677,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11738,13 +11694,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11767,7 +11723,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11790,14 +11746,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11817,7 +11773,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11834,13 +11790,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11863,7 +11819,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11886,14 +11842,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -11913,7 +11869,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -11930,13 +11886,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -11959,7 +11915,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -11982,14 +11938,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -12009,7 +11965,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -12029,14 +11985,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -12056,7 +12012,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -12073,13 +12029,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -12102,7 +12058,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -12125,14 +12081,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -12152,7 +12108,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -12169,13 +12125,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -12198,7 +12154,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -12221,14 +12177,14 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -12248,7 +12204,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -12265,13 +12221,13 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -12294,7 +12250,7 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -12326,18 +12282,18 @@ exports[`Snapshots Report render with summary table and logo 1`] = `
 exports[`Snapshots Report render with summary table and logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-kZmsYB exKuiO"
+    className="sc-gmeYpB hETgOf"
     id="report-page"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -12351,11 +12307,11 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
             >
               <img
                 alt="Weekly Sync Report"
-                className="sc-htoDjs hYowVK"
+                className="sc-gzVnrw fIxqHo"
                 src="https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg"
               />
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -12369,13 +12325,9 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -12390,7 +12342,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
             }
           >
             <h2
-              className="sc-gzVnrw dkdfDA"
+              className="sc-bZQynM hlVgYy"
             >
               Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
             </h2>
@@ -12399,16 +12351,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </div>
     </article>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -12425,13 +12377,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <span
-            className="sc-fAjcbJ fclNrM"
+            className="sc-eqIVtm ixzlzR"
           >
             <div
-              className="sc-iRbamj kNGkEx"
+              className="sc-gPEVay eFShNV"
               size="16px"
             >
               <img
@@ -12498,7 +12450,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-caSCKo dBUfBz"
+              className="sc-fAjcbJ jYwFjC"
             >
               <span
                 style={
@@ -12511,7 +12463,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-eqIVtm ecxnvs"
+                  className="sc-dVhcbM KPvEY"
                 >
                   Buffer
                 </span>
@@ -12521,17 +12473,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-kfGgVZ gNGxgR"
+        className="sc-kPVwWT ksBtpo"
       >
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -12551,7 +12503,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -12568,13 +12520,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -12597,7 +12549,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -12620,14 +12572,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -12647,7 +12599,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -12664,13 +12616,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -12693,7 +12645,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -12716,14 +12668,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -12743,7 +12695,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -12760,13 +12712,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -12789,7 +12741,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -12812,14 +12764,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -12839,7 +12791,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -12856,13 +12808,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -12885,7 +12837,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -12908,14 +12860,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -12935,7 +12887,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -12955,14 +12907,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -12982,7 +12934,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -12999,13 +12951,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13028,7 +12980,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13051,14 +13003,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13078,7 +13030,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13095,13 +13047,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13124,7 +13076,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13147,14 +13099,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13174,7 +13126,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13191,13 +13143,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13220,7 +13172,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13245,16 +13197,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -13271,13 +13223,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <span
-            className="sc-fAjcbJ fclNrM"
+            className="sc-eqIVtm ixzlzR"
           >
             <div
-              className="sc-iRbamj kNGkEx"
+              className="sc-gPEVay eFShNV"
               size="16px"
             >
               <img
@@ -13344,7 +13296,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-caSCKo dBUfBz"
+              className="sc-fAjcbJ jYwFjC"
             >
               <span
                 style={
@@ -13357,7 +13309,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-eqIVtm ecxnvs"
+                  className="sc-dVhcbM KPvEY"
                 >
                   Buffer
                 </span>
@@ -13367,17 +13319,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-kfGgVZ gNGxgR"
+        className="sc-kPVwWT ksBtpo"
       >
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13397,7 +13349,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13414,13 +13366,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13443,7 +13395,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13466,14 +13418,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13493,7 +13445,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13510,13 +13462,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13539,7 +13491,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13562,14 +13514,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13589,7 +13541,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13606,13 +13558,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13635,7 +13587,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13658,14 +13610,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13685,7 +13637,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13702,13 +13654,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13731,7 +13683,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13754,14 +13706,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13781,7 +13733,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13801,14 +13753,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13828,7 +13780,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13845,13 +13797,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13874,7 +13826,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13897,14 +13849,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -13924,7 +13876,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -13941,13 +13893,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -13970,7 +13922,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -13993,14 +13945,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14020,7 +13972,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14037,13 +13989,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14066,7 +14018,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14091,16 +14043,16 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -14117,13 +14069,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <span
-            className="sc-fAjcbJ fclNrM"
+            className="sc-eqIVtm ixzlzR"
           >
             <div
-              className="sc-iRbamj kNGkEx"
+              className="sc-gPEVay eFShNV"
               size="16px"
             >
               <img
@@ -14190,7 +14142,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </div>
             </div>
             <div
-              className="sc-caSCKo dBUfBz"
+              className="sc-fAjcbJ jYwFjC"
             >
               <span
                 style={
@@ -14203,7 +14155,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 }
               >
                 <span
-                  className="sc-eqIVtm ecxnvs"
+                  className="sc-dVhcbM KPvEY"
                 >
                   Buffer
                 </span>
@@ -14213,17 +14165,17 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
         </div>
       </div>
       <ul
-        className="sc-kfGgVZ gNGxgR"
+        className="sc-kPVwWT ksBtpo"
       >
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14243,7 +14195,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14260,13 +14212,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14289,7 +14241,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14312,14 +14264,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14339,7 +14291,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14356,13 +14308,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14385,7 +14337,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14408,14 +14360,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14435,7 +14387,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14452,13 +14404,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14481,7 +14433,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14504,14 +14456,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14531,7 +14483,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14548,13 +14500,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14577,7 +14529,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14600,14 +14552,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14627,7 +14579,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14647,14 +14599,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14674,7 +14626,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14691,13 +14643,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14720,7 +14672,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14743,14 +14695,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14770,7 +14722,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14787,13 +14739,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14816,7 +14768,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14839,14 +14791,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -14866,7 +14818,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -14883,13 +14835,13 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -14912,7 +14864,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -14937,7 +14889,7 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
       </ul>
     </section>
     <div
-      className="sc-kasBVs bedwKD"
+      className="sc-iGPElx eSNuwW"
     />
   </div>
 </span>
@@ -14946,14 +14898,14 @@ exports[`Snapshots Report render with summary table and logo whilst exporting 1`
 exports[`Snapshots Report render with summary table and no logo 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-kZmsYB exKuiO"
+      className="sc-gmeYpB hETgOf"
       id="report-page"
     >
       <div
-        className="sc-RcBXQ IZhjJ"
+        className="sc-kZmsYB putUk"
       >
         <span
           style={
@@ -14966,16 +14918,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           }
         >
           <div
-            className="sc-etwtAo eLnpad"
+            className="sc-clNaTc fkjCIp"
           >
             <div
-              className="sc-jTzLTM fXZkZI"
+              className="sc-VigVT hcpnyU"
             >
               <div
-                className="sc-fjdhpX LgDyd"
+                className="sc-jTzLTM kEHBFa"
               >
                 <span
-                  className="sc-kAzzGY gMJrTE"
+                  className="sc-cSHVUG dcBfFr"
                 >
                   <span
                     style={
@@ -15005,7 +14957,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               </div>
             </div>
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -15060,7 +15012,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h1
-                className="sc-iSDuPN jSvqTR"
+                className="sc-RcBXQ cdxqGl"
               >
                 Weekly Sync Report
               </h1>
@@ -15076,19 +15028,15 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
-            >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
           <div
-            className="sc-clNaTc iLQykU"
+            className="sc-fQejPQ iHNcjH"
           >
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -15143,7 +15091,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
               }
             >
               <h2
-                className="sc-fZwumE kMgtlM"
+                className="sc-iSDuPN hbyslV"
               >
                 Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
               </h2>
@@ -15152,16 +15100,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </span>
       </div>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -15353,13 +15301,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -15426,7 +15374,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -15439,7 +15387,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -15449,17 +15397,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -15479,7 +15427,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -15496,13 +15444,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -15525,7 +15473,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -15548,14 +15496,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -15575,7 +15523,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -15592,13 +15540,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -15621,7 +15569,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -15644,14 +15592,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -15671,7 +15619,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -15688,13 +15636,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -15717,7 +15665,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -15740,14 +15688,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -15767,7 +15715,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -15784,13 +15732,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -15813,7 +15761,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -15836,14 +15784,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -15863,7 +15811,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -15883,14 +15831,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -15910,7 +15858,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -15927,13 +15875,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -15956,7 +15904,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -15979,14 +15927,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16006,7 +15954,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16023,13 +15971,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16052,7 +16000,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -16075,14 +16023,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16102,7 +16050,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16119,13 +16067,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16148,7 +16096,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -16173,16 +16121,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -16374,13 +16322,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -16447,7 +16395,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -16460,7 +16408,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -16470,17 +16418,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16500,7 +16448,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16517,13 +16465,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16546,7 +16494,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -16569,14 +16517,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16596,7 +16544,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16613,13 +16561,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16642,7 +16590,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -16665,14 +16613,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16692,7 +16640,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16709,13 +16657,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16738,7 +16686,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -16761,14 +16709,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16788,7 +16736,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16805,13 +16753,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16834,7 +16782,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -16857,14 +16805,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16884,7 +16832,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16904,14 +16852,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -16931,7 +16879,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -16948,13 +16896,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -16977,7 +16925,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17000,14 +16948,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17027,7 +16975,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17044,13 +16992,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17073,7 +17021,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17096,14 +17044,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17123,7 +17071,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17140,13 +17088,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17169,7 +17117,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17194,16 +17142,16 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
         </ul>
       </section>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -17395,13 +17343,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -17468,7 +17416,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -17481,7 +17429,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -17491,17 +17439,17 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17521,7 +17469,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17538,13 +17486,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17567,7 +17515,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17590,14 +17538,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17617,7 +17565,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17634,13 +17582,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17663,7 +17611,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17686,14 +17634,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17713,7 +17661,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17730,13 +17678,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17759,7 +17707,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17782,14 +17730,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17809,7 +17757,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17826,13 +17774,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17855,7 +17803,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -17878,14 +17826,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17905,7 +17853,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17925,14 +17873,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -17952,7 +17900,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -17969,13 +17917,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -17998,7 +17946,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -18021,14 +17969,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -18048,7 +17996,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -18065,13 +18013,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -18094,7 +18042,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -18117,14 +18065,14 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -18144,7 +18092,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -18161,13 +18109,13 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -18190,7 +18138,7 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -18222,18 +18170,18 @@ exports[`Snapshots Report render with summary table and no logo 1`] = `
 exports[`Snapshots Report render with summary table and no logo whilst exporting 1`] = `
 <span>
   <div
-    className="sc-kZmsYB exKuiO"
+    className="sc-gmeYpB hETgOf"
     id="report-page"
   >
     <article
-      className="sc-bxivhb csPkxY"
+      className="sc-htpNat eoInDm"
     >
       <div
-        className="sc-ifAKCX ieKocY"
+        className="sc-bxivhb iizGgK"
       >
         <div>
           <div
-            className="sc-EHOje dClLkx"
+            className="sc-ifAKCX hjCpRr"
           >
             <span
               style={
@@ -18246,7 +18194,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               }
             >
               <h1
-                className="sc-bZQynM lckfgS"
+                className="sc-EHOje lfSVpT"
               >
                 Weekly Sync Report
               </h1>
@@ -18260,13 +18208,9 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   }
                 }
               >
-                <span
-                  className="sc-htpNat KtFsv"
-                >
-                  February 20, 2018
-                   to 
-                  February 25, 2018
-                </span>
+                February 20, 2018
+                 to 
+                February 25, 2018
               </span>
             </span>
           </div>
@@ -18281,7 +18225,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
             }
           >
             <h2
-              className="sc-gzVnrw dkdfDA"
+              className="sc-bZQynM hlVgYy"
             >
               Our weekly report for all social accounts that we run across Facebook and Twitter. It is important to note that we only use organic posts. This report should be generated every week to show off our performance across all the social networks. Keep up the good work.
             </h2>
@@ -18290,16 +18234,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </div>
     </article>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -18316,13 +18260,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <span
-            className="sc-fAjcbJ fclNrM"
+            className="sc-eqIVtm ixzlzR"
           >
             <div
-              className="sc-iRbamj kNGkEx"
+              className="sc-gPEVay eFShNV"
               size="16px"
             >
               <img
@@ -18389,7 +18333,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-caSCKo dBUfBz"
+              className="sc-fAjcbJ jYwFjC"
             >
               <span
                 style={
@@ -18402,7 +18346,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-eqIVtm ecxnvs"
+                  className="sc-dVhcbM KPvEY"
                 >
                   Buffer
                 </span>
@@ -18412,17 +18356,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-kfGgVZ gNGxgR"
+        className="sc-kPVwWT ksBtpo"
       >
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18442,7 +18386,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18459,13 +18403,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -18488,7 +18432,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -18511,14 +18455,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18538,7 +18482,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18555,13 +18499,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -18584,7 +18528,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -18607,14 +18551,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18634,7 +18578,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18651,13 +18595,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -18680,7 +18624,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -18703,14 +18647,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18730,7 +18674,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18747,13 +18691,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -18776,7 +18720,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -18799,14 +18743,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18826,7 +18770,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18846,14 +18790,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18873,7 +18817,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18890,13 +18834,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -18919,7 +18863,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -18942,14 +18886,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -18969,7 +18913,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -18986,13 +18930,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19015,7 +18959,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19038,14 +18982,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19065,7 +19009,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19082,13 +19026,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19111,7 +19055,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19136,16 +19080,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -19162,13 +19106,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <span
-            className="sc-fAjcbJ fclNrM"
+            className="sc-eqIVtm ixzlzR"
           >
             <div
-              className="sc-iRbamj kNGkEx"
+              className="sc-gPEVay eFShNV"
               size="16px"
             >
               <img
@@ -19235,7 +19179,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-caSCKo dBUfBz"
+              className="sc-fAjcbJ jYwFjC"
             >
               <span
                 style={
@@ -19248,7 +19192,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-eqIVtm ecxnvs"
+                  className="sc-dVhcbM KPvEY"
                 >
                   Buffer
                 </span>
@@ -19258,17 +19202,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-kfGgVZ gNGxgR"
+        className="sc-kPVwWT ksBtpo"
       >
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19288,7 +19232,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19305,13 +19249,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19334,7 +19278,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19357,14 +19301,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19384,7 +19328,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19401,13 +19345,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19430,7 +19374,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19453,14 +19397,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19480,7 +19424,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19497,13 +19441,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19526,7 +19470,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19549,14 +19493,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19576,7 +19520,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19593,13 +19537,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19622,7 +19566,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19645,14 +19589,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19672,7 +19616,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19692,14 +19636,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19719,7 +19663,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19736,13 +19680,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19765,7 +19709,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19788,14 +19732,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19815,7 +19759,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19832,13 +19776,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19861,7 +19805,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19884,14 +19828,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -19911,7 +19855,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -19928,13 +19872,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -19957,7 +19901,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -19982,16 +19926,16 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <section
-      className="sc-kxynE hggGNg"
+      className="sc-chbbiW cEsOfO"
     >
       <div
-        className="sc-gmeYpB iEJOnV"
+        className="sc-fcdeBU iNVTGA"
       >
         <div
-          className="sc-cooIXK cYHYkl"
+          className="sc-kxynE Vtclv"
         >
           <h2
-            className="sc-Rmtcm dMAMwK"
+            className="sc-csuQGl cMenPN"
           >
             <span
               style={
@@ -20008,13 +19952,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </h2>
         </div>
         <div
-          className="sc-fcdeBU iOEEra"
+          className="sc-cooIXK bOVWWn"
         >
           <span
-            className="sc-fAjcbJ fclNrM"
+            className="sc-eqIVtm ixzlzR"
           >
             <div
-              className="sc-iRbamj kNGkEx"
+              className="sc-gPEVay eFShNV"
               size="16px"
             >
               <img
@@ -20081,7 +20025,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </div>
             </div>
             <div
-              className="sc-caSCKo dBUfBz"
+              className="sc-fAjcbJ jYwFjC"
             >
               <span
                 style={
@@ -20094,7 +20038,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 }
               >
                 <span
-                  className="sc-eqIVtm ecxnvs"
+                  className="sc-dVhcbM KPvEY"
                 >
                   Buffer
                 </span>
@@ -20104,17 +20048,17 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
         </div>
       </div>
       <ul
-        className="sc-kfGgVZ gNGxgR"
+        className="sc-kPVwWT ksBtpo"
       >
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20134,7 +20078,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20151,13 +20095,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20180,7 +20124,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20203,14 +20147,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20230,7 +20174,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20247,13 +20191,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20276,7 +20220,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20299,14 +20243,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20326,7 +20270,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20343,13 +20287,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20372,7 +20316,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20395,14 +20339,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20422,7 +20366,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20439,13 +20383,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20468,7 +20412,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20491,14 +20435,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20518,7 +20462,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20538,14 +20482,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20565,7 +20509,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20582,13 +20526,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20611,7 +20555,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20634,14 +20578,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20661,7 +20605,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20678,13 +20622,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20707,7 +20651,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20730,14 +20674,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
           </div>
         </li>
         <li
-          className="sc-eHgmQL hUstPo"
+          className="sc-hSdWYo hbZqqh"
           width="25%"
         >
           <div
-            className="sc-jWBwVP eBgsec"
+            className="sc-cvbbAY FpcGm"
           >
             <span
-              className="sc-hSdWYo bpLJPs"
+              className="sc-iAyFgw acaZS"
             >
               <span
                 data-tip={null}
@@ -20757,7 +20701,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
               </span>
             </span>
             <div
-              className="sc-brqgnP bPJvMT"
+              className="sc-jWBwVP jFdhvt"
             >
               <span
                 style={
@@ -20774,13 +20718,13 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                 </span>
               </span>
               <div
-                className="sc-kEYyzF cNZdMg"
+                className="sc-hMqMXs idyYAP"
               >
                 <div
-                  className="sc-kkGfuU hxFSCl"
+                  className="sc-kEYyzF cPIOVY"
                 >
                   <div
-                    className="sc-hMqMXs hwVpmX"
+                    className="sc-eNQAEJ uiKxp"
                   >
                     <svg
                       fill="none"
@@ -20803,7 +20747,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
                   </div>
                 </div>
                 <div
-                  className="sc-iAyFgw kWLHyT"
+                  className="sc-kkGfuU dpSiAT"
                 >
                   <span
                     style={
@@ -20828,7 +20772,7 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
       </ul>
     </section>
     <div
-      className="sc-kasBVs bedwKD"
+      className="sc-iGPElx eSNuwW"
     />
   </div>
 </span>
@@ -20837,14 +20781,14 @@ exports[`Snapshots Report render with summary table and no logo whilst exporting
 exports[`Snapshots Report render with summary table, no logo and no description 1`] = `
 <span>
   <section
-    className="sc-hgHYgh huVFeC"
+    className="sc-kasBVs hPMNkS"
   >
     <div
-      className="sc-kZmsYB exKuiO"
+      className="sc-gmeYpB hETgOf"
       id="report-page"
     >
       <div
-        className="sc-RcBXQ IZhjJ"
+        className="sc-kZmsYB putUk"
       >
         <span
           style={
@@ -20857,16 +20801,16 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           }
         >
           <div
-            className="sc-etwtAo eLnpad"
+            className="sc-clNaTc fkjCIp"
           >
             <div
-              className="sc-jTzLTM fXZkZI"
+              className="sc-VigVT hcpnyU"
             >
               <div
-                className="sc-fjdhpX LgDyd"
+                className="sc-jTzLTM kEHBFa"
               >
                 <span
-                  className="sc-kAzzGY gMJrTE"
+                  className="sc-cSHVUG dcBfFr"
                 >
                   <span
                     style={
@@ -20896,7 +20840,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               </div>
             </div>
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -20951,7 +20895,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               }
             >
               <h1
-                className="sc-iSDuPN jSvqTR"
+                className="sc-RcBXQ cdxqGl"
               >
                 Weekly Sync Report New
               </h1>
@@ -20967,19 +20911,15 @@ exports[`Snapshots Report render with summary table, no logo and no description 
               }
             }
           >
-            <span
-              className="sc-htpNat KtFsv"
-            >
-              February 20, 2018
-               to 
-              February 25, 2018
-            </span>
+            February 20, 2018
+             to 
+            February 25, 2018
           </span>
           <div
-            className="sc-clNaTc iLQykU"
+            className="sc-fQejPQ iHNcjH"
           >
             <div
-              className="sc-jXQZqI iBWNXq"
+              className="sc-etwtAo kdVRkA"
             >
               <svg
                 height="100%"
@@ -21035,7 +20975,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             >
               
               <h2
-                className="sc-fQejPQ gXGPsM"
+                className="sc-fZwumE yKUcC"
               >
                 Add report description
               </h2>
@@ -21044,16 +20984,16 @@ exports[`Snapshots Report render with summary table, no logo and no description 
         </span>
       </div>
       <section
-        className="sc-kxynE beYkXW"
+        className="sc-chbbiW gtGkqp"
       >
         <div
-          className="sc-gmeYpB iEJOnV"
+          className="sc-fcdeBU iNVTGA"
         >
           <div
-            className="sc-cooIXK cYHYkl"
+            className="sc-kxynE Vtclv"
           >
             <h2
-              className="sc-Rmtcm dMAMwK"
+              className="sc-csuQGl cMenPN"
             >
               <span
                 style={
@@ -21245,13 +21185,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </aside>
           </div>
           <div
-            className="sc-fcdeBU iOEEra"
+            className="sc-cooIXK bOVWWn"
           >
             <span
-              className="sc-fAjcbJ fclNrM"
+              className="sc-eqIVtm ixzlzR"
             >
               <div
-                className="sc-iRbamj kNGkEx"
+                className="sc-gPEVay eFShNV"
                 size="16px"
               >
                 <img
@@ -21318,7 +21258,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </div>
               </div>
               <div
-                className="sc-caSCKo dBUfBz"
+                className="sc-fAjcbJ jYwFjC"
               >
                 <span
                   style={
@@ -21331,7 +21271,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   }
                 >
                   <span
-                    className="sc-eqIVtm ecxnvs"
+                    className="sc-dVhcbM KPvEY"
                   >
                     Buffer
                   </span>
@@ -21341,17 +21281,17 @@ exports[`Snapshots Report render with summary table, no logo and no description 
           </div>
         </div>
         <ul
-          className="sc-kfGgVZ gNGxgR"
+          className="sc-kPVwWT ksBtpo"
         >
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21371,7 +21311,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21388,13 +21328,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -21417,7 +21357,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -21440,14 +21380,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21467,7 +21407,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21484,13 +21424,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -21513,7 +21453,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -21536,14 +21476,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21563,7 +21503,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21580,13 +21520,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -21609,7 +21549,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -21632,14 +21572,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21659,7 +21599,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21676,13 +21616,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -21705,7 +21645,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -21728,14 +21668,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21755,7 +21695,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21775,14 +21715,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21802,7 +21742,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21819,13 +21759,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -21848,7 +21788,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -21871,14 +21811,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21898,7 +21838,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -21915,13 +21855,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -21944,7 +21884,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -21967,14 +21907,14 @@ exports[`Snapshots Report render with summary table, no logo and no description 
             </div>
           </li>
           <li
-            className="sc-eHgmQL hUstPo"
+            className="sc-hSdWYo hbZqqh"
             width="25%"
           >
             <div
-              className="sc-jWBwVP eBgsec"
+              className="sc-cvbbAY FpcGm"
             >
               <span
-                className="sc-hSdWYo bpLJPs"
+                className="sc-iAyFgw acaZS"
               >
                 <span
                   data-tip={null}
@@ -21994,7 +21934,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                 </span>
               </span>
               <div
-                className="sc-brqgnP bPJvMT"
+                className="sc-jWBwVP jFdhvt"
               >
                 <span
                   style={
@@ -22011,13 +21951,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                   </span>
                 </span>
                 <div
-                  className="sc-kEYyzF cNZdMg"
+                  className="sc-hMqMXs idyYAP"
                 >
                   <div
-                    className="sc-kkGfuU hxFSCl"
+                    className="sc-kEYyzF cPIOVY"
                   >
                     <div
-                      className="sc-hMqMXs hwVpmX"
+                      className="sc-eNQAEJ uiKxp"
                     >
                       <svg
                         fill="none"
@@ -22040,7 +21980,7 @@ exports[`Snapshots Report render with summary table, no logo and no description 
                     </div>
                   </div>
                   <div
-                    className="sc-iAyFgw kWLHyT"
+                    className="sc-kkGfuU dpSiAT"
                   >
                     <span
                       style={
@@ -22072,13 +22012,13 @@ exports[`Snapshots Report render with summary table, no logo and no description 
 exports[`Snapshots Report renders loading whilst exporting 1`] = `
 <span>
   <div
-    className="sc-iGPElx hIwNUa"
+    className="sc-jXQZqI fPoiYy"
   >
     <div
-      className="sc-kpOJdX dpBkoP"
+      className="sc-kGXeez iJENgK"
     >
       <div
-        className="sc-kGXeez jgBcBL"
+        className="sc-kgoBCf fEHafe"
       >
         <div
           style={

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -41,9 +41,9 @@ const Inner = styled.div`
 const Title = styled.h1`
   display: block;
   color: ${black};
-  font-size: 2.2rem;
+  font-size: 2.4rem;
   font-weight: 500;
-  margin: 0 0 1rem;
+  margin: 0 0 0.8rem;
 `;
 
 const Description = styled.h2`

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -41,8 +41,8 @@ const Inner = styled.div`
 const Title = styled.h1`
   display: block;
   color: ${black};
-  font-size: 2.4rem;
-  font-weight: 500;
+  font-size: 2.2rem;
+  font-weight: 600;
   margin: 0 0 0.8rem;
 `;
 

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -15,7 +15,9 @@ const Page = styled.article`
   overflow-y: hidden;
   height: 1446px; /* this seems to be the exact A4 portrait size */
   margin: 0;
-  padding: 0;
+  padding: 12rem 8rem;
+  box-sizing: border-box;
+  background: ${white};
 
   @media print {
     page-break-after: always;
@@ -23,27 +25,24 @@ const Page = styled.article`
 `;
 
 const Container = styled.div`
+  width: 100%;
   height: 100%;
   box-sizing: border-box;
-  padding: 4.5rem 1.5rem;
-  background: ${white};
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
 `;
 
-const Wrapper = styled.div``;
-
 const Inner = styled.div`
-  padding: 0 0 28rem;
+  padding: 8rem 0 48rem;
 `;
 
 const Title = styled.h1`
   display: block;
   color: ${black};
-  font-size: 5rem;
-  font-weight: 700;
+  font-size: 2.2rem;
+  font-weight: 500;
   margin: 0 0 1rem;
 `;
 
@@ -52,36 +51,38 @@ const Description = styled.h2`
   color: ${black};
   font-size: 1rem;
   font-weight: 400;
-  margin: 0 0 .5rem 0;
-  margin-top: 20px;
+  margin: 8rem auto 0;
   text-align: center;
-  max-width: 80%;
   line-height: 1.4;
-  padding-left: 10%;
 `;
 
 const Logo = styled.img`
   display: block;
-  margin: 8rem auto 0;
+  margin: 0 auto 1rem;
+  width: auto;
   min-width: 100px;
-  max-width: 300px;
+  max-width: 200px;
   height: auto;
-  max-height: 300px;
+  max-height: 200px;
 `;
 
 const Cover = ({ dateRange, logoUrl, name, description }) =>
   <Page>
     <Container>
-      <Wrapper>
+      <div>
         <Inner>
           <Text>
+            {logoUrl && <Logo src={logoUrl} alt={name} />}
             <Title>{name}</Title>
-            <DateRange {...dateRange} large />
-            <Description>{description}</Description>
+            <DateRange {...dateRange} />
           </Text>
         </Inner>
-        {logoUrl && <Logo src={logoUrl} alt={name} />}
-      </Wrapper>
+        {description && (
+          <Text>
+            <Description>{description}</Description>
+          </Text>
+        )}
+      </div>
     </Container>
   </Page>;
 

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Text } from '@bufferapp/components';
 
 import {
-  black,
+  outerSpace,
   white,
 } from '@bufferapp/components/style/color';
 
@@ -40,7 +40,7 @@ const Inner = styled.div`
 
 const Title = styled.h1`
   display: block;
-  color: ${black};
+  color: ${outerSpace};
   font-size: 2.2rem;
   font-weight: 600;
   margin: 0 0 0.8rem;
@@ -48,7 +48,7 @@ const Title = styled.h1`
 
 const Description = styled.h2`
   display: block;
-  color: ${black};
+  color: ${outerSpace};
   font-size: 0.9rem;
   font-weight: 400;
   margin: 1rem auto 0;

--- a/packages/report/components/Cover/index.jsx
+++ b/packages/report/components/Cover/index.jsx
@@ -30,7 +30,7 @@ const Container = styled.div`
   box-sizing: border-box;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: top;
   text-align: center;
 `;
 
@@ -49,21 +49,33 @@ const Title = styled.h1`
 const Description = styled.h2`
   display: block;
   color: ${black};
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 400;
-  margin: 8rem auto 0;
+  margin: 1rem auto 0;
   text-align: center;
   line-height: 1.4;
+  padding: 0 2rem;
+`;
+
+const Bottom = styled.div`
+  position: absolute;
+  bottom: 12rem;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
 `;
 
 const Logo = styled.img`
   display: block;
-  margin: 0 auto 1rem;
+  margin: 0 auto;
   width: auto;
   min-width: 100px;
-  max-width: 200px;
+  max-width: 150px;
   height: auto;
-  max-height: 200px;
+  max-height: 150px;
 `;
 
 const Cover = ({ dateRange, logoUrl, name, description }) =>
@@ -72,15 +84,15 @@ const Cover = ({ dateRange, logoUrl, name, description }) =>
       <div>
         <Inner>
           <Text>
-            {logoUrl && <Logo src={logoUrl} alt={name} />}
             <Title>{name}</Title>
             <DateRange {...dateRange} />
+            {description && <Description>{description}</Description>}
           </Text>
         </Inner>
-        {description && (
-          <Text>
-            <Description>{description}</Description>
-          </Text>
+        {logoUrl && (
+          <Bottom>
+            <Logo src={logoUrl} alt={name} />
+          </Bottom>
         )}
       </div>
     </Container>

--- a/packages/report/components/Cover/story.jsx
+++ b/packages/report/components/Cover/story.jsx
@@ -15,7 +15,8 @@ const Card = styled.section`
 `;
 
 const name = 'Weekly Sync Report';
-const description = 'Weekly report of all the social account of Buffer. We only use organic posts in this report. It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.';
+const description = 'This is our performance report for our weekly sync on Thursdays. It has a focus on the last 7-day period, showing upward trends from the content we have posted.';
+const logoUrl = 'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5b1330ff80d92.jpg';
 
 const dateRange = {
   startDate: '02/20/2018',
@@ -46,7 +47,7 @@ storiesOf('Cover')
       <Cover
         name={name}
         dateRange={dateRange}
-        logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
+        logoUrl={logoUrl}
       />
     </Card>
   ))
@@ -56,7 +57,7 @@ storiesOf('Cover')
         name={name}
         description={description}
         dateRange={dateRange}
-        logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
+        logoUrl={logoUrl}
       />
     </Card>
   ));

--- a/packages/report/components/Cover/story.jsx
+++ b/packages/report/components/Cover/story.jsx
@@ -15,7 +15,7 @@ const Card = styled.section`
 `;
 
 const name = 'Weekly Sync Report';
-const description = 'Weekly report of all the social account of Buffer. We only use organic posts in this report. t is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.';
+const description = 'Weekly report of all the social account of Buffer. We only use organic posts in this report. It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.';
 
 const dateRange = {
   startDate: '02/20/2018',
@@ -24,7 +24,15 @@ const dateRange = {
 
 storiesOf('Cover')
   .addDecorator(checkA11y)
-  .add('renders a cover without a logo', () => (
+  .add('renders a cover with name and date', () => (
+    <Card>
+      <Cover
+        name={name}
+        dateRange={dateRange}
+      />
+    </Card>
+  ))
+  .add('renders a cover with name, date and description', () => (
     <Card>
       <Cover
         name={name}
@@ -33,10 +41,20 @@ storiesOf('Cover')
       />
     </Card>
   ))
-  .add('renders a cover with a logo', () => (
+  .add('renders a cover with logo, name and date', () => (
     <Card>
       <Cover
         name={name}
+        dateRange={dateRange}
+        logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
+      />
+    </Card>
+  ))
+  .add('renders a cover with logo, name, date and description', () => (
+    <Card>
+      <Cover
+        name={name}
+        description={description}
         dateRange={dateRange}
         logoUrl={'https://buffer-analyze.s3.amazonaws.com/report-logos/img_5afc8d8f209ec.jpg'}
       />

--- a/packages/report/components/DateRange/index.jsx
+++ b/packages/report/components/DateRange/index.jsx
@@ -10,7 +10,7 @@ const Date = ({ children }) => moment(children, 'MM/DD/YYYY').format('MMMM D, YY
 
 const DateRange = ({ startDate, endDate }) =>
   <Text
-    weight="bold"
+    weight="medium"
     color="black"
   >
     <Date>{startDate}</Date> to <Date>{endDate}</Date>

--- a/packages/report/components/DateRange/index.jsx
+++ b/packages/report/components/DateRange/index.jsx
@@ -6,12 +6,16 @@ import {
   Text,
 } from '@bufferapp/components';
 
+import {
+  outerSpace,
+} from '@bufferapp/components/style/color';
+
 const Date = ({ children }) => moment(children, 'MM/DD/YYYY').format('MMMM D, YYYY');
 
 const DateRange = ({ startDate, endDate }) =>
   <Text
     weight="semi-bold"
-    color="black"
+    color={outerSpace}
   >
     <Date>{startDate}</Date> to <Date>{endDate}</Date>
   </Text>;

--- a/packages/report/components/DateRange/index.jsx
+++ b/packages/report/components/DateRange/index.jsx
@@ -10,7 +10,7 @@ const Date = ({ children }) => moment(children, 'MM/DD/YYYY').format('MMMM D, YY
 
 const DateRange = ({ startDate, endDate }) =>
   <Text
-    weight="medium"
+    weight="semi-bold"
     color="black"
   >
     <Date>{startDate}</Date> to <Date>{endDate}</Date>

--- a/packages/report/components/DateRange/index.jsx
+++ b/packages/report/components/DateRange/index.jsx
@@ -1,35 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import styled from 'styled-components';
 
 import {
   Text,
 } from '@bufferapp/components';
 
-const Range = styled.span``;
-
 const Date = ({ children }) => moment(children, 'MM/DD/YYYY').format('MMMM D, YYYY');
 
-const DateRange = ({ startDate, endDate, large }) =>
+const DateRange = ({ startDate, endDate }) =>
   <Text
     weight="bold"
     color="black"
-    size={(large ? 'extra-large' : null)}
   >
-    <Range>
-      <Date>{startDate}</Date> to <Date>{endDate}</Date>
-    </Range>
+    <Date>{startDate}</Date> to <Date>{endDate}</Date>
   </Text>;
-
-DateRange.defaultProps = {
-  large: false,
-};
 
 DateRange.propTypes = {
   startDate: PropTypes.string.isRequired,
   endDate: PropTypes.string.isRequired,
-  large: PropTypes.bool,
 };
 
 export default DateRange;

--- a/packages/report/components/EditTitle/index.jsx
+++ b/packages/report/components/EditTitle/index.jsx
@@ -11,7 +11,7 @@ const Form = styled.form`
 const Input = styled.input`
   color: #000000;
   font-size: 2rem;
-  font-weight: 700;
+  font-weight: 600;
   font-family: ${fontFamily};
   margin: 0 0 .5rem;
   border: none;

--- a/packages/report/components/Report/index.jsx
+++ b/packages/report/components/Report/index.jsx
@@ -16,8 +16,8 @@ import {
 } from '@bufferapp/components/Icon/Icons';
 
 import {
-  black,
   offWhite,
+  outerSpace,
   white,
 } from '@bufferapp/components/style/color';
 
@@ -41,7 +41,7 @@ const Header = styled.div`
 
 const Title = styled.h1`
   display: inline-block;
-  color: ${black};
+  color: ${outerSpace};
   font-size: 2rem;
   font-weight: 600;
   margin: 0 0 .5rem 0;

--- a/packages/report/components/Report/index.jsx
+++ b/packages/report/components/Report/index.jsx
@@ -43,7 +43,7 @@ const Title = styled.h1`
   display: inline-block;
   color: ${black};
   font-size: 2rem;
-  font-weight: 700;
+  font-weight: 600;
   margin: 0 0 .5rem 0;
 `;
 

--- a/packages/shared-components/ChartTitle/index.jsx
+++ b/packages/shared-components/ChartTitle/index.jsx
@@ -8,21 +8,11 @@ const Header = styled.h2`
   padding: 0;
 `;
 
-const renderForApp = children => (
-  <Text color="outerSpace" weight="bold" size="large">
-    {children}
-  </Text>
-);
-
-const renderForReport = children => (
-  <Text color="black" weight="bold" size="extra-large">
-    {children}
-  </Text>
-);
-
 const Title = ({ children, forReport }) => (
   <Header>
-    {forReport ? renderForReport(children) : renderForApp(children)}
+    <Text color={forReport ? 'black' : 'outerSpace'} weight="semi-bold" size="large">
+      {children}
+    </Text>
   </Header>
 );
 

--- a/packages/shared-components/ChartTitle/index.jsx
+++ b/packages/shared-components/ChartTitle/index.jsx
@@ -8,9 +8,9 @@ const Header = styled.h2`
   padding: 0;
 `;
 
-const Title = ({ children, forReport }) => (
+const Title = ({ children }) => (
   <Header>
-    <Text color={forReport ? 'black' : 'outerSpace'} weight="semi-bold" size="large">
+    <Text color="outerSpace" weight="semi-bold" size="large">
       {children}
     </Text>
   </Header>
@@ -18,11 +18,6 @@ const Title = ({ children, forReport }) => (
 
 Title.propTypes = {
   children: PropTypes.node.isRequired,
-  forReport: PropTypes.bool,
-};
-
-Title.defaultProps = {
-  forReport: false,
 };
 
 export default Title;

--- a/packages/summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/summary-table/__snapshots__/snapshot.test.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshots SummaryTable should render a "no data" state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -93,7 +93,7 @@ exports[`Snapshots SummaryTable should render a loading state 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -213,7 +213,7 @@ exports[`Snapshots SummaryTable should render the summary table 1`] = `
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -978,7 +978,7 @@ exports[`Snapshots SummaryTable should render the summary table with 5 metrics o
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -1455,7 +1455,7 @@ exports[`Snapshots SummaryTable should render the summary table with 6 metrics o
                 "color": "#323b43",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1.25rem",
-                "fontWeight": 700,
+                "fontWeight": 600,
               }
             }
           >
@@ -2015,7 +2015,7 @@ exports[`Snapshots Title should render title as if for app 1`] = `
           "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
-          "fontWeight": 700,
+          "fontWeight": 600,
         }
       }
     >
@@ -2035,8 +2035,8 @@ exports[`Snapshots Title should render title as if for report 1`] = `
         Object {
           "color": "#000",
           "fontFamily": "\\"Roboto\\", sans-serif",
-          "fontSize": "1.5rem",
-          "fontWeight": 700,
+          "fontSize": "1.25rem",
+          "fontWeight": 600,
         }
       }
     >

--- a/packages/summary-table/__snapshots__/snapshot.test.js.snap
+++ b/packages/summary-table/__snapshots__/snapshot.test.js.snap
@@ -2033,7 +2033,7 @@ exports[`Snapshots Title should render title as if for report 1`] = `
     <span
       style={
         Object {
-          "color": "#000",
+          "color": "#323b43",
           "fontFamily": "\\"Roboto\\", sans-serif",
           "fontSize": "1.25rem",
           "fontWeight": 600,

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -671,7 +671,7 @@ exports[`Snapshots App should render application 1`] = `
       }
     >
       <div
-        className="sc-iQtOjA dtchbn"
+        className="sc-hjRWVT cWDxVM"
       >
         <div
           style={
@@ -707,7 +707,7 @@ exports[`Snapshots App should render application 1`] = `
             target="_self"
           >
             <span
-              className="sc-hjRWVT cBIsoO"
+              className="sc-gPzReC eXTgrB"
               selected={false}
             >
               <span
@@ -781,7 +781,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hjRWVT cBIsoO"
+                className="sc-gPzReC eXTgrB"
                 selected={false}
               >
                 <span
@@ -817,7 +817,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hjRWVT cBIsoO"
+                className="sc-gPzReC eXTgrB"
                 selected={false}
               >
                 <span
@@ -853,7 +853,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hjRWVT cBIsoO"
+                className="sc-gPzReC eXTgrB"
                 selected={false}
               >
                 <span
@@ -928,7 +928,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hjRWVT cBIsoO"
+                className="sc-gPzReC eXTgrB"
                 selected={false}
               >
                 <span
@@ -964,7 +964,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hjRWVT cBIsoO"
+                className="sc-gPzReC eXTgrB"
                 selected={false}
               >
                 <span
@@ -1008,7 +1008,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-iybRtq cIsBKw"
+                className="sc-jrIrqw cEZmHW"
               >
                 <span
                   style={
@@ -1160,7 +1160,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hjRWVT cBIsoO"
+          className="sc-gPzReC eXTgrB"
           selected={false}
         >
           <span
@@ -1234,7 +1234,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1270,7 +1270,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1306,7 +1306,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1381,7 +1381,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1417,7 +1417,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1461,7 +1461,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-iybRtq cIsBKw"
+            className="sc-jrIrqw cEZmHW"
           >
             <span
               style={
@@ -1571,7 +1571,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
 exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
 <span>
   <div
-    className="sc-iQtOjA dtchbn"
+    className="sc-hjRWVT cWDxVM"
   >
     <div
       style={
@@ -1607,7 +1607,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hjRWVT hMxHKQ"
+          className="sc-gPzReC fRlrRs"
           selected={true}
         >
           <span
@@ -1681,7 +1681,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1717,7 +1717,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1753,7 +1753,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1828,7 +1828,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1864,7 +1864,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -1908,7 +1908,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-iybRtq cIsBKw"
+            className="sc-jrIrqw cEZmHW"
           >
             <span
               style={
@@ -2058,7 +2058,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hjRWVT cBIsoO"
+          className="sc-gPzReC eXTgrB"
           selected={false}
         >
           <span
@@ -2132,7 +2132,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2168,7 +2168,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2204,7 +2204,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2279,7 +2279,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2315,7 +2315,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2359,7 +2359,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-iybRtq cIsBKw"
+            className="sc-jrIrqw cEZmHW"
           >
             <span
               style={
@@ -2469,7 +2469,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-eIHaNI cglKAF"
+    className="sc-fyjhYU dICcqR"
   >
     <div
       style={
@@ -2505,7 +2505,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         target="_self"
       >
         <span
-          className="sc-hjRWVT cBIsoO"
+          className="sc-gPzReC eXTgrB"
           selected={false}
         >
           <span
@@ -2579,7 +2579,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2615,7 +2615,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2651,7 +2651,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2726,7 +2726,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2762,7 +2762,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT cBIsoO"
+            className="sc-gPzReC eXTgrB"
             selected={false}
           >
             <span
@@ -2806,7 +2806,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-iybRtq cIsBKw"
+            className="sc-jrIrqw cEZmHW"
           >
             <span
               style={
@@ -2825,10 +2825,10 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
       </div>
     </div>
     <div
-      className="sc-eTpRJs ipHQoi"
+      className="sc-ugnQR eAqyrK"
     >
       <header
-        className="sc-iomxrj bzhmWY"
+        className="sc-eTpRJs iwoWUf"
       >
         <button
           className="sc-kgoBCf cmMzae"
@@ -2848,7 +2848,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           </span>
         </button>
         <section
-          className="sc-iFMziU jYbhbN"
+          className="sc-iomxrj gIqDNc"
         >
           <div
             className="sc-kjoXOD bKsEHy"
@@ -3188,7 +3188,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
             />
           </div>
           <span
-            className="sc-fgfRvd rrfPA"
+            className="sc-eKZiaR cZJwvp"
           >
             <button
               className="sc-kgoBCf cmMzae"
@@ -3211,13 +3211,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </section>
       </header>
       <div
-        className="sc-dxZgTM cNUVIy"
+        className="sc-eIHaNI iBitcT"
       >
         <section
-          className="sc-dvCyap kSWGrX"
+          className="sc-dxZgTM eiKyMN"
         >
           <div
-            className="sc-eKZiaR dnXDWb"
+            className="sc-ePZHVD loUMUo"
           >
             <div
               className="sc-bwzfXH eFBPoz"

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -671,7 +671,7 @@ exports[`Snapshots App should render application 1`] = `
       }
     >
       <div
-        className="sc-hjRWVT cWDxVM"
+        className="sc-iybRtq cgQDKR"
       >
         <div
           style={
@@ -707,7 +707,7 @@ exports[`Snapshots App should render application 1`] = `
             target="_self"
           >
             <span
-              className="sc-gPzReC eXTgrB"
+              className="sc-jrIrqw dwJJul"
               selected={false}
             >
               <span
@@ -781,7 +781,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-gPzReC eXTgrB"
+                className="sc-jrIrqw dwJJul"
                 selected={false}
               >
                 <span
@@ -817,7 +817,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-gPzReC eXTgrB"
+                className="sc-jrIrqw dwJJul"
                 selected={false}
               >
                 <span
@@ -853,7 +853,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-gPzReC eXTgrB"
+                className="sc-jrIrqw dwJJul"
                 selected={false}
               >
                 <span
@@ -928,7 +928,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-gPzReC eXTgrB"
+                className="sc-jrIrqw dwJJul"
                 selected={false}
               >
                 <span
@@ -964,7 +964,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-gPzReC eXTgrB"
+                className="sc-jrIrqw dwJJul"
                 selected={false}
               >
                 <span
@@ -1008,7 +1008,7 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-jrIrqw cEZmHW"
+                className="sc-hjRWVT bAshbN"
               >
                 <span
                   style={
@@ -1160,7 +1160,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
         target="_self"
       >
         <span
-          className="sc-gPzReC eXTgrB"
+          className="sc-jrIrqw dwJJul"
           selected={false}
         >
           <span
@@ -1234,7 +1234,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1270,7 +1270,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1306,7 +1306,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1381,7 +1381,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1417,7 +1417,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1461,7 +1461,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-jrIrqw cEZmHW"
+            className="sc-hjRWVT bAshbN"
           >
             <span
               style={
@@ -1571,7 +1571,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
 exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
 <span>
   <div
-    className="sc-hjRWVT cWDxVM"
+    className="sc-iybRtq cgQDKR"
   >
     <div
       style={
@@ -1607,7 +1607,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
         target="_self"
       >
         <span
-          className="sc-gPzReC fRlrRs"
+          className="sc-jrIrqw eRshJy"
           selected={true}
         >
           <span
@@ -1681,7 +1681,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1717,7 +1717,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1753,7 +1753,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1828,7 +1828,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1864,7 +1864,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -1908,7 +1908,7 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-jrIrqw cEZmHW"
+            className="sc-hjRWVT bAshbN"
           >
             <span
               style={
@@ -2058,7 +2058,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
         target="_self"
       >
         <span
-          className="sc-gPzReC eXTgrB"
+          className="sc-jrIrqw dwJJul"
           selected={false}
         >
           <span
@@ -2132,7 +2132,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2168,7 +2168,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2204,7 +2204,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2279,7 +2279,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2315,7 +2315,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2359,7 +2359,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-jrIrqw cEZmHW"
+            className="sc-hjRWVT bAshbN"
           >
             <span
               style={
@@ -2469,7 +2469,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-fyjhYU dICcqR"
+    className="sc-ugnQR dXiuzX"
   >
     <div
       style={
@@ -2505,7 +2505,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         target="_self"
       >
         <span
-          className="sc-gPzReC eXTgrB"
+          className="sc-jrIrqw dwJJul"
           selected={false}
         >
           <span
@@ -2579,7 +2579,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2615,7 +2615,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2651,7 +2651,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2726,7 +2726,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2762,7 +2762,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-gPzReC eXTgrB"
+            className="sc-jrIrqw dwJJul"
             selected={false}
           >
             <span
@@ -2806,7 +2806,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-jrIrqw cEZmHW"
+            className="sc-hjRWVT bAshbN"
           >
             <span
               style={
@@ -2825,10 +2825,10 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
       </div>
     </div>
     <div
-      className="sc-ugnQR eAqyrK"
+      className="sc-eIHaNI fXpSSI"
     >
       <header
-        className="sc-eTpRJs iwoWUf"
+        className="sc-dxZgTM cgjjg"
       >
         <button
           className="sc-kgoBCf cmMzae"
@@ -2848,7 +2848,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           </span>
         </button>
         <section
-          className="sc-iomxrj gIqDNc"
+          className="sc-dvCyap dbxjpg"
         >
           <div
             className="sc-kjoXOD bKsEHy"
@@ -3188,7 +3188,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
             />
           </div>
           <span
-            className="sc-eKZiaR cZJwvp"
+            className="sc-drMfKT jNmFlF"
           >
             <button
               className="sc-kgoBCf cmMzae"
@@ -3211,13 +3211,13 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </section>
       </header>
       <div
-        className="sc-eIHaNI iBitcT"
+        className="sc-eTpRJs fFYnHR"
       >
         <section
-          className="sc-dxZgTM eiKyMN"
+          className="sc-iomxrj eJYqbR"
         >
           <div
-            className="sc-ePZHVD loUMUo"
+            className="sc-likbZx lhrdkz"
           >
             <div
               className="sc-bwzfXH eFBPoz"


### PR DESCRIPTION
### Purpose
This contains a few visual updates to the reports cover page. Things were looking a little hectic and it needed calming down a bit visually. I've rebalanced a few of the weights and sizes in the reports and in the chart headers so everything feels a little more consistent from the graphs to the reports to the PDF export.

### Notes
I was able to remove some code that didn't seem needed anymore as the chart headers for app and reports is now the same :)

### Staging Deployment
This repo is CI/CD enabled and staging deployment should be available at:
https://better-report-cover-analyze.dev.buffer.com/ :smile:
