### PR TITLE
Alphabetically sort profiles in the selector

### DIFF
--- a/packages/server/rpc/profiles/index.js
+++ b/packages/server/rpc/profiles/index.js
@@ -2,6 +2,15 @@ const { method } = require('@bufferapp/micro-rpc');
 const rp = require('request-promise');
 const profileParser = require('../utils/profileParser');
 
+function getComparableUsername(username) {
+  return username.replace('@', '').toUpperCase();
+}
+
+function sortProfilesByUsername(profiles) {
+  return profiles.sort((a, b) =>
+    getComparableUsername(a.username).localeCompare(getComparableUsername(b.username)));
+}
+
 module.exports = method(
   'profiles',
   'fetch profiles',
@@ -9,11 +18,11 @@ module.exports = method(
     rp({
       uri: `${process.env.API_ADDR}/1/analyze/users/${id}/get_social_accounts.json`,
       method: 'GET',
-      strictSSL: !(process.env.NODE_ENV === 'development'),
+      strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
       qs: {
         access_token: session.analyze.accessToken,
       },
     })
       .then(result => JSON.parse(result))
-      .then(({ profiles }) => profiles.map(profileParser)),
+      .then(({ profiles }) => sortProfilesByUsername(profiles.map(profileParser))),
 );

--- a/packages/server/rpc/profiles/index.test.js
+++ b/packages/server/rpc/profiles/index.test.js
@@ -1,0 +1,48 @@
+/* eslint-disable import/first */
+
+jest.mock('micro-rpc-client');
+jest.mock('request-promise');
+import rp from 'request-promise';
+import getProfiles from './';
+
+describe('rpc/profiles', () => {
+  it('should have the expected name', () => {
+    expect(getProfiles.name)
+      .toBe('profiles');
+  });
+
+  it('should have the expected docs', () => {
+    expect(getProfiles.docs)
+      .toBe('fetch profiles');
+  });
+
+  it('should send a GET request to / get_social_accounts with the provided parameters', async () => {
+    const id = 'user-123';
+    rp.mockReturnValueOnce(Promise.resolve(JSON.stringify({
+      profiles: [],
+    })));
+
+    await getProfiles.fn({ id }, { session: { analyze: { accessToken: 'foo' } } });
+
+    expect(rp.mock.calls[0]).toEqual([{
+      uri: `undefined/1/analyze/users/${id}/get_social_accounts.json`,
+      method: 'GET',
+      strictSSL: !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'),
+      qs: {
+        access_token: 'foo',
+      },
+    }]);
+  });
+
+  it('should sort profilet by name', async () => {
+    const id = 'user-123';
+    rp.mockReturnValueOnce(Promise.resolve(JSON.stringify({
+      profiles: [{ service_username: '@foo' }, { service_username: 'bar' }],
+    })));
+
+    const profiles = await getProfiles.fn({ id }, { session: { analyze: { accessToken: 'foo' } } });
+    expect(profiles[0].username).toEqual('bar');
+    expect(profiles[1].username).toEqual('@foo');
+  });
+});
+


### PR DESCRIPTION
### Purpose
To properly sort profiles in the selectors

### Notes

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
