### PR TITLE
[ANA-312] Tweak analyze early access to be based on enabled profiles

### DIFF
--- a/packages/early-access-check/middleware.js
+++ b/packages/early-access-check/middleware.js
@@ -9,10 +9,11 @@ const getRedirectURL = () => {
 
 export default () => next => (action) => {
   switch (action.type) {
-    case `user_${dataFetchActionTypes.FETCH_SUCCESS}`: {
-      const { result: { features = [] } } = action;
-      const hasEarlyAccess = features.includes('analyze_early_access');
-      if (!hasEarlyAccess) {
+    case `profiles_${dataFetchActionTypes.FETCH_SUCCESS}`: {
+      const profiles = action.result;
+      // if there aren't any active analyze profiles
+      // then redirect back to the home page
+      if (profiles.length < 1) {
         window.location.assign(getRedirectURL());
       }
       break;

--- a/packages/early-access-check/middleware.test.js
+++ b/packages/early-access-check/middleware.test.js
@@ -11,13 +11,11 @@ describe('middleware', () => {
 
   window.location.assign = jest.fn();
 
-  describe('should redirect visitors if they do not have the early access feature flip enabled', () => {
+  describe('should redirect visitors if they do not have any profiles', () => {
     it('non-local redirect', () => {
       const action = {
-        type: `user_${asyncDataFetchActions.FETCH_SUCCESS}`,
-        result: {
-          features: [],
-        },
+        type: `profiles_${asyncDataFetchActions.FETCH_SUCCESS}`,
+        result: [],
       };
       middleware(store)(next)(action);
       expect(window.location.assign).toHaveBeenCalledWith('https://buffer.com/analyze');
@@ -27,22 +25,21 @@ describe('middleware', () => {
         value: 'analyze.local.buffer.com',
       });
       const action = {
-        type: `user_${asyncDataFetchActions.FETCH_SUCCESS}`,
-        result: {
-          features: [],
-        },
+        type: `profiles_${asyncDataFetchActions.FETCH_SUCCESS}`,
+        result: [],
       };
       middleware(store)(next)(action);
       expect(window.location.assign).toHaveBeenCalledWith('https://local.buffer.com/analyze');
     });
   });
 
-  it('should not redirect if feature flip is present', () => {
+  it('should not redirect if the profiles is not empty', () => {
     const action = {
-      type: `user_${asyncDataFetchActions.FETCH_SUCCESS}`,
-      result: {
-        features: ['analyze_early_access'],
-      },
+      type: `profiles_${asyncDataFetchActions.FETCH_SUCCESS}`,
+      result: [
+        { id: '5939bcf94160550b007b23df' },
+        { id: '5939bcf94160550b007b23ee' },
+      ],
     };
     middleware(store)(next)(action);
     expect(window.location.assign).not.toHaveBeenCalled();


### PR DESCRIPTION
### Purpose
Instead of checking to see if the user has `analyze_early_access` feature flip we can simply check if the user has any analyze enabled profiles or not. 

### Notes
This PR will be merged after we ran the mongo script that will disable all analyze active profiles that don't have analyze subscriptions anymore. 

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
