### PR TITLE
fixes reports state error

### DIFF
--- a/packages/report/components/ChartFactory/index.jsx
+++ b/packages/report/components/ChartFactory/index.jsx
@@ -134,7 +134,6 @@ const ChartFactory = ({ charts, moveUp, moveDown, deleteChart, exporting }) =>
       </Header>
       {React.createElement(CHARTS[chart.chart_id].chart, {
         ...chart,
-        ...chart.state,
         forReport: true,
         timezone: chart.profile.timezone,
         service: chart.profile.service,


### PR DESCRIPTION
### Purpose
To fix Hourly Chart rendering in reports.

### Notes
Expanding the state was creating an error in the Hourly chart in reports as the SelectedMetric is going to be overridden with by a string. And actually is not needed because we are passing that down from the RPC endpoint. Not sure why it wasn't properly doing that when I was testing the hashtag table :confused:.

### Review

#### Staging Deployment

_This repo is CI/CD enabled and staging deployment should be available at:
https://<branch_name>.analyze.buffer.com :smile:_
