### PR TITLE
Trial status on sidebar

### DIFF
--- a/packages/account/.babelrc
+++ b/packages/account/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "es2015",
+    "react",
+    "stage-0"
+  ],
+  "plugins": [
+    "react-hot-loader/babel"
+  ]
+}

--- a/packages/account/README.md
+++ b/packages/account/README.md
@@ -1,0 +1,115 @@
+# @bufferapp/account
+
+Account information for Analyze
+
+- [Quick Start](#quick-start)
+- [Package Anatomy](#component-anatomy)
+
+## Quick Start
+
+### Start Storybook
+
+If you're interested in working on or observing _how things look_, starting with [React Storybook](https://storybook.js.org/) is a great way to get going. It's setup to automatically reload as the code changes to make it easy to do rapid iteration on components.
+
+
+```sh
+npm start
+```
+
+After that copy and paste the host and port that is displayed on the console into a browser.
+
+#### Developing Multiple Packages In Parallel
+
+If you're running this for multiple packages at the same time, it's helpful to pass in the port number.
+
+```sh
+npm start -- --port 8003
+```
+
+### Run Tests
+
+Tests are run using [Jest](https://facebook.github.io/jest/) and UIs are tested and locked down using [Jest Snapshots](https://facebook.github.io/jest/docs/snapshot-testing.html) and [React Storybook](https://storybook.js.org/).
+
+#### Standard Tests
+
+Runs linter, then unit and snapshot tests. These tests are run using CI and are currently running on TravisCI:
+
+https://travis-ci.com/bufferapp/buffer-publish
+
+```bash
+npm test
+```
+
+#### Watch Mode
+
+When writing unit tests for things like middleware and the main index file, it's useful to only run the test that change so you can rapidly iterate. Jest watch mode allows you do do this with a single command:
+
+```sh
+npm run test-watch
+```
+
+## Package Anatomy
+
+A UI package should include all concerns related to a given feature.
+
+```
+account/ # root
++-- __snapshots__/
+    `-- snapshot.test.js.snap # jest snapshots storage
++-- .storybook/ # React Storybook Configuration
+    `-- addons.js # storybook action panel configuration
+    `-- config.js # storybook main configuration
+    `-- preview-head.html # configure <head> in storybook preview
++-- components/ # presentational components
+    +--  # component that is only used in the package
+        `-- index.jsx # implementation of the component
+        `-- story.jsx # description of all the possible configurations of the component
+`-- .babelrc # babel transpiler
+`-- index.js # main package file, should export the container and top level  resources
+`-- index.test.js # main package file tests
+`-- middleware.js # all action side effects
+`-- middleware.test.js # test action side effects
+`-- package.json # npm package
+`-- README.md # you are here
+`-- reducer.js # describe how data changes when actions occur
+`-- reducer.test.js # test the reducer!
+`-- snapshot.test.js # configure jest snapshots
+```
+
+### index.js
+
+This is the main package file, it's default export should be the container.
+
+Imagine another package is trying to use the package you're building. The package API should look like this:
+
+```js
+import Account, { actions, actionTypes, middleware, reducer } from '@bufferapp/account';
+```
+
+### components/
+
+Presentational components ([pure ui](https://rauchg.com/2015/pure-ui)) are implemented with the followign structure:
+
+```
++-- components/
+    +-- /
+        `-- index.jsx
+        `-- story.jsx
+```
+
+#### components//index.jsx
+
+This should export a [functional and stateless](https://medium.com/@housecor/react-stateless-functional-components-nine-wins-you-might-have-overlooked-997b0d933dbc#.ukhlhrqlw) component. There are some special cases where handling things like `focus`, `hover` and active states that need to be tracked.
+
+If you need `focus` and or `hover` take a look at PseudoClassComponent to wrap the component you're building:
+
+https://github.com/bufferapp/buffer-components/blob/master/PseudoClassComponent/index.jsx
+
+Here's an example of how to wrap a `Button`:
+
+https://github.com/bufferapp/buffer-components/blob/master/Button/index.jsx
+
+#### components//story.jsx
+
+This should set the context (properties) for every configuration of the component in `index.jsx`. The story is used for both `React Storybook` as well as `Jest Snapshots`.
+

--- a/packages/account/index.js
+++ b/packages/account/index.js
@@ -1,0 +1,3 @@
+// export reducer, actions and action types
+export reducer, { actions, actionTypes } from './reducer';
+export middleware from './middleware';

--- a/packages/account/index.test.jsx
+++ b/packages/account/index.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import {
+  reducer,
+  actions,
+  actionTypes,
+  middleware,
+} from './index';
+
+describe('AccountContainer', () => {
+
+  it('should export reducer', () => {
+    expect(reducer)
+      .toBeDefined();
+  });
+
+  it('should export actions', () => {
+    expect(actions)
+      .toBeDefined();
+  });
+
+  it('should export actionTypes', () => {
+    expect(actionTypes)
+      .toBeDefined();
+  });
+
+  it('should export middleware', () => {
+    expect(middleware)
+      .toBeDefined();
+  });
+});

--- a/packages/account/middleware.js
+++ b/packages/account/middleware.js
@@ -1,0 +1,17 @@
+import { actions, actionTypes as fetchActions } from '@bufferapp/async-data-fetch';
+
+export default store => next => (action) => { // eslint-disable-line no-unused-vars
+  switch (action.type) {
+    case `profiles_${fetchActions.FETCH_SUCCESS}`:
+      store.dispatch(actions.fetch({
+        name: 'get_account_details',
+        args: {
+          organizationId: action.result[0].organizationId,
+        },
+      }));
+      break;
+    default:
+      break;
+  }
+  return next(action);
+};

--- a/packages/account/middleware.test.js
+++ b/packages/account/middleware.test.js
@@ -1,0 +1,26 @@
+import { actions, actionTypes as fetchActions } from '@bufferapp/async-data-fetch';
+import middleware from './middleware';
+
+describe('middleware', () => {
+  const state = {};
+  const store = {
+    dispatch: jest.fn(),
+    getState: jest.fn(() => state),
+  };
+  const next = jest.fn();
+  it('it should request account details on profiles_FETCH_SUCCESS', () => {
+    const action = {
+      type: `profiles_${fetchActions.FETCH_SUCCESS}`,
+      result: [{
+        organizationId: 'org-1',
+      }],
+    };
+    middleware(store)(next)(action);
+    expect(store.dispatch).toHaveBeenCalledWith(actions.fetch({
+      name: 'get_account_details',
+      args: {
+        organizationId: 'org-1',
+      },
+    }));
+  });
+});

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bufferapp/analyze-account",
+  "version": "0.0.1",
+  "description": "Account information for Analyze",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern coverage node_modules",
+    "test": "sh ../../package_test.sh",
+    "test-update": "jest -u"
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!@bufferapp/*)"
+    ],
+    "verbose": true,
+    "moduleNameMapper": {
+      "\\.(css|less)$": "identity-obj-proxy"
+    }
+  },
+  "author": "mike@msanroman.io",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "eslint": "3.19.0",
+    "jest": "19.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/account/reducer.js
+++ b/packages/account/reducer.js
@@ -1,0 +1,23 @@
+import { actionTypes as asyncDataFetchActionTypes } from '@bufferapp/async-data-fetch';
+
+export const actionTypes = {};
+
+const initialState = {
+  trialDaysRemaining: -1,
+  onTrial: false,
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case `get_account_details_${asyncDataFetchActionTypes.FETCH_SUCCESS}`:
+      return {
+        ...state,
+        trialDaysRemaining: action.result.daysRemaining,
+        onTrial: action.result.onTrial,
+      };
+    default:
+      return state;
+  }
+};
+
+export const actions = {};

--- a/packages/account/reducer.test.js
+++ b/packages/account/reducer.test.js
@@ -1,0 +1,23 @@
+import { actionTypes } from '@bufferapp/async-data-fetch';
+import reducer from './reducer';
+
+describe('reducer', () => {
+  it('initial state has no trial information', () => {
+    const initialState = reducer(undefined, {});
+    expect(initialState.onTrial).toBeFalsy();
+    expect(initialState.trialDaysRemaining).toBe(-1);
+  });
+
+  it('gets trial information on a successful response from /get_account_details', () => {
+    const state = reducer(undefined, {
+      type: `get_account_details_${actionTypes.FETCH_SUCCESS}`,
+      result: {
+        onTrial: true,
+        daysRemaining: 7,
+      },
+    });
+
+    expect(state.onTrial).toBeTruthy();
+    expect(state.trialDaysRemaining).toBe(7);
+  });
+});

--- a/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
+++ b/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
@@ -194,7 +194,7 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
+                "fontSize": "0.5rem",
                 "fontWeight": 500,
               }
             }
@@ -341,7 +341,7 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
+                "fontSize": "0.5rem",
                 "fontWeight": 500,
               }
             }
@@ -448,19 +448,49 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
           target="_self"
         >
           <span
-            className="sc-bwzfXH jkMRYo"
+            className="sc-bwzfXH XIkvy"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+             
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>
@@ -562,7 +592,7 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
+                "fontSize": "0.5rem",
                 "fontWeight": 500,
               }
             }
@@ -709,7 +739,7 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
+                "fontSize": "0.5rem",
                 "fontWeight": 500,
               }
             }
@@ -816,19 +846,49 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
           target="_self"
         >
           <span
-            className="sc-bwzfXH jkMRYo"
+            className="sc-bwzfXH XIkvy"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+             
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>
@@ -930,7 +990,7 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
+                "fontSize": "0.5rem",
                 "fontWeight": 500,
               }
             }
@@ -1077,7 +1137,7 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.75rem",
+                "fontSize": "0.5rem",
                 "fontWeight": 500,
               }
             }
@@ -1184,19 +1244,49 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
           target="_self"
         >
           <span
-            className="sc-bwzfXH jkMRYo"
+            className="sc-bwzfXH XIkvy"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+             
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>

--- a/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
+++ b/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
@@ -102,6 +102,485 @@ exports[`Snapshots Item normal state 1`] = `
 </span>
 `;
 
+exports[`Snapshots NavSidebar Trial status should have a link to org admin if viewed by the account owner 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "height": "100%",
+        "width": "260px",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fff",
+          "borderRight": "1px solid #e6ebef",
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "maxHeight": "100vh",
+          "minHeight": "100vh",
+          "padding": "0.75rem 0",
+          "width": "200px",
+        }
+      }
+    >
+      <a
+        href="/"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "color": "#168eea",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "outline": "none",
+            "padding": "0",
+            "textDecoration": "none",
+          }
+        }
+        target="_self"
+      >
+        <span
+          className="sc-bdVaJa eZRxo"
+          selected={false}
+        >
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            Dashboard
+          </span>
+        </span>
+      </a>
+      <hr
+        style={
+          Object {
+            "background": "#e6ebef",
+            "border": "none",
+            "boxSizing": "border-box",
+            "height": "0.063rem",
+            "marginBottom": "1rem",
+            "marginTop": "0.75rem",
+            "width": "100%",
+          }
+        }
+      />
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Insights
+          </span>
+        </span>
+        <a
+          href="/overview"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Overview
+            </span>
+          </span>
+        </a>
+        <a
+          href="/posts"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
+        <hr
+          style={
+            Object {
+              "background": "#e6ebef",
+              "border": "none",
+              "boxSizing": "border-box",
+              "height": "0.063rem",
+              "marginBottom": "1rem",
+              "marginTop": "0.75rem",
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Tools
+          </span>
+        </span>
+        <a
+          href="/comparisons/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Comparisons
+            </span>
+          </span>
+        </a>
+        <a
+          href="/reports/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Reports
+            </span>
+          </span>
+        </a>
+      </div>
+      <div
+        style={
+          Object {
+            "marginTop": "auto",
+          }
+        }
+      >
+        <span
+          className="sc-bxivhb hTpJur"
+        >
+          <span
+            className="sc-EHOje bfZdDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#168eea",
+                  "height": "13px",
+                  "width": "13px",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="#168eea"
+              >
+                <path
+                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z M8,14 C11.3137085,14 14,11.3137085 14,8 C14,4.6862915 11.3137085,2 8,2 C4.6862915,2 2,4.6862915 2,8 C2,11.3137085 4.6862915,14 8,14 Z"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  width="2"
+                  x="7"
+                  y="3"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  transform="translate(9.418427, 9.578427) rotate(-225.000000) translate(-9.418427, -9.578427) "
+                  width="2"
+                  x="8.41842728"
+                  y="6.57842712"
+                />
+              </g>
+            </svg>
+          </span>
+          <span
+            className="sc-ifAKCX dMBlCr"
+          >
+            <a
+              href="https://buffer.com/manage/organization123/analyze"
+              onBlur={[Function]}
+              onClick={undefined}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "color": "#168eea",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "outline": "none",
+                  "padding": "0",
+                  "textDecoration": "none",
+                }
+              }
+              target="_self"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#168eea",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Trial ends 
+                today
+              </span>
+            </a>
+          </span>
+        </span>
+        <a
+          href="mailto:hello+analyze@buffer.com?subject=Analyze feedback"
+          onBlur={[Function]}
+          onClick={undefined}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bwzfXH fodwfL"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
 exports[`Snapshots NavSidebar displays trial status if user is on trial 1`] = `
 <span>
   <div
@@ -477,18 +956,20 @@ exports[`Snapshots NavSidebar displays trial status if user is on trial 1`] = `
           <span
             className="sc-ifAKCX dMBlCr"
           >
-            <span
-              style={
-                Object {
-                  "color": "#168eea",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 400,
+            <span>
+              <span
+                style={
+                  Object {
+                    "color": "#168eea",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
                 }
-              }
-            >
-              Trial ends 
-              in 7 days
+              >
+                Trial ends 
+                in 7 days
+              </span>
             </span>
           </span>
         </span>
@@ -2128,18 +2609,20 @@ exports[`Snapshots NavSidebar trial ends today 1`] = `
           <span
             className="sc-ifAKCX dMBlCr"
           >
-            <span
-              style={
-                Object {
-                  "color": "#168eea",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 400,
+            <span>
+              <span
+                style={
+                  Object {
+                    "color": "#168eea",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
                 }
-              }
-            >
-              Trial ends 
-              today
+              >
+                Trial ends 
+                today
+              </span>
             </span>
           </span>
         </span>
@@ -2588,18 +3071,20 @@ exports[`Snapshots NavSidebar trial status for 1 day remaining 1`] = `
           <span
             className="sc-ifAKCX dMBlCr"
           >
-            <span
-              style={
-                Object {
-                  "color": "#168eea",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "0.75rem",
-                  "fontWeight": 400,
+            <span>
+              <span
+                style={
+                  Object {
+                    "color": "#168eea",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
                 }
-              }
-            >
-              Trial ends 
-              in 1 day
+              >
+                Trial ends 
+                in 1 day
+              </span>
             </span>
           </span>
         </span>

--- a/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
+++ b/packages/nav-sidebar/__snapshots__/snapshot.test.js.snap
@@ -102,7 +102,7 @@ exports[`Snapshots Item normal state 1`] = `
 </span>
 `;
 
-exports[`Snapshots NavSidebar if there are no profiles it should not show the Insights section 1`] = `
+exports[`Snapshots NavSidebar displays trial status if user is on trial 1`] = `
 <span>
   <div
     style={
@@ -147,16 +147,16 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
         target="_self"
       >
         <span
-          className="sc-bdVaJa ijtgk"
-          selected={true}
+          className="sc-bdVaJa eZRxo"
+          selected={false}
         >
           <span
             style={
               Object {
-                "color": "#323b43",
+                "color": "#59626a",
                 "fontFamily": "\\"Roboto\\", sans-serif",
                 "fontSize": "1rem",
-                "fontWeight": 700,
+                "fontWeight": 400,
               }
             }
           >
@@ -194,7 +194,7 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.5rem",
+                "fontSize": "0.75rem",
                 "fontWeight": 500,
               }
             }
@@ -341,7 +341,467 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.5rem",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Tools
+          </span>
+        </span>
+        <a
+          href="/comparisons/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Comparisons
+            </span>
+          </span>
+        </a>
+        <a
+          href="/reports/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Reports
+            </span>
+          </span>
+        </a>
+      </div>
+      <div
+        style={
+          Object {
+            "marginTop": "auto",
+          }
+        }
+      >
+        <span
+          className="sc-bxivhb hTpJur"
+        >
+          <span
+            className="sc-EHOje bfZdDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#168eea",
+                  "height": "13px",
+                  "width": "13px",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="#168eea"
+              >
+                <path
+                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z M8,14 C11.3137085,14 14,11.3137085 14,8 C14,4.6862915 11.3137085,2 8,2 C4.6862915,2 2,4.6862915 2,8 C2,11.3137085 4.6862915,14 8,14 Z"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  width="2"
+                  x="7"
+                  y="3"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  transform="translate(9.418427, 9.578427) rotate(-225.000000) translate(-9.418427, -9.578427) "
+                  width="2"
+                  x="8.41842728"
+                  y="6.57842712"
+                />
+              </g>
+            </svg>
+          </span>
+          <span
+            className="sc-ifAKCX dMBlCr"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#168eea",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Trial ends 
+              in 7 days
+            </span>
+          </span>
+        </span>
+        <a
+          href="mailto:hello+analyze@buffer.com?subject=Analyze feedback"
+          onBlur={[Function]}
+          onClick={undefined}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bwzfXH fodwfL"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`Snapshots NavSidebar if there are no profiles it should not show the Insights section 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "height": "100%",
+        "width": "260px",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fff",
+          "borderRight": "1px solid #e6ebef",
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "maxHeight": "100vh",
+          "minHeight": "100vh",
+          "padding": "0.75rem 0",
+          "width": "200px",
+        }
+      }
+    >
+      <a
+        href="/"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "color": "#168eea",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "outline": "none",
+            "padding": "0",
+            "textDecoration": "none",
+          }
+        }
+        target="_self"
+      >
+        <span
+          className="sc-bdVaJa ijtgk"
+          selected={true}
+        >
+          <span
+            style={
+              Object {
+                "color": "#323b43",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 700,
+              }
+            }
+          >
+            Dashboard
+          </span>
+        </span>
+      </a>
+      <hr
+        style={
+          Object {
+            "background": "#e6ebef",
+            "border": "none",
+            "boxSizing": "border-box",
+            "height": "0.063rem",
+            "marginBottom": "1rem",
+            "marginTop": "0.75rem",
+            "width": "100%",
+          }
+        }
+      />
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Insights
+          </span>
+        </span>
+        <a
+          href="/overview"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Overview
+            </span>
+          </span>
+        </a>
+        <a
+          href="/posts"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
+        <hr
+          style={
+            Object {
+              "background": "#e6ebef",
+              "border": "none",
+              "boxSizing": "border-box",
+              "height": "0.063rem",
+              "marginBottom": "1rem",
+              "marginTop": "0.75rem",
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
                 "fontWeight": 500,
               }
             }
@@ -448,7 +908,7 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
           target="_self"
         >
           <span
-            className="sc-bwzfXH XIkvy"
+            className="sc-bwzfXH fodwfL"
           >
             <svg
               height="100%"
@@ -475,7 +935,6 @@ exports[`Snapshots NavSidebar if there are no profiles it should not show the In
                 />
               </g>
             </svg>
-             
             <span
               className="sc-htpNat dvzxOY"
             >
@@ -592,7 +1051,7 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.5rem",
+                "fontSize": "0.75rem",
                 "fontWeight": 500,
               }
             }
@@ -739,7 +1198,7 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.5rem",
+                "fontSize": "0.75rem",
                 "fontWeight": 500,
               }
             }
@@ -846,7 +1305,7 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
           target="_self"
         >
           <span
-            className="sc-bwzfXH XIkvy"
+            className="sc-bwzfXH fodwfL"
           >
             <svg
               height="100%"
@@ -873,7 +1332,6 @@ exports[`Snapshots NavSidebar should show nav sidebar with Dashboard as active l
                 />
               </g>
             </svg>
-             
             <span
               className="sc-htpNat dvzxOY"
             >
@@ -990,7 +1448,7 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.5rem",
+                "fontSize": "0.75rem",
                 "fontWeight": 500,
               }
             }
@@ -1137,7 +1595,7 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
               Object {
                 "color": "#8A9097",
                 "fontFamily": "\\"Roboto\\", sans-serif",
-                "fontSize": "0.5rem",
+                "fontSize": "0.75rem",
                 "fontWeight": 500,
               }
             }
@@ -1244,7 +1702,7 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
           target="_self"
         >
           <span
-            className="sc-bwzfXH XIkvy"
+            className="sc-bwzfXH fodwfL"
           >
             <svg
               height="100%"
@@ -1271,7 +1729,926 @@ exports[`Snapshots NavSidebar should show only services for which the user has p
                 />
               </g>
             </svg>
-             
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`Snapshots NavSidebar trial ends today 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "height": "100%",
+        "width": "260px",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fff",
+          "borderRight": "1px solid #e6ebef",
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "maxHeight": "100vh",
+          "minHeight": "100vh",
+          "padding": "0.75rem 0",
+          "width": "200px",
+        }
+      }
+    >
+      <a
+        href="/"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "color": "#168eea",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "outline": "none",
+            "padding": "0",
+            "textDecoration": "none",
+          }
+        }
+        target="_self"
+      >
+        <span
+          className="sc-bdVaJa eZRxo"
+          selected={false}
+        >
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            Dashboard
+          </span>
+        </span>
+      </a>
+      <hr
+        style={
+          Object {
+            "background": "#e6ebef",
+            "border": "none",
+            "boxSizing": "border-box",
+            "height": "0.063rem",
+            "marginBottom": "1rem",
+            "marginTop": "0.75rem",
+            "width": "100%",
+          }
+        }
+      />
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Insights
+          </span>
+        </span>
+        <a
+          href="/overview"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Overview
+            </span>
+          </span>
+        </a>
+        <a
+          href="/posts"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
+        <hr
+          style={
+            Object {
+              "background": "#e6ebef",
+              "border": "none",
+              "boxSizing": "border-box",
+              "height": "0.063rem",
+              "marginBottom": "1rem",
+              "marginTop": "0.75rem",
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Tools
+          </span>
+        </span>
+        <a
+          href="/comparisons/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Comparisons
+            </span>
+          </span>
+        </a>
+        <a
+          href="/reports/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Reports
+            </span>
+          </span>
+        </a>
+      </div>
+      <div
+        style={
+          Object {
+            "marginTop": "auto",
+          }
+        }
+      >
+        <span
+          className="sc-bxivhb hTpJur"
+        >
+          <span
+            className="sc-EHOje bfZdDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#168eea",
+                  "height": "13px",
+                  "width": "13px",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="#168eea"
+              >
+                <path
+                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z M8,14 C11.3137085,14 14,11.3137085 14,8 C14,4.6862915 11.3137085,2 8,2 C4.6862915,2 2,4.6862915 2,8 C2,11.3137085 4.6862915,14 8,14 Z"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  width="2"
+                  x="7"
+                  y="3"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  transform="translate(9.418427, 9.578427) rotate(-225.000000) translate(-9.418427, -9.578427) "
+                  width="2"
+                  x="8.41842728"
+                  y="6.57842712"
+                />
+              </g>
+            </svg>
+          </span>
+          <span
+            className="sc-ifAKCX dMBlCr"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#168eea",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Trial ends 
+              today
+            </span>
+          </span>
+        </span>
+        <a
+          href="mailto:hello+analyze@buffer.com?subject=Analyze feedback"
+          onBlur={[Function]}
+          onClick={undefined}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bwzfXH fodwfL"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-htpNat dvzxOY"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`Snapshots NavSidebar trial status for 1 day remaining 1`] = `
+<span>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "height": "100%",
+        "width": "260px",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fff",
+          "borderRight": "1px solid #e6ebef",
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "maxHeight": "100vh",
+          "minHeight": "100vh",
+          "padding": "0.75rem 0",
+          "width": "200px",
+        }
+      }
+    >
+      <a
+        href="/"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "color": "#168eea",
+            "fontFamily": "\\"Roboto\\", sans-serif",
+            "outline": "none",
+            "padding": "0",
+            "textDecoration": "none",
+          }
+        }
+        target="_self"
+      >
+        <span
+          className="sc-bdVaJa eZRxo"
+          selected={false}
+        >
+          <span
+            style={
+              Object {
+                "color": "#59626a",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+              }
+            }
+          >
+            Dashboard
+          </span>
+        </span>
+      </a>
+      <hr
+        style={
+          Object {
+            "background": "#e6ebef",
+            "border": "none",
+            "boxSizing": "border-box",
+            "height": "0.063rem",
+            "marginBottom": "1rem",
+            "marginTop": "0.75rem",
+            "width": "100%",
+          }
+        }
+      />
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Insights
+          </span>
+        </span>
+        <a
+          href="/overview"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Overview
+            </span>
+          </span>
+        </a>
+        <a
+          href="/posts"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Posts
+            </span>
+          </span>
+        </a>
+        <a
+          href="/answers"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Answers
+            </span>
+          </span>
+        </a>
+        <hr
+          style={
+            Object {
+              "background": "#e6ebef",
+              "border": "none",
+              "boxSizing": "border-box",
+              "height": "0.063rem",
+              "marginBottom": "1rem",
+              "marginTop": "0.75rem",
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+      <div>
+        <span
+          style={
+            Object {
+              "display": "block",
+              "letterSpacing": ".075rem",
+              "margin": "0 1rem 0.75rem",
+              "padding": "0",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "color": "#8A9097",
+                "fontFamily": "\\"Roboto\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 500,
+              }
+            }
+          >
+            Tools
+          </span>
+        </span>
+        <a
+          href="/comparisons/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Comparisons
+            </span>
+          </span>
+        </a>
+        <a
+          href="/reports/"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bdVaJa eZRxo"
+            selected={false}
+          >
+            <span
+              style={
+                Object {
+                  "color": "#59626a",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Reports
+            </span>
+          </span>
+        </a>
+      </div>
+      <div
+        style={
+          Object {
+            "marginTop": "auto",
+          }
+        }
+      >
+        <span
+          className="sc-bxivhb hTpJur"
+        >
+          <span
+            className="sc-EHOje bfZdDt"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#168eea",
+                  "height": "13px",
+                  "width": "13px",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="#168eea"
+              >
+                <path
+                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z M8,14 C11.3137085,14 14,11.3137085 14,8 C14,4.6862915 11.3137085,2 8,2 C4.6862915,2 2,4.6862915 2,8 C2,11.3137085 4.6862915,14 8,14 Z"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  width="2"
+                  x="7"
+                  y="3"
+                />
+                <rect
+                  height="6"
+                  rx="1"
+                  transform="translate(9.418427, 9.578427) rotate(-225.000000) translate(-9.418427, -9.578427) "
+                  width="2"
+                  x="8.41842728"
+                  y="6.57842712"
+                />
+              </g>
+            </svg>
+          </span>
+          <span
+            className="sc-ifAKCX dMBlCr"
+          >
+            <span
+              style={
+                Object {
+                  "color": "#168eea",
+                  "fontFamily": "\\"Roboto\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                }
+              }
+            >
+              Trial ends 
+              in 1 day
+            </span>
+          </span>
+        </span>
+        <a
+          href="mailto:hello+analyze@buffer.com?subject=Analyze feedback"
+          onBlur={[Function]}
+          onClick={undefined}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "color": "#168eea",
+              "fontFamily": "\\"Roboto\\", sans-serif",
+              "outline": "none",
+              "padding": "0",
+              "textDecoration": "none",
+            }
+          }
+          target="_self"
+        >
+          <span
+            className="sc-bwzfXH fodwfL"
+          >
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
             <span
               className="sc-htpNat dvzxOY"
             >

--- a/packages/nav-sidebar/components/FeedbackLink.jsx
+++ b/packages/nav-sidebar/components/FeedbackLink.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { curiousBlue } from '@bufferapp/components/style/color';
+import { MessageIcon } from '@bufferapp/components';
 
 import {
   Text,
@@ -9,7 +10,8 @@ import {
 } from '@bufferapp/components';
 
 const InnerLink = styled.span`
-  display: block;
+  display: flex;
+  align-items: flex-start;
   padding: 0.75rem 0.5rem;
   margin: 0 0.5rem;
   border-radius: 4px;
@@ -19,10 +21,15 @@ const InnerLink = styled.span`
   }
 `;
 
+const TextWrapper = styled.span`
+  margin-left: .5rem;
+  display: inline-flex;
+`;
+
 const FeedbackLink = ({ children, email }) => (
   <Link unstyled href={`mailto:${email}?subject=Analyze feedback`}>
     <InnerLink>
-      <Text color="shuttleGray">{children}</Text>
+      <MessageIcon /> <TextWrapper><Text size="small" color="shuttleGray">{children}</Text></TextWrapper>
     </InnerLink>
   </Link>
 );

--- a/packages/nav-sidebar/components/FeedbackLink.jsx
+++ b/packages/nav-sidebar/components/FeedbackLink.jsx
@@ -2,17 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { curiousBlue } from '@bufferapp/components/style/color';
-import { MessageIcon } from '@bufferapp/components';
 
 import {
   Text,
   Link,
+  MessageIcon,
 } from '@bufferapp/components';
 
 const InnerLink = styled.span`
   display: flex;
   align-items: flex-start;
-  padding: 0.75rem 0.5rem;
+  padding: 0.5rem 0.5rem;
   margin: 0 0.5rem;
   border-radius: 4px;
 
@@ -29,7 +29,8 @@ const TextWrapper = styled.span`
 const FeedbackLink = ({ children, email }) => (
   <Link unstyled href={`mailto:${email}?subject=Analyze feedback`}>
     <InnerLink>
-      <MessageIcon /> <TextWrapper><Text size="small" color="shuttleGray">{children}</Text></TextWrapper>
+      <MessageIcon />
+      <TextWrapper><Text size="small" color="shuttleGray">{children}</Text></TextWrapper>
     </InnerLink>
   </Link>
 );

--- a/packages/nav-sidebar/components/Label.jsx
+++ b/packages/nav-sidebar/components/Label.jsx
@@ -13,7 +13,7 @@ const labelStyle = {
 
 const Label = ({ children }) => (
   <span style={labelStyle}>
-    <Text size="extra-small" color="lightSlate" weight="medium">{children}</Text>
+    <Text size="small" color="lightSlate" weight="medium">{children}</Text>
   </span>
 );
 

--- a/packages/nav-sidebar/components/NavSidebar.jsx
+++ b/packages/nav-sidebar/components/NavSidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   Divider,
@@ -13,6 +14,7 @@ import Label from './Label';
 import Item from './Item';
 import Insights from './Insights';
 import FeedbackLink from './FeedbackLink';
+import TrialStatus from './TrialStatus';
 
 const sidebarStyle = {
   display: 'flex',
@@ -41,6 +43,7 @@ const NavSidebar = props => (
       <Item href="/reports/" {...props}>Reports</Item>
     </div>
     <div style={bottomSectionStyle}>
+      <TrialStatus {...props} />
       <FeedbackLink email="hello+analyze@buffer.com">Send Feedback</FeedbackLink>
     </div>
   </div>

--- a/packages/nav-sidebar/components/TrialStatus.jsx
+++ b/packages/nav-sidebar/components/TrialStatus.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { curiousBlue } from '@bufferapp/components/style/color';
-import { ClockIcon, Text } from '@bufferapp/components';
+import { Link, ClockIcon, Text } from '@bufferapp/components';
 
 const Wrapper = styled.span`
   display: flex;
@@ -30,14 +30,38 @@ const formatRemainingDays = (days) => {
   return `in ${days} ${days > 1 ? 'days' : 'day'}`;
 };
 
-const TrialStatus = ({ onTrial, daysRemaining }) => {
+const AccountManagementLink = ({ isOwner, organizationId, children }) => {
+  if (isOwner) {
+    return <Link unstyled href={`https://buffer.com/manage/${organizationId}/analyze`}>{ children }</Link>;
+  }
+  return (<span>
+    { children }
+  </span>);
+};
+
+AccountManagementLink.propTypes = {
+  isOwner: PropTypes.bool,
+  organizationId: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+AccountManagementLink.defaultProps = {
+  isOwner: false,
+  organizationId: null,
+};
+
+const TrialStatus = ({ onTrial, daysRemaining, organizationId, isOwner }) => {
   if (!onTrial) {
     return null;
   }
   return (
     <Wrapper>
       <IconWrapper><ClockIcon size={{ width: '13px', height: '13px' }} color={curiousBlue} /></IconWrapper>
-      <TextWrapper><Text size="small" color="curiousBlue">Trial ends {formatRemainingDays(daysRemaining)}</Text></TextWrapper>
+      <TextWrapper>
+        <AccountManagementLink isOwner={isOwner} organizationId={organizationId}>
+          <Text size="small" color="curiousBlue">Trial ends {formatRemainingDays(daysRemaining)}</Text>
+        </AccountManagementLink>
+      </TextWrapper>
     </Wrapper>
   );
 };
@@ -45,11 +69,15 @@ const TrialStatus = ({ onTrial, daysRemaining }) => {
 TrialStatus.propTypes = {
   daysRemaining: PropTypes.number,
   onTrial: PropTypes.bool,
+  isOwner: PropTypes.bool,
+  organizationId: PropTypes.string,
 };
 
 TrialStatus.defaultProps = {
   daysRemaining: 0,
   onTrial: false,
+  isOwner: false,
+  organizationId: null,
 };
 
 export default TrialStatus;

--- a/packages/nav-sidebar/components/TrialStatus.jsx
+++ b/packages/nav-sidebar/components/TrialStatus.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { curiousBlue } from '@bufferapp/components/style/color';
+import { ClockIcon, Text } from '@bufferapp/components';
+
+const Wrapper = styled.span`
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.5rem;
+  margin: 0 0.5rem;
+  border-radius: 4px;
+`;
+
+const TextWrapper = styled.span`
+  margin-left: .5rem;
+  margin-right: auto;
+  display: inline-flex;
+`;
+
+const IconWrapper = styled.span`
+  width: 16px;
+  height: 16px;
+`;
+
+const formatRemainingDays = (days) => {
+  if (days === 0) {
+    return 'today';
+  }
+  return `in ${days} ${days > 1 ? 'days' : 'day'}`;
+};
+
+const TrialStatus = ({ onTrial, daysRemaining }) => {
+  if (!onTrial) {
+    return null;
+  }
+  return (
+    <Wrapper>
+      <IconWrapper><ClockIcon size={{ width: '13px', height: '13px' }} color={curiousBlue} /></IconWrapper>
+      <TextWrapper><Text size="small" color="curiousBlue">Trial ends {formatRemainingDays(daysRemaining)}</Text></TextWrapper>
+    </Wrapper>
+  );
+};
+
+TrialStatus.propTypes = {
+  daysRemaining: PropTypes.number,
+  onTrial: PropTypes.bool,
+};
+
+TrialStatus.defaultProps = {
+  daysRemaining: 0,
+  onTrial: false,
+};
+
+export default TrialStatus;

--- a/packages/nav-sidebar/components/story.jsx
+++ b/packages/nav-sidebar/components/story.jsx
@@ -90,6 +90,21 @@ storiesOf('NavSidebar')
         daysRemaining={0}
       />
     </div>
+  ))
+  .add('Trial status should have a link to org admin if viewed by the account owner', () => (
+    <div style={{ width: '260px', height: '100%', display: 'flex' }}>
+      <NavSidebar
+        route="/insights/twitter"
+        profileService="twitter"
+        facebookProfile={facebookProfile}
+        twitterProfile={twitterProfile}
+        onClick={action('click item')}
+        onTrial
+        isOwner
+        organizationId="organization123"
+        daysRemaining={0}
+      />
+    </div>
   ));
 
 storiesOf('Item')

--- a/packages/nav-sidebar/components/story.jsx
+++ b/packages/nav-sidebar/components/story.jsx
@@ -51,6 +51,45 @@ storiesOf('NavSidebar')
         onClick={action('click item')}
       />
     </div>
+  ))
+  .add('displays trial status if user is on trial', () => (
+    <div style={{ width: '260px', height: '100%', display: 'flex' }}>
+      <NavSidebar
+        route="/insights/twitter"
+        profileService="twitter"
+        facebookProfile={facebookProfile}
+        twitterProfile={twitterProfile}
+        onClick={action('click item')}
+        onTrial
+        daysRemaining={7}
+      />
+    </div>
+  ))
+  .add('trial status for 1 day remaining', () => (
+    <div style={{ width: '260px', height: '100%', display: 'flex' }}>
+      <NavSidebar
+        route="/insights/twitter"
+        profileService="twitter"
+        facebookProfile={facebookProfile}
+        twitterProfile={twitterProfile}
+        onClick={action('click item')}
+        onTrial
+        daysRemaining={1}
+      />
+    </div>
+  ))
+  .add('trial ends today', () => (
+    <div style={{ width: '260px', height: '100%', display: 'flex' }}>
+      <NavSidebar
+        route="/insights/twitter"
+        profileService="twitter"
+        facebookProfile={facebookProfile}
+        twitterProfile={twitterProfile}
+        onClick={action('click item')}
+        onTrial
+        daysRemaining={0}
+      />
+    </div>
   ));
 
 storiesOf('Item')

--- a/packages/nav-sidebar/index.js
+++ b/packages/nav-sidebar/index.js
@@ -7,6 +7,8 @@ export default connect(
   state => ({
     daysRemaining: state.account.trialDaysRemaining,
     onTrial: state.account.onTrial,
+    isOwner: state.profiles.isOwner,
+    organizationId: state.profiles.organizationId,
   }),
   dispatch => ({
     onClick: path => dispatch(push(path)),

--- a/packages/nav-sidebar/index.js
+++ b/packages/nav-sidebar/index.js
@@ -4,7 +4,9 @@ import { connect } from 'react-redux';
 import NavSidebar from './components/NavSidebar';
 
 export default connect(
-  () => ({
+  state => ({
+    daysRemaining: state.account.trialDaysRemaining,
+    onTrial: state.account.onTrial,
   }),
   dispatch => ({
     onClick: path => dispatch(push(path)),

--- a/packages/nav-sidebar/index.test.jsx
+++ b/packages/nav-sidebar/index.test.jsx
@@ -20,6 +20,9 @@ const storeFake = state => ({
 describe('NavSidebar', () => {
   it('should render with links to Insights', () => {
     const store = storeFake({
+      account: {
+        trialDaysRemaining: 6,
+      },
       navSidebar: {
         instagramProfile: {
           id: '2',
@@ -50,6 +53,9 @@ describe('NavSidebar', () => {
 
     beforeEach(() => {
       store = storeFake({
+        account: {
+          trialDaysRemaining: 6,
+        },
         navSidebar: {
           instagramProfile: {
             id: '2',
@@ -101,6 +107,9 @@ describe('NavSidebar', () => {
 
   it('it should export onClick', () => {
     const store = storeFake({
+      account: {
+        trialDaysRemaining: 6,
+      },
       navSidebar: {
         profiles: [],
       },

--- a/packages/nav-sidebar/index.test.jsx
+++ b/packages/nav-sidebar/index.test.jsx
@@ -23,6 +23,10 @@ describe('NavSidebar', () => {
       account: {
         trialDaysRemaining: 6,
       },
+      profiles: {
+        organizationId: 'organization123',
+        isOwner: false,
+      },
       navSidebar: {
         instagramProfile: {
           id: '2',
@@ -53,6 +57,10 @@ describe('NavSidebar', () => {
 
     beforeEach(() => {
       store = storeFake({
+        profiles: {
+          organizationId: 'organization123',
+          isOwner: false,
+        },
         account: {
           trialDaysRemaining: 6,
         },
@@ -109,6 +117,10 @@ describe('NavSidebar', () => {
     const store = storeFake({
       account: {
         trialDaysRemaining: 6,
+      },
+      profiles: {
+        organizationId: 'organization123',
+        isOwner: false,
       },
       navSidebar: {
         profiles: [],

--- a/packages/nav-sidebar/package.json
+++ b/packages/nav-sidebar/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@bufferapp/analyze-profile-selector": "^0.65.0",
     "@bufferapp/async-data-fetch": "0.5.36-beta01",
-    "@bufferapp/components": "2.1.1-alpha.6",
+    "@bufferapp/components": "2.3.3",
     "@bufferapp/report-list": "^0.67.0"
   },
   "devDependencies": {

--- a/packages/profile-selector/reducer.js
+++ b/packages/profile-selector/reducer.js
@@ -13,8 +13,10 @@ const initialState = {
   profiles: [],
   isDropdownOpen: false,
   profilesFilterString: '',
+  organizationId: null,
   selectedProfile: null,
   loading: true,
+  isOwner: false,
 };
 
 export default (state = initialState, action) => {

--- a/packages/profile-selector/reducer.test.js
+++ b/packages/profile-selector/reducer.test.js
@@ -11,8 +11,10 @@ describe('reducer', () => {
       profiles: [],
       isDropdownOpen: false,
       profilesFilterString: '',
+      organizationId: null,
       selectedProfile: null,
       loading: true,
+      isOwner: false,
     };
   });
 

--- a/packages/server/rpc/getAccountDetails/index.js
+++ b/packages/server/rpc/getAccountDetails/index.js
@@ -1,0 +1,40 @@
+const { method } = require('@bufferapp/micro-rpc');
+const moment = require('moment');
+const rp = require('request-promise');
+
+const getTrialInformation = (response) => {
+  const subscription = response.data.subscriptions[0];
+  if (!subscription || !subscription.is_trial) {
+    return {
+      onTrial: false,
+      daysRemaining: -1,
+    };
+  }
+
+  const today = moment();
+  const endOfTrial = moment.unix(subscription.current_period_end);
+
+  return {
+    onTrial: true,
+    daysRemaining: endOfTrial.diff(today, 'days'),
+  };
+};
+
+module.exports = method(
+  'get_account_details',
+  'get details for user account',
+  ({ organizationId }, { session }) =>
+    rp({
+      uri: `${process.env.API_ADDR}/1/billing/retrieve-billing-data.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
+      qs: {
+        access_token: session.analyze.accessToken,
+        organization_id: organizationId,
+        product: 'analyze',
+      },
+      json: true,
+    }).then(getTrialInformation)
+  ,
+);
+

--- a/packages/server/rpc/getAccountDetails/test.js
+++ b/packages/server/rpc/getAccountDetails/test.js
@@ -1,0 +1,56 @@
+/* eslint-disable import/first */
+jest.mock('micro-rpc-client');
+jest.mock('request-promise');
+import rp from 'request-promise';
+import moment from 'moment';
+import getAccountDetails from './';
+
+describe('rpc/get_account_details', () => {
+  const organizationId = 'org-1';
+
+  it('should have the expected name', () => {
+    expect(getAccountDetails.name)
+      .toBe('get_account_details');
+  });
+
+  it('should have the expected docs', () => {
+    expect(getAccountDetails.docs)
+      .toBe('get details for user account');
+  });
+
+  it('should send a POST request to /retrieve-billing-data.json with the organization id and analyze as product', async () => {
+    const response = {
+      data: {
+        subscriptions: [{
+          is_trial: true,
+          current_period_end: moment().add(2, 'days').unix(),
+        }],
+      },
+    };
+    rp.mockReturnValueOnce(Promise.resolve(response));
+    const session = {
+      analyze: {
+        accessToken: 'access-token',
+      },
+    };
+
+    const result = await getAccountDetails.fn({ organizationId }, { session });
+
+    expect(result).toEqual({
+      onTrial: true,
+      daysRemaining: 1,
+    });
+    expect(rp.mock.calls[0]).toEqual([{
+      uri: `${process.env.API_ADDR}/1/billing/retrieve-billing-data.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
+      qs: {
+        access_token: session.analyze.accessToken,
+        organization_id: organizationId,
+        product: 'analyze',
+      },
+      json: true,
+    }]);
+  });
+});
+

--- a/packages/server/rpc/index.js
+++ b/packages/server/rpc/index.js
@@ -27,6 +27,7 @@ const hourly = require('./hourly');
 const uploadReportLogo = require('./uploadReportLogo');
 const deleteReportLogo = require('./deleteReportLogo');
 const profilesOverview = require('./profilesOverview');
+const getAccountDetails = require('./getAccountDetails');
 
 module.exports = checkToken(rpc(
   profilesMethod,
@@ -56,4 +57,5 @@ module.exports = checkToken(rpc(
   uploadReportLogo,
   deleteReportLogo,
   profilesOverview,
+  getAccountDetails,
 ));

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -33,6 +33,7 @@ import { middleware as unauthorizedRedirectMiddleware } from '@bufferapp/unautho
 import { middleware as exportToPDFMiddleware } from '@bufferapp/pdf-export';
 import { middleware as earlyAccessMiddleware } from '@bufferapp/analyze-early-access';
 import { middleware as profilesOverviewMiddleware } from '@bufferapp/analyze-profiles-overview';
+import { middleware as accountMiddleware } from '@bufferapp/analyze-account';
 import { createMiddleware } from '@bufferapp/buffermetrics/redux';
 import initMiddleware from './initMiddleware';
 
@@ -90,6 +91,7 @@ const configureStore = (initialstate) => {
         hourlyMiddleware,
         environmentMiddleware,
         unauthorizedRedirectMiddleware,
+        accountMiddleware,
         exportToPDFMiddleware,
         buffermetricsMiddleware,
       ),

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -20,6 +20,7 @@
   "author": "hharnisc@gmail.com",
   "dependencies": {
     "@bufferapp/add-report": "^0.67.0",
+    "@bufferapp/analyze-account": "^0.0.1",
     "@bufferapp/analyze-csv-export": "^0.65.1",
     "@bufferapp/analyze-date-picker": "^0.65.0",
     "@bufferapp/analyze-early-access": "^0.68.0",

--- a/packages/store/reducers.js
+++ b/packages/store/reducers.js
@@ -25,6 +25,7 @@ import { reducer as comparisonReducer } from '@bufferapp/comparison-chart';
 import { reducer as hourlyReducer } from '@bufferapp/hourly-chart';
 import { reducer as environmentReducer } from '@bufferapp/environment';
 import { reducer as profilesOverviewReducer } from '@bufferapp/analyze-profiles-overview';
+import { reducer as accountReducer } from '@bufferapp/analyze-account';
 
 export default combineReducers({
   router: routerReducer,
@@ -53,4 +54,5 @@ export default combineReducers({
   comparison: comparisonReducer,
   hourly: hourlyReducer,
   environment: environmentReducer,
+  account: accountReducer,
 });

--- a/packages/web/__snapshots__/snapshot.test.js.snap
+++ b/packages/web/__snapshots__/snapshot.test.js.snap
@@ -675,7 +675,7 @@ exports[`Snapshots App should render application 1`] = `
       }
     >
       <div
-        className="sc-iybRtq cgQDKR"
+        className="sc-kXeGPI bVfQcK"
       >
         <div
           style={
@@ -1012,19 +1012,48 @@ exports[`Snapshots App should render application 1`] = `
               target="_self"
             >
               <span
-                className="sc-hjRWVT bAshbN"
+                className="sc-hjRWVT hNhKmY"
               >
-                <span
+                <svg
+                  height="100%"
                   style={
                     Object {
-                      "color": "#59626a",
-                      "fontFamily": "\\"Roboto\\", sans-serif",
-                      "fontSize": "1rem",
-                      "fontWeight": 400,
+                      "fill": "#59626a",
+                      "height": "1rem",
+                      "width": "1rem",
                     }
                   }
+                  version="1.1"
+                  viewBox="0 0 16 16"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
                 >
-                  Send Feedback
+                  <g
+                    className="shuttleGray"
+                  >
+                    <path
+                      d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                      fill="#596269"
+                      transform="translate(0.5)"
+                    />
+                  </g>
+                </svg>
+                <span
+                  className="sc-iybRtq ePzWvU"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#59626a",
+                        "fontFamily": "\\"Roboto\\", sans-serif",
+                        "fontSize": "0.75rem",
+                        "fontWeight": 400,
+                      }
+                    }
+                  >
+                    Send Feedback
+                  </span>
                 </span>
               </span>
             </a>
@@ -1465,19 +1494,48 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT bAshbN"
+            className="sc-hjRWVT hNhKmY"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-iybRtq ePzWvU"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>
@@ -1575,7 +1633,7 @@ exports[`Snapshots ComparisonsPage should render comparisons page 1`] = `
 exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
 <span>
   <div
-    className="sc-iybRtq cgQDKR"
+    className="sc-kXeGPI bVfQcK"
   >
     <div
       style={
@@ -1912,19 +1970,48 @@ exports[`Snapshots DefaultPage should render the dashboard page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT bAshbN"
+            className="sc-hjRWVT hNhKmY"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-iybRtq ePzWvU"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>
@@ -2363,19 +2450,48 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT bAshbN"
+            className="sc-hjRWVT hNhKmY"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-iybRtq ePzWvU"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>
@@ -2473,7 +2589,7 @@ exports[`Snapshots InsightsPage should render Insights page 1`] = `
 exports[`Snapshots ReportsPage should render reports page 1`] = `
 <span>
   <div
-    className="sc-ugnQR dXiuzX"
+    className="sc-iomxrj ccVSH"
   >
     <div
       style={
@@ -2810,29 +2926,58 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           target="_self"
         >
           <span
-            className="sc-hjRWVT bAshbN"
+            className="sc-hjRWVT hNhKmY"
           >
-            <span
+            <svg
+              height="100%"
               style={
                 Object {
-                  "color": "#59626a",
-                  "fontFamily": "\\"Roboto\\", sans-serif",
-                  "fontSize": "1rem",
-                  "fontWeight": 400,
+                  "fill": "#59626a",
+                  "height": "1rem",
+                  "width": "1rem",
                 }
               }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
             >
-              Send Feedback
+              <g
+                className="shuttleGray"
+              >
+                <path
+                  d="M6.5 1.5C9.48675 1.5 11.5 2.9965 11.5 5.34842C11.5 7.60283 9.81075 8.45779 7.5 9L6.5 11L5.5 9C3.16867 8.45238 1.64257 7.57142 1.64257 5.34842C1.64257 2.9965 3.51325 1.5 6.5 1.5ZM6.5 0C2.91038 0 0 2.39417 0 5.34842C0 7.79242 1.99225 9.85346 4.71304 10.4921L6.5 13L8.28696 10.4921C11.0078 9.85292 13 7.79187 13 5.34842C13 2.39417 10.0896 0 6.5 0Z"
+                  fill="#596269"
+                  transform="translate(0.5)"
+                />
+              </g>
+            </svg>
+            <span
+              className="sc-iybRtq ePzWvU"
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#59626a",
+                    "fontFamily": "\\"Roboto\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                  }
+                }
+              >
+                Send Feedback
+              </span>
             </span>
           </span>
         </a>
       </div>
     </div>
     <div
-      className="sc-eIHaNI fXpSSI"
+      className="sc-dvCyap kJVUDl"
     >
       <header
-        className="sc-dxZgTM cgjjg"
+        className="sc-keVrkP cmyZvZ"
       >
         <button
           className="sc-kgoBCf cmMzae"
@@ -2852,7 +2997,7 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
           </span>
         </button>
         <section
-          className="sc-dvCyap dbxjpg"
+          className="sc-cBdUnI JozdO"
         >
           <div
             className="sc-kjoXOD bKsEHy"
@@ -3215,10 +3360,10 @@ exports[`Snapshots ReportsPage should render reports page 1`] = `
         </section>
       </header>
       <div
-        className="sc-eTpRJs fFYnHR"
+        className="sc-iFMziU jxpJdI"
       >
         <section
-          className="sc-iomxrj eJYqbR"
+          className="sc-gVLVqr cfukti"
         >
           <div
             className="sc-likbZx lhrdkz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,15 @@
     react-autocomplete "1.7.2"
     react-day-picker "6.2.1"
 
+"@bufferapp/components@2.3.3":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.3.3.tgz#eb9ca5dc4e563a76d793420a9f8f675613526cd3"
+  dependencies:
+    "@bufferapp/react-keyframes" "0.2.5"
+    raf "3.4.0"
+    react-autocomplete "1.7.2"
+    react-day-picker "6.2.1"
+
 "@bufferapp/components@^2.1.1":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@bufferapp/components/-/components-2.3.3.tgz#eb9ca5dc4e563a76d793420a9f8f675613526cd3"


### PR DESCRIPTION
## Purpose

To provide the trial status on the nav sidebar for Analyze. The status is displayed only for owners right now, as that's data that's only available for them. Once I merge and deploy https://github.com/bufferapp/buffer-web/pull/15382, it will become available for all team members too!

## Note

There is also a piece of code that wraps the trial status on a `Link` component that will become available only for the owner. For now, that's hardcoded to `false` in the profiles reducer, but I will create another PR that will return that information from the profiles endpoint on the API as well (whether the user requesting the profiles for the organization is the owner or not), and will tweak the reducer & RPC accordingly :)